### PR TITLE
Fix connector drawing on connection removal

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -37,6 +37,15 @@ Connection(PortType portType,
 Connection::
 ~Connection()
 {
+  if (auto in = _inNode.lock())
+  {
+	in->nodeGraphicsObject()->update();
+  }
+  if (auto out = _outNode.lock())
+  {
+	out->nodeGraphicsObject()->update();
+  }
+
   std::cout << "Connection destructor" << std::endl;
 }
 


### PR DESCRIPTION
Fixed issue:
When removing a connection between nodes, only one node connector would update.