### PR TITLE
Add runtime types

### DIFF
--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -28,6 +28,11 @@ public:
   name()
   { return QString("Addition"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<AdditionModel>(new AdditionModel);
+  }
+  
 public:
 
   void

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -24,7 +24,11 @@ public:
   static QString name()
   { return QString("Division"); }
 
-
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<DivisionModel>(new DivisionModel);
+  }
+  
 public:
 
   void

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -28,6 +28,11 @@ public:
   name()
   { return QString("Multiplication"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<MultiplicationModel>(new MultiplicationModel);
+  }
+  
 public:
 
   void

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -33,6 +33,11 @@ public:
   name()
   { return QString("Result"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<NumberDisplayDataModel>(new NumberDisplayDataModel);
+  }
+  
 public:
 
   void

--- a/examples/calculator/NumberSourceDataModel.hpp
+++ b/examples/calculator/NumberSourceDataModel.hpp
@@ -35,6 +35,11 @@ public:
   static QString
   name() { return QString("NumberSource"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<NumberSourceDataModel>(new NumberSourceDataModel);
+  }
+  
 public:
 
   void

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -26,6 +26,11 @@ public:
   static QString name()
   { return QString("Subtraction"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<SubtractionModel>(new SubtractionModel);
+  }
+  
 public:
 
   void

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -18,29 +18,29 @@
 static bool
 registerDataModels()
 {
-  DataModelRegistry::registerModel<NumberSourceDataModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<NumberSourceDataModel>(new NumberSourceDataModel));
 
-  DataModelRegistry::registerModel<NumberDisplayDataModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<NumberDisplayDataModel>(new NumberDisplayDataModel));
 
-  DataModelRegistry::registerModel<AdditionModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<AdditionModel>(new AdditionModel));
 
-  DataModelRegistry::registerModel<SubtractionModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<SubtractionModel>(new SubtractionModel));
 
-  DataModelRegistry::registerModel<MultiplicationModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<MultiplicationModel>(new MultiplicationModel));
 
-  DataModelRegistry::registerModel<DivisionModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<DivisionModel>(new DivisionModel));
 
   return true;
 }
-
-
-static bool registerOK = registerDataModels();
 
 int
 main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
-
+  
+  bool success = registerDataModels();
+  Q_ASSERT(success);
+  
   QWidget mainWidget;
 
   auto menuBar    = new QMenuBar();

--- a/examples/example1/main.cpp
+++ b/examples/example1/main.cpp
@@ -11,21 +11,19 @@
 static bool
 registerDataModels()
 {
-  DataModelRegistry::registerModel<NaiveDataModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<NaiveDataModel>(new NaiveDataModel));
 
   /*
    We could have more models registered.
    All of them become items in the context meny of the scene.
 
-  DataModelRegistry::registerModel<AnotherDataModel>();
-  DataModelRegistry::registerModel<OneMoreDataModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<AnotherDataModel>(new AnotherDataModel));
+  DataModelRegistry::registerModel(std::unique_ptr<OneMoreDataModel>(new OneMoreDataModel));
 
   */
 
   return true;
 }
-
-static bool registerOK = registerDataModels();
 
 
 //------------------------------------------------------------------------------
@@ -35,6 +33,9 @@ main(int argc, char* argv[])
 {
   QApplication app(argc, argv);
 
+  bool success = registerDataModels();
+  Q_ASSERT(success);
+  
   FlowScene scene;
 
   FlowView view(&scene);

--- a/examples/example1/models.hpp
+++ b/examples/example1/models.hpp
@@ -5,6 +5,8 @@
 #include <nodes/NodeData>
 #include <nodes/NodeDataModel>
 
+#include <memory>
+
 /// The class can potentially incapsulate any user data which
 /// need to be transferred within the Node Editor graph
 class MyNodeData : public NodeData
@@ -50,6 +52,11 @@ public:
   name()
   { return QString("NaiveDataModel"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<NaiveDataModel>(new NaiveDataModel);
+  }
+  
 public:
 
   void

--- a/examples/example2/TextDisplayDataModel.hpp
+++ b/examples/example2/TextDisplayDataModel.hpp
@@ -32,6 +32,9 @@ public:
   name()
   { return QString("TextDisplayDataModel"); }
 
+  std::unique_ptr<NodeDataModel>
+  clone() const override
+  { return std::unique_ptr<NodeDataModel>(new TextDisplayDataModel); }
 
 public:
 

--- a/examples/example2/TextSourceDataModel.hpp
+++ b/examples/example2/TextSourceDataModel.hpp
@@ -33,6 +33,11 @@ public:
   name()
   { return QString("TextSourceDataModel"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<TextSourceDataModel>(new TextSourceDataModel);
+  }
+  
 public:
 
   void

--- a/examples/example2/main.cpp
+++ b/examples/example2/main.cpp
@@ -13,20 +13,20 @@
 static bool
 registerDataModels()
 {
-  DataModelRegistry::registerModel<TextSourceDataModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<TextSourceDataModel>(new TextSourceDataModel));
 
-  DataModelRegistry::registerModel<TextDisplayDataModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<TextDisplayDataModel>(new TextDisplayDataModel));
 
   return true;
 }
-
-static bool registerOK = registerDataModels();
 
 int
 main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
 
+  bool success = registerDataModels();
+  Q_ASSERT(success);
   FlowScene scene;
 
   FlowView view(&scene);

--- a/examples/images/ImageLoaderModel.hpp
+++ b/examples/images/ImageLoaderModel.hpp
@@ -31,6 +31,11 @@ public:
   static QString
   name() { return QString("ImageLoaderModel"); }
 
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<ImageLoaderModel>(new ImageLoaderModel);
+  }
+  
 public:
 
   void

--- a/examples/images/ImageShowModel.hpp
+++ b/examples/images/ImageShowModel.hpp
@@ -28,7 +28,12 @@ public:
 
   static QString
   name() { return QString("ImageShowModel"); }
-
+  
+  std::unique_ptr<NodeDataModel> 
+  clone() const override {
+    return std::unique_ptr<ImageShowModel>(new ImageShowModel);
+  }
+  
 public:
 
   void

--- a/examples/images/main.cpp
+++ b/examples/images/main.cpp
@@ -10,21 +10,21 @@
 static bool
 registerDataModels()
 {
-  DataModelRegistry::registerModel<ImageShowModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<ImageShowModel>(new ImageShowModel));
 
-  DataModelRegistry::registerModel<ImageLoaderModel>();
+  DataModelRegistry::registerModel(std::unique_ptr<ImageLoaderModel>(new ImageLoaderModel));
 
   return true;
 }
 
-
-static bool registerOK = registerDataModels();
 
 int
 main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
 
+  bool success = registerDataModels();
+  Q_ASSERT(success);
   FlowScene scene;
 
   FlowView view(&scene);

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -11,10 +11,10 @@ create(QString const &modelName)
 
   if (it != _registeredModels.end())
   {
-    return it->second->create();
+    return it->second->clone();
   }
 
-  return std::unique_ptr<NodeDataModel>();
+  return nullptr;
 }
 
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -115,14 +115,12 @@ restoreNode(Properties const &p)
 
   p.get("model_name", &modelName);
 
-  auto const &models = DataModelRegistry::registeredModels();
-  auto it = models.find(modelName);
-
-  if (it == models.end())
+  auto dataModel = DataModelRegistry::create(modelName);
+  
+  if (!dataModel)
     throw std::logic_error(std::string("No registered model with name ") +
                            modelName.toLocal8Bit().data());
 
-  auto dataModel = it->second->create();
   auto node      = std::make_shared<Node>(std::move(dataModel));
   auto ngo       = std::make_unique<NodeGraphicsObject>(*this, node);
   node->setGraphicsObject(std::move(ngo));

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -63,14 +63,11 @@ contextMenuEvent(QContextMenuEvent *event)
 
     QString modelName = action->text();
 
-    auto const &models =
-      DataModelRegistry::registeredModels();
+    auto type = DataModelRegistry::create(modelName);
 
-    auto it = models.find(modelName);
-
-    if (it != models.end())
+    if (type)
     {
-      auto node = _scene->createNode(it->second->create() );
+      auto node = _scene->createNode(std::move(type));
 
       QPoint pos = event->pos();
 

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -28,6 +28,9 @@ public:
   /// It is possible to hide caption in GUI
   virtual bool
   captionVisible() const { return true; }
+  
+  virtual std::unique_ptr<NodeDataModel> 
+  clone() const = 0;
 
 public:
 


### PR DESCRIPTION
(This fixes #7)

Explanation of some less trivial changes:

in the examples' main.cpp, I moved the `registerDataModels` call to after the `QApplication` has been constructed. This is good because we are actually constructing the `NodeDataModel` instances, which means some will construct widgets, and it's illegal to construct a `QWidget` before the `QApplication` is constructed. 

Why not `make_unique`? UniquePtr.hpp is a private header, so the examples can't really use it and c++14 isn't turned on for this project (if it was turned on we could use it and not worry about UniquePtr.hpp at all)