### PR TITLE
Use std::shared_ptr for storing registries so editors can share them

### DIFF
--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -15,21 +15,21 @@
 #include "MultiplicationModel.hpp"
 #include "DivisionModel.hpp"
 
-static DataModelRegistry
+static std::shared_ptr<DataModelRegistry>
 registerDataModels()
 {
-  DataModelRegistry ret;
-  ret.registerModel(std::make_unique<NumberSourceDataModel>());
+  auto ret = std::make_shared<DataModelRegistry>();
+  ret->registerModel(std::make_unique<NumberSourceDataModel>());
 
-  ret.registerModel(std::make_unique<NumberDisplayDataModel>());
+  ret->registerModel(std::make_unique<NumberDisplayDataModel>());
 
-  ret.registerModel(std::make_unique<AdditionModel>());
+  ret->registerModel(std::make_unique<AdditionModel>());
 
-  ret.registerModel(std::make_unique<SubtractionModel>());
+  ret->registerModel(std::make_unique<SubtractionModel>());
 
-  ret.registerModel(std::make_unique<MultiplicationModel>());
+  ret->registerModel(std::make_unique<MultiplicationModel>());
 
-  ret.registerModel(std::make_unique<DivisionModel>());
+  ret->registerModel(std::make_unique<DivisionModel>());
 
   return ret;
 }

--- a/examples/example1/main.cpp
+++ b/examples/example1/main.cpp
@@ -8,18 +8,18 @@
 #include "models.hpp"
 
 
-static DataModelRegistry
+static std::shared_ptr<DataModelRegistry>
 registerDataModels()
 {
-  DataModelRegistry ret;
-  ret.registerModel(std::make_unique<NaiveDataModel>());
+  auto ret = std::make_shared<DataModelRegistry>();
+  ret->registerModel(std::make_unique<NaiveDataModel>());
 
   /*
      We could have more models registered.
      All of them become items in the context meny of the scene.
 
-  ret.registerModel(std::make_unique<AnotherDataModel>());
-  ret.registerModel(std::make_unique<OneMoreDataModel>());
+  ret->registerModel(std::make_unique<AnotherDataModel>());
+  ret->registerModel(std::make_unique<OneMoreDataModel>());
 
    */
 

--- a/examples/example2/main.cpp
+++ b/examples/example2/main.cpp
@@ -9,14 +9,14 @@
 #include "TextSourceDataModel.hpp"
 #include "TextDisplayDataModel.hpp"
 
-static DataModelRegistry
+static std::shared_ptr<DataModelRegistry>
 registerDataModels()
 {
-  DataModelRegistry ret;
+  auto ret = std::make_shared<DataModelRegistry>();
 
-  ret.registerModel(std::make_unique<TextSourceDataModel>());
+  ret->registerModel(std::make_unique<TextSourceDataModel>());
 
-  ret.registerModel(std::make_unique<TextDisplayDataModel>());
+  ret->registerModel(std::make_unique<TextDisplayDataModel>());
 
   return ret;
 }

--- a/examples/images/main.cpp
+++ b/examples/images/main.cpp
@@ -7,13 +7,13 @@
 #include "ImageShowModel.hpp"
 #include "ImageLoaderModel.hpp"
 
-static DataModelRegistry
+static std::shared_ptr<DataModelRegistry>
 registerDataModels()
 {
-  DataModelRegistry ret;
-  ret.registerModel(std::make_unique<ImageShowModel>());
+  auto ret = std::make_shared<DataModelRegistry>();
+  ret->registerModel(std::make_unique<ImageShowModel>());
 
-  ret.registerModel(std::make_unique<ImageLoaderModel>());
+  ret->registerModel(std::make_unique<ImageLoaderModel>());
 
   return ret;
 }

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <stdexcept>
-#include <memory>
 
 #include <QtWidgets/QGraphicsSceneMoveEvent>
 #include <QtWidgets/QFileDialog>
@@ -292,10 +291,11 @@ load()
 
 
 FlowScene::
-FlowScene(DataModelRegistry && registry) : _registry {std::move(registry)}
+FlowScene(std::shared_ptr<DataModelRegistry> registry) : _registry{std::move(registry)}
 {
   setItemIndexMethod(QGraphicsScene::NoIndex);
 }
+
 
 FlowScene::
 ~FlowScene()

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -23,8 +23,7 @@ class NODE_EDITOR_PUBLIC FlowScene
 {
 public:
 
-  // Use && to assure that a rvalue reference is passed and the caller has to use std::move() or an rvalue
-  FlowScene(DataModelRegistry && registry = {});
+  FlowScene(std::shared_ptr<DataModelRegistry> registry = std::make_shared<DataModelRegistry>());
 
   ~FlowScene();
 
@@ -60,15 +59,13 @@ public:
   load();
 
   DataModelRegistry&
-  registry()
-  {
-    return _registry;
+  registry() {
+    return *_registry;
   }
 
   void
-  setRegistry(DataModelRegistry && registry)
-  {
-    _registry = std::move(registry);
+  setRegistry(std::shared_ptr<DataModelRegistry> registry) {
+    if(registry) _registry = std::move(registry); // make sure _registry cannot be null
   }
 
 private:
@@ -78,7 +75,7 @@ private:
 
   std::unordered_map<QUuid, SharedConnection> _connections;
   std::unordered_map<QUuid, SharedNode>       _nodes;
-  DataModelRegistry _registry;
+  std::shared_ptr<DataModelRegistry>          _registry;
 };
 
 std::shared_ptr<Node>


### PR DESCRIPTION
Use case:
You are writing an editor for graphs (like I am) and you want to have multiple graphs that share the same node types. These node types could change throughout the program execution, it would be a pain in the butt to copy them all for each update to the registry. Therefore, a shared registry is the way to go for this scenario (unless you have any other ideas)