### PR TITLE
Add an option to not build the examples in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.2)
 
 project(NodeEditor)
 
+option(BUILD_EXAMPLES ON)
+
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -51,5 +53,6 @@ target_link_libraries(nodes
                       Qt5::Gui
                       Qt5::OpenGL)
 
-
-add_subdirectory(examples)
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()


### PR DESCRIPTION
This makes it so you don't have to build the examples. This is nice when building it as a library. The default behavior isn't changed.