### PR TITLE
Add headers in include that should be there

### DIFF
--- a/include/nodes/Node
+++ b/include/nodes/Node
@@ -1,0 +1,2 @@
+#include "../../src/Node.hpp"
+

--- a/include/nodes/NodeGraphicsObject
+++ b/include/nodes/NodeGraphicsObject
@@ -1,0 +1,2 @@
+#include "../../src/NodeGraphicsObject.hpp"
+


### PR DESCRIPTION
These are clearly meant to be exposed because there are functions returning pointers to these objects, but..there is no way to include them other than '../../src/...' which is a bit ugly.

I might have missed some that should be there, this is what came to mind.