### PR TITLE
Don't use const std::unique_ptr<...>& everywhere, use raw pointer instead

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -104,19 +104,19 @@ resetReactionToConnection()
 }
 
 
-std::unique_ptr<NodeGraphicsObject> const &
+NodeGraphicsObject const *
 Node::
 nodeGraphicsObject() const
 {
-  return _nodeGraphicsObject;
+  return _nodeGraphicsObject.get();
 }
 
 
-std::unique_ptr<NodeGraphicsObject> &
+NodeGraphicsObject *
 Node::
 nodeGraphicsObject()
 {
-  return _nodeGraphicsObject;
+  return _nodeGraphicsObject.get();
 }
 
 
@@ -162,11 +162,11 @@ nodeState()
 }
 
 
-std::unique_ptr<NodeDataModel> const &
+NodeDataModel* const
 Node::
 nodeDataModel() const
 {
-  return _nodeDataModel;
+  return _nodeDataModel.get();
 }
 
 

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -53,10 +53,10 @@ public:
 
 public:
 
-  std::unique_ptr<NodeGraphicsObject> const&
+  NodeGraphicsObject const*
   nodeGraphicsObject() const;
 
-  std::unique_ptr<NodeGraphicsObject>&
+  NodeGraphicsObject*
   nodeGraphicsObject();
 
   void
@@ -74,7 +74,7 @@ public:
   NodeState &
   nodeState();
 
-  std::unique_ptr<NodeDataModel> const &
+  NodeDataModel* const
   nodeDataModel() const;
 
 public slots: // data propagation

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -153,7 +153,7 @@ nodePortScenePosition(PortType portType, PortIndex portIndex) const
 
   QPointF p = geom.portScenePosition(portIndex, portType);
 
-  std::unique_ptr<NodeGraphicsObject> const & ngo =
+  NodeGraphicsObject* ngo =
     _node->nodeGraphicsObject();
 
   return ngo->sceneTransform().map(p);

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -22,7 +22,7 @@ paint(QPainter* painter,
 
   NodeState const& state = node->nodeState();
 
-  std::unique_ptr<NodeGraphicsObject> const& graphicsObject = node->nodeGraphicsObject();
+  NodeGraphicsObject* const graphicsObject = node->nodeGraphicsObject();
 
   geom.recalculateSize(painter->fontMetrics());
 
@@ -48,7 +48,7 @@ void
 NodePainter::
 drawNodeRect(QPainter* painter,
              NodeGeometry const& geom,
-             std::unique_ptr<NodeGraphicsObject> const& graphicsObject)
+             NodeGraphicsObject* const graphicsObject)
 {
   auto color = graphicsObject->isSelected()
                ? nodeStyle.SelectedBoundaryColor
@@ -91,7 +91,7 @@ NodePainter::
 drawConnectionPoints(QPainter* painter,
                      NodeGeometry const& geom,
                      NodeState const& state,
-                     std::unique_ptr<NodeDataModel> const & model)
+                     NodeDataModel* const model)
 {
   // TODO make specific color name
   painter->setBrush(nodeStyle.ConnectionPointColor);
@@ -185,7 +185,7 @@ NodePainter::
 drawModelName(QPainter * painter,
               NodeGeometry const & geom,
               NodeState const & state,
-              std::unique_ptr<NodeDataModel> const & model)
+              NodeDataModel* const model)
 {
   Q_UNUSED(state);
 
@@ -219,7 +219,7 @@ NodePainter::
 drawEntryLabels(QPainter * painter,
                 NodeGeometry const & geom,
                 NodeState const & state,
-                std::unique_ptr<NodeDataModel> const & model)
+                NodeDataModel* const model)
 {
   QFontMetrics const & metrics =
     painter->fontMetrics();
@@ -275,7 +275,7 @@ void
 NodePainter::
 drawResizeRect(QPainter * painter,
                NodeGeometry const & geom,
-               std::unique_ptr<NodeDataModel> const & model)
+               NodeDataModel* const model)
 {
   if (model->resizable())
   {

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -29,28 +29,28 @@ public:
   static
   void
   drawNodeRect(QPainter* painter, NodeGeometry const& geom,
-               std::unique_ptr<NodeGraphicsObject> const& graphicsObject);
+               NodeGraphicsObject* const graphicsObject);
 
   static
   void
   drawModelName(QPainter* painter,
                 NodeGeometry const& geom,
                 NodeState const& state,
-                std::unique_ptr<NodeDataModel> const & model);
+                NodeDataModel* const model);
 
   static
   void
   drawEntryLabels(QPainter* painter,
                   NodeGeometry const& geom,
                   NodeState const& state,
-                  std::unique_ptr<NodeDataModel> const & model);
+                  NodeDataModel* const model);
 
   static
   void
   drawConnectionPoints(QPainter* painter,
                        NodeGeometry const& geom,
                        NodeState const& state,
-                       std::unique_ptr<NodeDataModel> const & model);
+                       NodeDataModel* const model);
 
   static
   void
@@ -62,7 +62,7 @@ public:
   void
   drawResizeRect(QPainter* painter,
                  NodeGeometry const& geom,
-                 std::unique_ptr<NodeDataModel> const & model);
+                 NodeDataModel* const model);
 
   static NodeStyle nodeStyle;
 };


### PR DESCRIPTION
It's not really considered good practice to have `const unique_ptr<...>&` everywehre because you can just use C pointers that are much more flexible. The rule of thumb (at least that i've heard) is that only use smart pointers if the callee cares about the lifetime of the object. 

This actually gets rid of a potential error in `Node::nodeGraphicsObject` where somebody could change the graphics object and `recalculateSize` wouldn't be called.