### PR TITLE
Fix signal callbacks in FlowScene

### DIFF
--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -89,6 +89,8 @@ createConnection(std::shared_ptr<Node> nodeIn,
 
   _connections[connection->id()] = connection;
 
+  connectionCreated(*connection);
+  
   return connection;
 }
 
@@ -199,8 +201,6 @@ void
 FlowScene::
 removeConnection(std::shared_ptr<Connection> conn)
 {
-  connectionDeleted(*conn);
-
   deleteConnection(conn);
 }
 


### PR DESCRIPTION
`deleteConnection` was being called twice and `connectionCreated` not enough

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paceholder/nodeeditor/29)
<!-- Reviewable:end -->
