### PR TITLE
Make Nodes uniquely owned by FlowScene instead of using shared_ptr

### DIFF
--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -4,6 +4,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QUuid>
+#include <QVariant>
 
 #include "PortType.hpp"
 #include "NodeData.hpp"
@@ -43,12 +44,12 @@ public:
   /// The port has parameters (portType, portIndex).
   /// The opposite connection end will require anothre port.
   Connection(PortType portType,
-             std::shared_ptr<Node> node,
+             Node& node,
              PortIndex portIndex);
 
-  Connection(std::shared_ptr<Node> nodeIn,
+  Connection(Node& nodeIn,
              PortIndex portIndexIn,
-             std::shared_ptr<Node> nodeOut,
+             Node& nodeOut,
              PortIndex portIndexOut);
 
   ~Connection();
@@ -77,7 +78,7 @@ public:
   /// Assigns a node to the required port.
   /// It is assumed that there is a required port, no extra checks
   void
-  setNodeToPort(std::shared_ptr<Node> node,
+  setNodeToPort(Node& node,
                 PortType portType,
                 PortIndex portIndex);
 
@@ -86,7 +87,7 @@ public:
 
 public:
 
-  std::unique_ptr<ConnectionGraphicsObject> const&
+  ConnectionGraphicsObject&
   getConnectionGraphicsObject() const;
 
   ConnectionState const &
@@ -96,10 +97,14 @@ public:
 
   ConnectionGeometry&
   connectionGeometry();
+  
+  ConnectionGeometry const&
+  connectionGeometry() const;
 
-  std::weak_ptr<Node> const &
+  Node*
   getNode(PortType portType) const;
-  std::weak_ptr<Node> &
+  
+  Node*&
   getNode(PortType portType);
 
   PortIndex
@@ -124,8 +129,8 @@ private:
 
 private:
 
-  std::weak_ptr<Node> _outNode;
-  std::weak_ptr<Node> _inNode;
+  Node* _outNode = nullptr;
+  Node* _inNode = nullptr;
 
   PortIndex _outPortIndex;
   PortIndex _inPortIndex;

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -22,7 +22,7 @@
 
 ConnectionGraphicsObject::
 ConnectionGraphicsObject(FlowScene &scene,
-                         std::shared_ptr<Connection> &connection)
+                         Connection &connection)
   : _scene(scene)
   , _connection(connection)
 {
@@ -49,7 +49,7 @@ ConnectionGraphicsObject::
 }
 
 
-std::weak_ptr<Connection>&
+Connection&
 ConnectionGraphicsObject::
 connection()
 {
@@ -61,7 +61,7 @@ QRectF
 ConnectionGraphicsObject::
 boundingRect() const
 {
-  return _connection.lock()->connectionGeometry().boundingRect();
+  return _connection.connectionGeometry().boundingRect();
 }
 
 
@@ -78,7 +78,7 @@ shape() const
 
 #else
   auto const &geom =
-    _connection.lock()->connectionGeometry();
+    _connection.connectionGeometry();
 
   return ConnectionPainter::getPainterStroke(geom);
 
@@ -98,22 +98,19 @@ void
 ConnectionGraphicsObject::
 move()
 {
-  auto con = _connection.lock();
 
-  if (!con)
-    return;
 
   auto moveEndPoint =
-  [&con, this] (PortType portType)
+  [this] (PortType portType)
   {
-    if (auto node = con->getNode(portType).lock())
+    if (auto node = _connection.getNode(portType))
     {
       auto const &nodeGraphics = node->nodeGraphicsObject();
 
       auto const &nodeGeom = node->nodeGeometry();
 
       QPointF scenePos =
-        nodeGeom.portScenePosition(con->getPortIndex(portType),
+        nodeGeom.portScenePosition(_connection.getPortIndex(portType),
                                    portType,
                                    nodeGraphics.sceneTransform());
 
@@ -122,11 +119,11 @@ move()
 
         QPointF connectionPos = sceneTransform.inverted().map(scenePos);
 
-        con->connectionGeometry().setEndPoint(portType,
+        _connection.connectionGeometry().setEndPoint(portType,
                                               connectionPos);
 
-        con->getConnectionGraphicsObject()->setGeometryChanged();
-        con->getConnectionGraphicsObject()->update();
+        _connection.getConnectionGraphicsObject().setGeometryChanged();
+        _connection.getConnectionGraphicsObject().update();
       }
     }
   };
@@ -145,7 +142,7 @@ paint(QPainter* painter,
   painter->setClipRect(option->exposedRect);
 
   ConnectionPainter::paint(painter,
-                           _connection.lock());
+                           _connection);
 }
 
 
@@ -169,26 +166,26 @@ mouseMoveEvent(QGraphicsSceneMouseEvent* event)
                              _scene,
                              view->transform());
 
-  auto con    = _connection.lock();
-  auto &state = con->connectionState();
+  auto &state = _connection.connectionState();
 
   state.interactWithNode(node);
   if (node)
   {
     node->reactToPossibleConnection(state.requiredPort(),
-                                    con->dataType(),
+                                    _connection.dataType(),
                                     event->scenePos());
+
   }
 
   //-------------------
 
   QPointF offset = event->pos() - event->lastPos();
 
-  auto requiredPort = con->requiredPort();
+  auto requiredPort = _connection.requiredPort();
 
   if (requiredPort != PortType::None)
   {
-    con->connectionGeometry().moveEndPoint(requiredPort, offset);
+    _connection.connectionGeometry().moveEndPoint(requiredPort, offset);
   }
 
   //-------------------
@@ -209,17 +206,15 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   auto node = ::locateNodeAt(event->scenePos(), _scene,
                              _scene.views()[0]->transform());
 
-  auto connection = _connection.lock();
-
-  NodeConnectionInteraction interaction(node, connection);
+  NodeConnectionInteraction interaction(*node, _connection);
 
   if (node && interaction.tryConnect())
   {
     node->resetReactionToConnection();
   }
-  else if (connection->connectionState().requiresPort())
+  else if (_connection.connectionState().requiresPort())
   {
-    _scene.deleteConnection(connection);
+    _scene.deleteConnection(_connection);
   }
 }
 
@@ -228,7 +223,7 @@ void
 ConnectionGraphicsObject::
 hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
-  _connection.lock()->connectionGeometry().setHovered(true);
+  _connection.connectionGeometry().setHovered(true);
 
   update();
   event->accept();
@@ -239,7 +234,7 @@ void
 ConnectionGraphicsObject::
 hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-  _connection.lock()->connectionGeometry().setHovered(false);
+  _connection.connectionGeometry().setHovered(false);
 
   update();
   event->accept();

--- a/src/ConnectionGraphicsObject.hpp
+++ b/src/ConnectionGraphicsObject.hpp
@@ -22,14 +22,14 @@ class ConnectionGraphicsObject
 public:
 
   ConnectionGraphicsObject(FlowScene &scene,
-                           std::shared_ptr<Connection> &connection);
+                           Connection &connection);
 
   virtual
   ~ConnectionGraphicsObject();
 
 public:
 
-  std::weak_ptr<Connection>&
+  Connection&
   connection();
 
   QRectF
@@ -76,5 +76,5 @@ private:
 
   FlowScene & _scene;
 
-  std::weak_ptr<Connection> _connection;
+  Connection& _connection;
 };

--- a/src/ConnectionPainter.cpp
+++ b/src/ConnectionPainter.cpp
@@ -63,29 +63,30 @@ getPainterStroke(ConnectionGeometry const& geom)
 void
 ConnectionPainter::
 paint(QPainter* painter,
-      std::shared_ptr<Connection> const &connection)
+      Connection const &connection)
 {
   auto const &connectionStyle =
     StyleCollection::connectionStyle();
-
-  NodeDataType dataType = connection->dataType();
 
   QColor normalColor   = connectionStyle.normalColor();
   QColor hoverColor    = connectionStyle.hoveredColor();
   QColor selectedColor = connectionStyle.selectedColor();
 
+  auto dataType = connection.dataType();
+  
   if (connectionStyle.useDataDefinedColors())
   {
+    
     normalColor = connectionStyle.normalColor(dataType.id);
     hoverColor    = normalColor.lighter(200);
     selectedColor = normalColor.darker(200);
   }
 
   ConnectionGeometry const& geom =
-    connection->connectionGeometry();
+    connection.connectionGeometry();
 
   ConnectionState const& state =
-    connection->connectionState();
+    connection.connectionState();
 
   double const lineWidth     = connectionStyle.lineWidth();
   double const pointDiameter = connectionStyle.pointDiameter();
@@ -118,9 +119,9 @@ paint(QPainter* painter,
   bool const hovered = geom.hovered();
 
   auto const& graphicsObject =
-    connection->getConnectionGraphicsObject();
+    connection.getConnectionGraphicsObject();
 
-  bool const selected = graphicsObject->isSelected();
+  bool const selected = graphicsObject.isSelected();
 
   if (hovered || selected)
   {

--- a/src/ConnectionPainter.hpp
+++ b/src/ConnectionPainter.hpp
@@ -27,5 +27,5 @@ public:
   static
   void
   paint(QPainter* painter,
-        std::shared_ptr<Connection> const &connection);
+        Connection const& connection);
 };

--- a/src/ConnectionState.cpp
+++ b/src/ConnectionState.cpp
@@ -16,7 +16,7 @@ ConnectionState::
 
 void
 ConnectionState::
-interactWithNode(std::shared_ptr<Node> node)
+interactWithNode(Node* node)
 {
   if (node)
   {
@@ -31,7 +31,7 @@ interactWithNode(std::shared_ptr<Node> node)
 
 void
 ConnectionState::
-setLastHoveredNode(std::shared_ptr<Node> node)
+setLastHoveredNode(Node* node)
 {
   _lastHoveredNode = node;
 }
@@ -41,10 +41,8 @@ void
 ConnectionState::
 resetLastHoveredNode()
 {
-  auto node = _lastHoveredNode.lock();
+  if (_lastHoveredNode)
+    _lastHoveredNode->resetReactionToConnection();
 
-  if (node)
-    node->resetReactionToConnection();
-
-  _lastHoveredNode.reset();
+  _lastHoveredNode = nullptr;
 }

--- a/src/ConnectionState.hpp
+++ b/src/ConnectionState.hpp
@@ -37,13 +37,13 @@ public:
 
 public:
 
-  void interactWithNode(std::shared_ptr<Node> node);
+  void interactWithNode(Node* node);
 
-  void setLastHoveredNode(std::shared_ptr<Node> node);
+  void setLastHoveredNode(Node* node);
 
-  std::shared_ptr<Node> const
+  Node* const
   lastHoveredNode() const
-  { return _lastHoveredNode.lock(); }
+  { return _lastHoveredNode; }
 
   void resetLastHoveredNode();
 
@@ -51,5 +51,5 @@ private:
 
   PortType _requiredPort;
 
-  std::weak_ptr<Node> _lastHoveredNode;
+  Node* _lastHoveredNode = nullptr;
 };

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -34,32 +34,29 @@ public:
 
   std::shared_ptr<Connection>
   createConnection(PortType connectedPort,
-                   std::shared_ptr<Node> node,
+                   Node& node,
                    PortIndex portIndex);
 
   std::shared_ptr<Connection>
-  createConnection(std::shared_ptr<Node> nodeIn,
+  createConnection(Node& nodeIn,
                    PortIndex portIndexIn,
-                   std::shared_ptr<Node> nodeOut,
+                   Node& nodeOut,
                    PortIndex portIndexOut);
 
   std::shared_ptr<Connection>
   restoreConnection(Properties const &p);
 
   void
-  deleteConnection(std::shared_ptr<Connection> connection);
+  deleteConnection(Connection& connection);
 
-  std::shared_ptr<Node>
+  Node&
   createNode(std::unique_ptr<NodeDataModel> && dataModel);
 
-  std::shared_ptr<Node>
+  Node&
   restoreNode(Properties const &p);
 
   void
-  removeNode(std::shared_ptr<Node> node);
-
-  void
-  removeConnection(std::shared_ptr<Connection> connection);
+  removeNode(Node& node);
 
   DataModelRegistry&
   registry();
@@ -77,25 +74,25 @@ public:
 
 signals:
   void
-  nodeCreated(const std::shared_ptr<Node>& n);
+  nodeCreated(Node &n);
   void
-  nodeDeleted(const std::shared_ptr<Node>& n);
+  nodeDeleted(Node &n);
 
   void
-  connectionCreated(Connection& c);
+  connectionCreated(Connection &c);
   void
-  connectionDeleted(Connection& c);
+  connectionDeleted(Connection &c);
 
 private:
 
   using SharedConnection = std::shared_ptr<Connection>;
-  using SharedNode       = std::shared_ptr<Node>;
+  using UniqueNode       = std::unique_ptr<Node>;
 
   std::unordered_map<QUuid, SharedConnection> _connections;
-  std::unordered_map<QUuid, SharedNode>       _nodes;
+  std::unordered_map<QUuid, UniqueNode>       _nodes;
   std::shared_ptr<DataModelRegistry>          _registry;
 };
 
-std::shared_ptr<Node>
+Node*
 locateNodeAt(QPointF scenePoint, FlowScene &scene,
              QTransform viewTransform);

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -70,13 +70,13 @@ contextMenuEvent(QContextMenuEvent *event)
 
     if (type)
     {
-      auto node = _scene->createNode(std::move(type));
+      auto& node = _scene->createNode(std::move(type));
 
       QPoint pos = event->pos();
 
       QPointF posView = this->mapToScene(pos);
 
-      node->nodeGraphicsObject().setPos(posView);
+      node.nodeGraphicsObject().setPos(posView);
     }
     else
     {
@@ -146,22 +146,22 @@ keyPressEvent(QKeyEvent *event)
 
     case Qt::Key_Delete:
     {
-      std::vector<std::shared_ptr<Node>> nodesToDelete;
-      std::vector<std::shared_ptr<Connection>> connectionsToDelete;
+      std::vector<Node*> nodesToDelete;
+      std::vector<Connection*> connectionsToDelete;
       for (QGraphicsItem * item : _scene->selectedItems())
       {
         if (auto n = dynamic_cast<NodeGraphicsObject*>(item))
-          nodesToDelete.push_back(n->node().lock());
+          nodesToDelete.push_back(&n->node());
 
         if (auto c = dynamic_cast<ConnectionGraphicsObject*>(item))
-          connectionsToDelete.push_back(c->connection().lock());
+          connectionsToDelete.push_back(&c->connection());
       }
 
       for( auto & n : nodesToDelete )
-        _scene->removeNode(n);
+        _scene->removeNode(*n);
 
       for( auto & c : connectionsToDelete )
-        _scene->removeConnection(c);
+        _scene->deleteConnection(*c);
 
     }
 

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -37,7 +37,7 @@ canConnect(PortIndex &portIndex) const
 
   // 4) Connection type == node port type (not implemented yet)
 
-  NodeDataType connectionDataType = _connection->dataType();
+  auto connectionDataType = _connection->dataType();
 
   auto const   &modelTarget = _node->nodeDataModel();
   NodeDataType candidateNodeDataType = modelTarget->dataType(requiredPort, portIndex);
@@ -66,11 +66,11 @@ tryConnect() const
   PortType requiredPort = connectionRequiredPort();
   _node->nodeState().setConnection(requiredPort,
                                    portIndex,
-                                   _connection);
+                                   *_connection);
 
   // 3) Assign Connection to empty port in NodeState
   // The port is not longer required after this function
-  _connection->setNodeToPort(_node, requiredPort, portIndex);
+  _connection->setNodeToPort(*_node, requiredPort, portIndex);
 
   // 4) Adjust Connection geometry
 
@@ -78,7 +78,7 @@ tryConnect() const
 
   // 5) Poke model to intiate data transfer
 
-  auto outNode = _connection->getNode(PortType::Out).lock();
+  auto outNode = _connection->getNode(PortType::Out);
   if (outNode)
   {
     PortIndex outPortIndex = _connection->getPortIndex(PortType::Out);
@@ -112,7 +112,7 @@ disconnect(PortType portToDisconnect) const
 
   _connection->setRequiredPort(portToDisconnect);
 
-  _connection->getConnectionGraphicsObject()->grabMouse();
+  _connection->getConnectionGraphicsObject().grabMouse();
 
   return true;
 }
@@ -134,14 +134,14 @@ QPointF
 NodeConnectionInteraction::
 connectionEndScenePosition(PortType portType) const
 {
-  std::unique_ptr<ConnectionGraphicsObject> const &go =
+  auto &go =
     _connection->getConnectionGraphicsObject();
 
   ConnectionGeometry& geometry = _connection->connectionGeometry();
 
   QPointF endPoint = geometry.getEndPoint(portType);
 
-  return go->mapToScene(endPoint);
+  return go.mapToScene(endPoint);
 }
 
 

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -11,10 +11,10 @@
 class NodeConnectionInteraction
 {
 public:
-  NodeConnectionInteraction(std::shared_ptr<Node> node,
-                            std::shared_ptr<Connection> connection)
-    : _node(node)
-    , _connection(connection)
+  NodeConnectionInteraction(Node& node,
+                            Connection& connection)
+    : _node(&node)
+    , _connection(&connection)
   {}
 
   /// Can connect when following conditions are met:
@@ -54,7 +54,7 @@ private:
 
 private:
 
-  std::shared_ptr<Node> _node;
+  Node* _node;
 
-  std::shared_ptr<Connection> _connection;
+  Connection* _connection;
 };

--- a/src/NodeGraphicsObject.hpp
+++ b/src/NodeGraphicsObject.hpp
@@ -21,12 +21,12 @@ class NodeGraphicsObject : public QGraphicsObject
 
 public:
   NodeGraphicsObject(FlowScene &scene,
-                     std::shared_ptr<Node>& node);
+                     Node& node);
 
   virtual
   ~NodeGraphicsObject();
 
-  std::weak_ptr<Node>&
+  Node&
   node();
 
   QRectF
@@ -75,7 +75,7 @@ private:
 
   FlowScene & _scene;
 
-  std::weak_ptr<Node> _node;
+  Node& _node;
 
   // either nullptr or owned by parent QGraphicsItem
   QGraphicsProxyWidget * _proxyWidget;

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -15,13 +15,13 @@
 void
 NodePainter::
 paint(QPainter* painter,
-      std::shared_ptr<Node> const &node)
+      Node& node)
 {
-  NodeGeometry const& geom = node->nodeGeometry();
+  NodeGeometry const& geom = node.nodeGeometry();
 
-  NodeState const& state = node->nodeState();
+  NodeState const& state = node.nodeState();
 
-  NodeGraphicsObject const & graphicsObject = node->nodeGraphicsObject();
+  NodeGraphicsObject const & graphicsObject = node.nodeGraphicsObject();
 
   geom.recalculateSize(painter->font());
 
@@ -29,7 +29,7 @@ paint(QPainter* painter,
 
   drawNodeRect(painter, geom, graphicsObject);
 
-  auto const &model = node->nodeDataModel();
+  auto const &model = node.nodeDataModel();
 
   drawConnectionPoints(painter, geom, state, model);
 

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -22,7 +22,7 @@ public:
   static
   void
   paint(QPainter* painter,
-        std::shared_ptr<Node> const &node);
+        Node& node);
 
   static
   void

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -51,12 +51,12 @@ void
 NodeState::
 setConnection(PortType portType,
               PortIndex portIndex,
-              std::shared_ptr<Connection> connection)
+              Connection& connection)
 {
   auto &connections = getEntries(portType);
 
-  connections[portIndex].insert(std::make_pair(connection->id(),
-                                               connection));
+  connections[portIndex].insert(std::make_pair(connection.id(),
+                                               &connection));
 }
 
 

--- a/src/NodeState.hpp
+++ b/src/NodeState.hpp
@@ -30,7 +30,7 @@ public:
 public:
 
   using ConnectionPtrSet =
-          std::unordered_map<QUuid, std::shared_ptr<Connection> >;
+          std::unordered_map<QUuid, Connection*>;
 
   /// Returns vector of connections ID.
   /// Some of them can be empty (null)
@@ -46,7 +46,7 @@ public:
   void
   setConnection(PortType portType,
                 PortIndex portIndex,
-                std::shared_ptr<Connection> connection);
+                Connection& connection);
 
   void
   eraseConnection(PortType portType,


### PR DESCRIPTION
Nodes were stored in `shared_ptr` objects, which doesn't make sense
because `FlowScene` should be the only owner of Nodes.