### PR TITLE
Remove uneeded const

### DIFF
--- a/src/ConnectionState.hpp
+++ b/src/ConnectionState.hpp
@@ -41,7 +41,7 @@ public:
 
   void setLastHoveredNode(Node* node);
 
-  Node* const
+  Node*
   lastHoveredNode() const
   { return _lastHoveredNode; }
 


### PR DESCRIPTION
The const means nothing, because the pointer is being copied anyways. This also fixes this warning:

`ConnectionState.hpp:44:9: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]`