### PR TITLE
Renamable input and output ports on nodes

### DIFF
--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -22,7 +22,32 @@ public:
   QString
   caption() const override
   { return QString("Division"); }
+  
+  virtual bool
+  portCaptionVisible(PortType portType, PortIndex portIndex) const override
+  { return true; }
 
+  virtual QString
+  portCaption(PortType portType, PortIndex portIndex) const override
+  {
+    switch (portType)
+    {
+      case PortType::In:
+        if (portIndex == 0)
+          return "Dividend";
+        else if (portIndex == 1)
+          return "Divisor";
+        break;
+
+      case PortType::Out:
+        return "Result";
+
+      default:
+        break;
+    }
+  return "";
+  }
+  
   QString
   name() const override
   { return QString("Division"); }

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -34,18 +34,18 @@ public:
     {
       case PortType::In:
         if (portIndex == 0)
-          return "Dividend";
+          return QString("Dividend");
         else if (portIndex == 1)
-          return "Divisor";
+          return QString("Divisor");
         break;
 
       case PortType::Out:
-        return "Result";
+        return QString("Result");
 
       default:
         break;
     }
-  return "";
+	return QString("");
   }
   
   QString

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -24,6 +24,31 @@ public:
   caption() const override
   { return QString("Subtraction"); }
 
+  virtual bool
+  portCaptionVisible(PortType portType, PortIndex portIndex) const override
+  { return true; }
+
+  virtual QString
+  portCaption(PortType portType, PortIndex portIndex) const override
+  {
+    switch (portType)
+    {
+    case PortType::In:
+      if (portIndex == 0)
+        return "Minuend";
+      else if (portIndex == 1)
+        return "Subtrahend";
+      break;
+
+    case PortType::Out:
+      return "Result";
+
+    default:
+      break;
+    }
+    return "";
+  }
+
   QString
   name() const override
   { return QString("Subtraction"); }

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -35,18 +35,18 @@ public:
     {
     case PortType::In:
       if (portIndex == 0)
-        return "Minuend";
+        return QString("Minuend");
       else if (portIndex == 1)
-        return "Subtrahend";
+        return QString("Subtrahend");
       break;
 
     case PortType::Out:
-      return "Result";
+      return QString("Result");
 
     default:
       break;
     }
-    return "";
+	return QString("");
   }
 
   QString

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -31,7 +31,7 @@ public:
 
   /// Port caption is used in GUI to label individual ports
   virtual QString
-  portCaption(PortType portType, PortIndex portIndex) const { return ""; }
+  portCaption(PortType portType, PortIndex portIndex) const { return QString(""); }
 
   /// It is possible to hide port caption in GUI
   virtual bool

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -29,6 +29,14 @@ public:
   virtual bool
   captionVisible() const { return true; }
 
+  /// Port caption is used in GUI to label individual ports
+  virtual QString
+  portCaption(PortType portType, PortIndex portIndex) const { return ""; }
+
+  /// It is possible to hide port caption in GUI
+  virtual bool
+  portCaptionVisible(PortType portType, PortIndex portIndex) const { return false; }
+
   /// Name makes this model unique
   virtual QString
   name() const = 0;

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -256,7 +256,13 @@ portWidth(PortType portType) const
 
   for (auto i = 0ul; i < _dataModel->nPorts(portType); ++i)
   {
-    auto const &name = _dataModel->dataType(PortType::In, i).name;
+    QString name;
+	
+    if (_dataModel->portCaptionVisible(portType, i))
+      name = _dataModel->portCaption(portType, i);
+    else
+      name = _dataModel->dataType(portType, i).name;
+
     width = std::max(unsigned(_fontMetrics.width(name)),
                      width);
   }

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -271,7 +271,12 @@ drawEntryLabels(QPainter * painter,
       else
         painter->setPen(nodeStyle.FontColor);
 
-      QString s = model->dataType(portType, i).name;
+      QString s;
+
+      if (model->portCaptionVisible(portType, i))
+        s = model->portCaption(portType, i);
+      else
+        s = model->dataType(portType, i).name;
 
       auto rect = metrics.boundingRect(s);
 


### PR DESCRIPTION
Minor modification to add the capability to modify port labels from the node model. Helps with cases where input ports are not interchangeable, or the different ports with the same type carry different meaning. (Like the divison and subtraction nodes in the calculator example, the input ports are not interchangeable, so it's clearer to name them accordingly to what role they fill in the calculation.)
![calc](https://cloud.githubusercontent.com/assets/7118075/21908564/7f2f0a4e-d914-11e6-9d09-8045d3703c0f.jpg)
