### PR TITLE
Runtime validation and error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 
 before_install:
   #- if [ "$QT_BASE" = "54" ]; then sudo add-apt-repository ppa:beineri/opt-qt542-trusty -y; fi
-  - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt57-trusty -y; fi
+  - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
   - sudo apt-get update -qq
 
 install:

--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -52,11 +52,15 @@ private:
 
     if (n1 && n2)
     {
+      modelValidationState = NodeValidationState::Valid;
+      modelValidationError = QString("");
       _result = std::make_shared<NumberData>(n1->number() +
                                              n2->number());
     }
     else
     {
+      modelValidationState = NodeValidationState::Warning;
+      modelValidationError = QString("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -13,6 +13,9 @@
 /// In this example it has no logic.
 class DivisionModel : public MathOperationDataModel
 {
+private:
+  bool isModelValid = true;
+  QString modelValidationError = QString("");
 public:
 
   virtual
@@ -45,7 +48,7 @@ public:
       default:
         break;
     }
-	return QString("");
+	  return QString("");
   }
   
   QString
@@ -56,6 +59,14 @@ public:
   clone() const override
   { return std::make_unique<DivisionModel>(); }
 
+  virtual
+  bool
+  isValid() const { return isModelValid; }
+
+  virtual
+  QString
+  errorMessage() const { return modelValidationError; }
+
 public:
 
   void
@@ -65,7 +76,13 @@ public:
   }
 
 private:
-
+  void
+  setValidationState(bool isValid, const QString &msg)
+  {
+    isModelValid = isValid;
+    modelValidationError = msg;
+  }
+  
   void
   compute() override
   {
@@ -74,14 +91,24 @@ private:
     auto n1 = _number1.lock();
     auto n2 = _number2.lock();
 
-    if (n1 && n2 && (n2->number() != 0.0))
+    if (n2 && (n2->number() == 0.0))
     {
-      _result = std::make_shared<NumberData>(n1->number() /
-                                             n2->number());
+      setValidationState(false, 
+        QString("Division by zero error"));
     }
     else
     {
-      _result.reset();
+      setValidationState(true,
+        QString(""));
+      if (n1 && n2 && (n2->number() != 0.0))
+      {
+        _result = std::make_shared<NumberData>(n1->number() /
+          n2->number());
+      }
+      else
+      {
+        _result.reset();
+      }
     }
 
     emit dataUpdated(outPortIndex);

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -48,7 +48,7 @@ public:
       default:
         break;
     }
-	  return QString("");
+    return QString("");
   }
   
   QString
@@ -59,13 +59,13 @@ public:
   clone() const override
   { return std::make_unique<DivisionModel>(); }
 
-  virtual
   bool
-  isValid() const { return isModelValid; }
+  isValid() const override 
+  { return isModelValid; }
 
-  virtual
   QString
-  errorMessage() const { return modelValidationError; }
+  errorMessage() const override
+  { return modelValidationError; }
 
 public:
 
@@ -76,13 +76,7 @@ public:
   }
 
 private:
-  void
-  setValidationState(bool isValid, const QString &msg)
-  {
-    isModelValid = isValid;
-    modelValidationError = msg;
-  }
-  
+
   void
   compute() override
   {
@@ -93,14 +87,14 @@ private:
 
     if (n2 && (n2->number() == 0.0))
     {
-      setValidationState(false, 
-        QString("Division by zero error"));
+      isModelValid = false;
+      modelValidationError = QString("Division by zero error");
     }
     else
     {
-      setValidationState(true,
-        QString(""));
-      if (n1 && n2 && (n2->number() != 0.0))
+      isModelValid = true;
+      modelValidationError = QString("");
+      if (n1 && n2)
       {
         _result = std::make_shared<NumberData>(n1->number() /
           n2->number());

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -13,9 +13,6 @@
 /// In this example it has no logic.
 class DivisionModel : public MathOperationDataModel
 {
-private:
-  bool isModelValid = true;
-  QString modelValidationError = QString("");
 public:
 
   virtual
@@ -59,14 +56,6 @@ public:
   clone() const override
   { return std::make_unique<DivisionModel>(); }
 
-  bool
-  isValid() const override 
-  { return isModelValid; }
-
-  QString
-  errorMessage() const override
-  { return modelValidationError; }
-
 public:
 
   void
@@ -87,24 +76,24 @@ private:
 
     if (n2 && (n2->number() == 0.0))
     {
-      isModelValid = false;
+      modelValidationState = NodeValidationState::Error;
       modelValidationError = QString("Division by zero error");
+      _result.reset();
+    }
+    else if (n1 && n2)
+    {
+      modelValidationState = NodeValidationState::Valid;
+      modelValidationError = QString("");
+      _result = std::make_shared<NumberData>(n1->number() /
+        n2->number());
     }
     else
     {
-      isModelValid = true;
-      modelValidationError = QString("");
-      if (n1 && n2)
-      {
-        _result = std::make_shared<NumberData>(n1->number() /
-          n2->number());
-      }
-      else
-      {
-        _result.reset();
-      }
+      modelValidationState = NodeValidationState::Warning;
+      modelValidationError = QString("Missing or incorrect inputs");
+      _result.reset();
     }
-
+    
     emit dataUpdated(outPortIndex);
   }
 };

--- a/examples/calculator/MathOperationDataModel.cpp
+++ b/examples/calculator/MathOperationDataModel.cpp
@@ -53,3 +53,17 @@ setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
 }
 
 
+NodeValidationState
+MathOperationDataModel::
+validationState() const
+{
+  return modelValidationState;
+}
+
+
+QString
+MathOperationDataModel::
+validationMessage() const
+{
+  return modelValidationError;
+}

--- a/examples/calculator/MathOperationDataModel.hpp
+++ b/examples/calculator/MathOperationDataModel.hpp
@@ -32,6 +32,10 @@ public:
 
   QWidget * embeddedWidget() override { return nullptr; }
 
+  NodeValidationState validationState() const override;
+
+  QString validationMessage() const override;
+
 protected:
 
   virtual void compute() = 0;
@@ -42,4 +46,7 @@ protected:
   std::weak_ptr<NumberData> _number2;
 
   std::shared_ptr<NumberData> _result;
+
+  NodeValidationState modelValidationState = NodeValidationState::Warning;
+  QString modelValidationError = QString("Missing or incorrect inputs");
 };

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -52,11 +52,15 @@ private:
 
     if (n1 && n2)
     {
+      modelValidationState = NodeValidationState::Valid;
+      modelValidationError = QString("");
       _result = std::make_shared<NumberData>(n1->number() *
                                              n2->number());
     }
     else
     {
+      modelValidationState = NodeValidationState::Warning;
+      modelValidationError = QString("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/examples/calculator/NumberDisplayDataModel.cpp
+++ b/examples/calculator/NumberDisplayDataModel.cpp
@@ -58,12 +58,32 @@ setInData(std::shared_ptr<NodeData> data, int)
 
   if (numberData)
   {
+    modelValidationState = NodeValidationState::Valid;
+    modelValidationError = QString("");
     _label->setText(numberData->numberAsText());
   }
   else
   {
+    modelValidationState = NodeValidationState::Warning;
+    modelValidationError = QString("Missing or incorrect inputs");
     _label->clear();
   }
 
   _label->adjustSize();
+}
+
+
+NodeValidationState
+NumberDisplayDataModel::
+validationState() const
+{
+  return modelValidationState;
+}
+
+
+QString
+NumberDisplayDataModel::
+validationMessage() const
+{
+  return modelValidationError;
 }

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -63,7 +63,16 @@ public:
   QWidget *
   embeddedWidget() override { return _label; }
 
+  NodeValidationState 
+  validationState() const override;
+
+  QString 
+  validationMessage() const override;
+
 private:
+
+  NodeValidationState modelValidationState = NodeValidationState::Warning;
+  QString modelValidationError = QString("Missing or incorrect inputs");
 
   QLabel * _label;
 };

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -77,11 +77,15 @@ private:
 
     if (n1 && n2)
     {
+      modelValidationState = NodeValidationState::Valid;
+      modelValidationError = QString("");
       _result = std::make_shared<NumberData>(n1->number() -
                                              n2->number());
     }
     else
     {
+      modelValidationState = NodeValidationState::Warning;
+      modelValidationError = QString("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/resources/DefaultStyle.json
+++ b/resources/DefaultStyle.json
@@ -16,6 +16,8 @@
     "FontColorFaded" : "gray",
     "ConnectionPointColor": [169, 169, 169],
     "FilledConnectionPointColor": "cyan",
+	"ErrorColor": "red",
+	"WarningColor": [128, 128, 0],
 
     "PenWidth": 1.0,
     "HoveredPenWidth": 1.5,

--- a/resources/DefaultStyle.json
+++ b/resources/DefaultStyle.json
@@ -16,8 +16,8 @@
     "FontColorFaded" : "gray",
     "ConnectionPointColor": [169, 169, 169],
     "FilledConnectionPointColor": "cyan",
-	"ErrorColor": "red",
-	"WarningColor": [128, 128, 0],
+    "ErrorColor": "red",
+    "WarningColor": [128, 128, 0],
 
     "PenWidth": 1.0,
     "HoveredPenWidth": 1.5,

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -221,7 +221,7 @@ iterateOverNodes(std::function<void(Node*)> visitor)
 {
   for (const auto& _node : _nodes)
   {
-	  visitor(_node.second.get());
+    visitor(_node.second.get());
   }
 }
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -221,7 +221,7 @@ iterateOverNodes(std::function<void(Node*)> visitor)
 {
   for (const auto& _node : _nodes)
   {
-	visitor(_node.second.get());
+	  visitor(_node.second.get());
   }
 }
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -215,6 +215,17 @@ setRegistry(std::shared_ptr<DataModelRegistry> registry)
 }
 
 
+void
+FlowScene::
+iterateOverNodes(std::function<void(Node*)> visitor)
+{
+  for (const auto& _node : _nodes)
+  {
+	visitor(_node.second.get());
+  }
+}
+
+
 //------------------------------------------------------------------------------
 
 void

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <tuple>
 #include <memory>
+#include <functional>
 
 #include "Connection.hpp"
 #include "Export.hpp"
@@ -63,6 +64,9 @@ public:
 
   void
   setRegistry(std::shared_ptr<DataModelRegistry> registry);
+
+  void
+  iterateOverNodes(std::function<void(Node*)> visitor);
 
 public:
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -175,8 +175,19 @@ Node::
 propagateData(std::shared_ptr<NodeData> nodeData,
               PortIndex inPortIndex) const
 {
+  bool validBefore = _nodeDataModel->isValid();
+
   _nodeDataModel->setInData(nodeData, inPortIndex);
 
+  bool validAfter = _nodeDataModel->isValid();
+
+  if (validBefore != validAfter)
+  {
+    _nodeGraphicsObject->setGeometryChanged();
+    _nodeGeometry.recalculateSize();
+    _nodeGraphicsObject->update();
+    _nodeGraphicsObject->moveConnections();
+  }
 }
 
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -175,19 +175,13 @@ Node::
 propagateData(std::shared_ptr<NodeData> nodeData,
               PortIndex inPortIndex) const
 {
-  bool validBefore = _nodeDataModel->isValid();
-
   _nodeDataModel->setInData(nodeData, inPortIndex);
-
-  bool validAfter = _nodeDataModel->isValid();
-
-  if (validBefore != validAfter)
-  {
-    _nodeGraphicsObject->setGeometryChanged();
-    _nodeGeometry.recalculateSize();
-    _nodeGraphicsObject->update();
-    _nodeGraphicsObject->moveConnections();
-  }
+  
+  //Recalculate the nodes visuals. A data change can result in the node taking more space than before, so this forces a recalculate+repaint on the affected node
+  _nodeGraphicsObject->setGeometryChanged();
+  _nodeGeometry.recalculateSize();
+  _nodeGraphicsObject->update();
+  _nodeGraphicsObject->moveConnections();
 }
 
 

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -10,6 +10,13 @@
 
 #include "Export.hpp"
 
+enum class NodeValidationState
+{
+  Valid,
+  Warning,
+  Error
+};
+
 class NODE_EDITOR_PUBLIC NodeDataModel
   : public QObject
   , public Serializable
@@ -76,12 +83,12 @@ public:
   resizable() const { return false; }
   
   virtual
-  bool
-  isValid() const { return true; }
+  NodeValidationState
+  validationState() const { return NodeValidationState::Valid; }
 
   virtual
   QString
-  errorMessage() const { return QString(""); }
+  validationMessage() const { return QString(""); }
 
 signals:
 

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -74,6 +74,14 @@ public:
   virtual
   bool
   resizable() const { return false; }
+  
+  virtual
+  bool
+  isValid() const { return true; }
+
+  virtual
+  QString
+  errorMessage() const { return QString(""); }
 
 signals:
 

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -89,6 +89,12 @@ recalculateSize() const
   }
 
   _width = std::max(_width, captionWidth());
+
+  if (!_dataModel->isValid())
+  {
+    _width = std::max(_width, errorWidth());
+    _height += errorHeight() + _spacing;
+  }
 }
 
 
@@ -250,6 +256,26 @@ captionWidth() const
 
 unsigned int
 NodeGeometry::
+errorHeight() const
+{
+  QString msg = _dataModel->errorMessage();
+
+  return _boldFontMetrics.boundingRect(msg).height();
+}
+
+
+unsigned int
+NodeGeometry::
+errorWidth() const
+{
+  QString msg = _dataModel->errorMessage();
+
+  return _boldFontMetrics.boundingRect(msg).width();
+}
+
+
+unsigned int
+NodeGeometry::
 portWidth(PortType portType) const
 {
   unsigned width = 0;
@@ -259,9 +285,13 @@ portWidth(PortType portType) const
     QString name;
 	
     if (_dataModel->portCaptionVisible(portType, i))
+    {
       name = _dataModel->portCaption(portType, i);
+    }
     else
+    {
       name = _dataModel->dataType(portType, i).name;
+    }
 
     width = std::max(unsigned(_fontMetrics.width(name)),
                      width);

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -90,10 +90,10 @@ recalculateSize() const
 
   _width = std::max(_width, captionWidth());
 
-  if (!_dataModel->isValid())
+  if (_dataModel->validationState() != NodeValidationState::Valid)
   {
-    _width = std::max(_width, errorWidth());
-    _height += errorHeight() + _spacing;
+    _width = std::max(_width, validationWidth());
+    _height += validationHeight() + _spacing;
   }
 }
 
@@ -219,7 +219,11 @@ widgetPosition() const
 {
   if (auto w = _dataModel->embeddedWidget())
   {
-
+    if (_dataModel->validationState() != NodeValidationState::Valid)
+    {
+      return QPointF(_spacing + portWidth(PortType::In),
+                     (captionHeight() + _height - validationHeight() - _spacing - w->height()) / 2.0);
+    }
     return QPointF(_spacing + portWidth(PortType::In),
                    (captionHeight() + _height - w->height()) / 2.0);
   }
@@ -256,9 +260,9 @@ captionWidth() const
 
 unsigned int
 NodeGeometry::
-errorHeight() const
+validationHeight() const
 {
-  QString msg = _dataModel->errorMessage();
+  QString msg = _dataModel->validationMessage();
 
   return _boldFontMetrics.boundingRect(msg).height();
 }
@@ -266,9 +270,9 @@ errorHeight() const
 
 unsigned int
 NodeGeometry::
-errorWidth() const
+validationWidth() const
 {
-  QString msg = _dataModel->errorMessage();
+  QString msg = _dataModel->validationMessage();
 
   return _boldFontMetrics.boundingRect(msg).width();
 }

--- a/src/NodeGeometry.hpp
+++ b/src/NodeGeometry.hpp
@@ -102,6 +102,12 @@ public:
   QPointF
   widgetPosition() const;
 
+  unsigned int
+  errorHeight() const;
+
+  unsigned int
+  errorWidth() const;
+
 private:
 
   unsigned int

--- a/src/NodeGeometry.hpp
+++ b/src/NodeGeometry.hpp
@@ -103,10 +103,10 @@ public:
   widgetPosition() const;
 
   unsigned int
-  errorHeight() const;
+  validationHeight() const;
 
   unsigned int
-  errorWidth() const;
+  validationWidth() const;
 
 private:
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -40,6 +40,8 @@ paint(QPainter* painter,
   drawEntryLabels(painter, geom, state, model);
 
   drawResizeRect(painter, geom, model);
+
+  drawErrorRect(painter, geom, model);
 }
 
 
@@ -274,9 +276,13 @@ drawEntryLabels(QPainter * painter,
       QString s;
 
       if (model->portCaptionVisible(portType, i))
+      {
         s = model->portCaption(portType, i);
+      }
       else
+      {
         s = model->dataType(portType, i).name;
+      }
 
       auto rect = metrics.boundingRect(s);
 
@@ -317,5 +323,45 @@ drawResizeRect(QPainter * painter,
     painter->setBrush(Qt::gray);
 
     painter->drawEllipse(geom.resizeRect());
+  }
+}
+
+void
+NodePainter::
+drawErrorRect(QPainter * painter,
+               NodeGeometry const & geom,
+               NodeDataModel* const model)
+{
+  if (!model->isValid())
+  {
+    //Drawing the red background
+    painter->setBrush(Qt::red);
+
+    double const radius = 3.0;
+
+    NodeStyle const& nodeStyle = StyleCollection::nodeStyle();
+
+    float diam = nodeStyle.ConnectionPointDiameter;
+
+    QRectF    boundary(0.0, geom.height() - geom.errorHeight(), geom.width(), geom.errorHeight());
+    QMarginsF m(diam, diam, diam, diam);
+    
+    painter->drawRoundedRect(boundary.marginsAdded(m), radius, radius);
+
+    //Drawing the error message itself
+    QString const &errorMsg = model->errorMessage();
+
+    QFont f = painter->font();
+    
+    QFontMetrics metrics(f);
+
+    auto rect = metrics.boundingRect(errorMsg);
+
+    QPointF position((geom.width() - rect.width()) / 2.0,
+      geom.height() - (geom.errorHeight() - diam) / 2.0);
+
+    painter->setFont(f);
+    painter->setPen(nodeStyle.FontColor);
+    painter->drawText(position, errorMsg);
   }
 }

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -62,4 +62,10 @@ public:
   drawResizeRect(QPainter* painter,
                  NodeGeometry const& geom,
                  NodeDataModel* const model);
+  
+  static
+  void
+  drawErrorRect(QPainter * painter,
+                NodeGeometry const & geom,
+                NodeDataModel* const model);
 };

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -65,7 +65,8 @@ public:
   
   static
   void
-  drawErrorRect(QPainter * painter,
-                NodeGeometry const & geom,
-                NodeDataModel* const model);
+  drawValidationRect(QPainter * painter,
+                     NodeGeometry const & geom,
+                     NodeDataModel* const model,
+                     NodeGraphicsObject const & graphicsObject);
 };

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -117,6 +117,8 @@ loadJsonFromByteArray(QByteArray const &byteArray)
   NODE_STYLE_READ_COLOR(obj, FontColorFaded);
   NODE_STYLE_READ_COLOR(obj, ConnectionPointColor);
   NODE_STYLE_READ_COLOR(obj, FilledConnectionPointColor);
+  NODE_STYLE_READ_COLOR(obj, WarningColor);
+  NODE_STYLE_READ_COLOR(obj, ErrorColor);
 
   NODE_STYLE_READ_FLOAT(obj, PenWidth);
   NODE_STYLE_READ_FLOAT(obj, HoveredPenWidth);

--- a/src/NodeStyle.hpp
+++ b/src/NodeStyle.hpp
@@ -44,6 +44,9 @@ public:
   QColor ConnectionPointColor;
   QColor FilledConnectionPointColor;
 
+  QColor WarningColor;
+  QColor ErrorColor;
+
   float PenWidth;
   float HoveredPenWidth;
 


### PR DESCRIPTION
Extension to the library to provide a way to handle internal node errors in a more visible way. Nodes now have a chance to implement a kind of self validation mechanism, and report to the scene if the operation they representing is not possible on the data they contain. (Example in the calculator sample, if the division node gets a 0 value on the divisor port, that now results in a validation error.) In case of an error, the reported error message if displayed on the invalid node.
![errormsg](https://cloud.githubusercontent.com/assets/7118075/22158335/0f1d8e8c-df3c-11e6-915a-d3d520b38e3b.jpg)
Additionally there's a minor modification to create an easy way to iterate through all the existing nodes in the scene.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paceholder/nodeeditor/46)
<!-- Reviewable:end -->
