### PR TITLE
Context menu filter

### DIFF
--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -56,13 +56,15 @@ contextMenuEvent(QContextMenuEvent *event)
 {
   QMenu modelMenu;
 
+  auto filterActionText = QString("skip me");
+
   auto *txtBox = new QLineEdit(&modelMenu);
   txtBox->setPlaceholderText(QString("Filter"));
   txtBox->setClearButtonEnabled(true);
 
   auto *txtBoxAction = new QWidgetAction(&modelMenu);
   txtBoxAction->setDefaultWidget(txtBox);
-  txtBoxAction->setText(QString("skip me"));
+  txtBoxAction->setText(filterActionText);
 
   modelMenu.addAction(txtBoxAction);
 
@@ -70,7 +72,8 @@ contextMenuEvent(QContextMenuEvent *event)
   {
     for (auto action : modelMenu.actions())
     {
-      if (action->text() != QString("skip me") && !action->text().contains(text, Qt::CaseInsensitive))
+      auto actionText = action->text();
+      if (actionText != filterActionText && !actionText.contains(text, Qt::CaseInsensitive))
       {
         action->setVisible(false);
       }

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -56,12 +56,37 @@ contextMenuEvent(QContextMenuEvent *event)
 {
   QMenu modelMenu;
 
+  auto *txtBox = new QLineEdit(&modelMenu);
+  txtBox->setPlaceholderText(QString("Filter"));
+  txtBox->setClearButtonEnabled(true);
+
+  auto *txtBoxAction = new QWidgetAction(&modelMenu);
+  txtBoxAction->setDefaultWidget(txtBox);
+  txtBoxAction->setText(QString("skip me"));
+
+  modelMenu.addAction(txtBoxAction);
+
+  connect(txtBox, &QLineEdit::textChanged, [&](const QString &text) 
+  {
+    for (auto action : modelMenu.actions())
+    {
+      if (action->text() != QString("skip me") && !action->text().contains(text, Qt::CaseInsensitive))
+      {
+        action->setVisible(false);
+      }
+      else
+      {
+        action->setVisible(true);
+      }
+    }
+  });
+
   for (auto const &modelRegistry : _scene->registry().registeredModels())
   {
     QString const &modelName = modelRegistry.first;
     modelMenu.addAction(modelName);
   }
-
+  
   if (QAction * action = modelMenu.exec(event->globalPos()))
   {
     QString modelName = action->text();


### PR DESCRIPTION
Minor addition to the node insert context menu, to make it's contents real time filterable. With a bunch of different node types, this could make the editor much easier to use.
![filter](https://cloud.githubusercontent.com/assets/7118075/22334754/34ed191c-e3dc-11e6-84df-d0cb97768985.jpg)
