### PR TITLE
Fix segfault in NodeScene

### DIFF
--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -81,11 +81,11 @@ createConnection(Node& nodeIn,
   nodeIn.nodeState().setConnection(PortType::In, portIndexIn, *connection);
   nodeOut.nodeState().setConnection(PortType::Out, portIndexOut, *connection);
 
-  // trigger data propagation
-  nodeOut.onDataUpdated(portIndexOut);
-
   // after this function connection points are set to node port
   connection->setGraphicsObject(std::move(cgo));
+  
+  // trigger data propagation
+  nodeOut.onDataUpdated(portIndexOut);
 
   _connections[connection->id()] = connection;
 


### PR DESCRIPTION
The CGO is requested in `NodeGraphicsObject::moveConnections` with the call stack:
```
Node::onDataUpdated
Connection::propagateData
Node::onDataUpdated
```

Which is called in createConnection