### PR TITLE
Automatic insertion of typecast nodes

### DIFF
--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -22,11 +22,11 @@ public:
 
   QString
   caption() const override
-  { return QString("Addition"); }
+  { return QStringLiteral("Addition"); }
 
   QString
   name() const override
-  { return QString("Addition"); }
+  { return QStringLiteral("Addition"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
@@ -53,14 +53,14 @@ private:
     if (n1 && n2)
     {
       modelValidationState = NodeValidationState::Valid;
-      modelValidationError = QString("");
+      modelValidationError = QString();
       _result = std::make_shared<DecimalData>(n1->number() +
                                               n2->number());
     }
     else
     {
       modelValidationState = NodeValidationState::Warning;
-      modelValidationError = QString("Missing or incorrect inputs");
+      modelValidationError = QStringLiteral("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -7,7 +7,7 @@
 
 #include "MathOperationDataModel.hpp"
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -54,8 +54,8 @@ private:
     {
       modelValidationState = NodeValidationState::Valid;
       modelValidationError = QString("");
-      _result = std::make_shared<NumberData>(n1->number() +
-                                             n2->number());
+      _result = std::make_shared<DecimalData>(n1->number() +
+                                              n2->number());
     }
     else
     {

--- a/examples/calculator/DecimalData.hpp
+++ b/examples/calculator/DecimalData.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <nodes/NodeDataModel>
+
+/// The class can potentially incapsulate any user data which
+/// need to be transferred within the Node Editor graph
+class DecimalData : public NodeData
+{
+public:
+
+  DecimalData()
+    : _number(0.0)
+  {}
+
+  DecimalData(double const number)
+    : _number(number)
+  {}
+
+  NodeDataType type() const override
+  {
+    return NodeDataType {"decimal",
+                         "Decimal"};
+  }
+
+  double number() const
+  { return _number; }
+
+  QString numberAsText() const
+  { return QString::number(_number, 'f'); }
+
+private:
+
+  double _number;
+};

--- a/examples/calculator/DecimalToIntegerModel.cpp
+++ b/examples/calculator/DecimalToIntegerModel.cpp
@@ -59,6 +59,7 @@ outData(PortIndex)
   return _integer;
 }
 
+
 void
 DecimalToIntegerModel::
 setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)

--- a/examples/calculator/DecimalToIntegerModel.cpp
+++ b/examples/calculator/DecimalToIntegerModel.cpp
@@ -1,0 +1,80 @@
+#include "DecimalToIntegerModel.hpp"
+
+#include <QtGui/QDoubleValidator>
+
+#include "DecimalData.hpp"
+#include "IntegerData.hpp"
+
+DecimalToIntegerModel::
+DecimalToIntegerModel()
+{
+}
+
+
+void
+DecimalToIntegerModel::
+save(Properties &p) const
+{
+  p.put("model_name", DecimalToIntegerModel::name());
+}
+
+
+unsigned int
+DecimalToIntegerModel::
+nPorts(PortType portType) const
+{
+  unsigned int result = 1;
+
+  switch (portType)
+  {
+    case PortType::In:
+      result = 1;
+      break;
+
+    case PortType::Out:
+      result = 1;
+
+    default:
+      break;
+  }
+
+  return result;
+}
+
+
+NodeDataType
+DecimalToIntegerModel::
+dataType(PortType portType, PortIndex) const
+{
+  if (portType == PortType::In)
+    return DecimalData().type();
+  return IntegerData().type();
+}
+
+
+std::shared_ptr<NodeData>
+DecimalToIntegerModel::
+outData(PortIndex)
+{
+  return _integer;
+}
+
+void
+DecimalToIntegerModel::
+setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
+{
+  auto numberData =
+    std::dynamic_pointer_cast<DecimalData>(data);
+
+  if (portIndex == 0)
+  {
+    _decimal = numberData;
+  }
+
+  if (_decimal)
+    _integer = std::make_shared<IntegerData>(_decimal->number());
+
+  PortIndex const outPortIndex = 0;
+
+  emit dataUpdated(outPortIndex);
+}

--- a/examples/calculator/DecimalToIntegerModel.cpp
+++ b/examples/calculator/DecimalToIntegerModel.cpp
@@ -5,11 +5,6 @@
 #include "DecimalData.hpp"
 #include "IntegerData.hpp"
 
-DecimalToIntegerModel::
-DecimalToIntegerModel()
-{
-}
-
 
 void
 DecimalToIntegerModel::

--- a/examples/calculator/DecimalToIntegerModel.hpp
+++ b/examples/calculator/DecimalToIntegerModel.hpp
@@ -8,25 +8,24 @@
 #include <iostream>
 
 class DecimalData;
+class IntegerData;
 
-/// The model dictates the number of inputs and outputs for the Node.
-/// In this example it has no logic.
-class NumberSourceDataModel
+class DecimalToIntegerModel
   : public NodeDataModel
 {
   Q_OBJECT
 
 public:
-  NumberSourceDataModel();
+  DecimalToIntegerModel();
 
   virtual
-  ~NumberSourceDataModel() {}
+  ~DecimalToIntegerModel() {}
 
 public:
 
   QString
   caption() const override
-  { return QString("Number Source"); }
+  { return QString("Decimal to integer"); }
 
   bool
   captionVisible() const override
@@ -34,20 +33,17 @@ public:
 
   QString
   name() const override
-  { return QString("NumberSource"); }
+  { return QString("DecimalToInteger"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
-  { return std::make_unique<NumberSourceDataModel>(); }
+  { return std::make_unique<DecimalToIntegerModel>(); }
 
 public:
 
   void
   save(Properties &p) const override;
-
-  void
-  restore(Properties const &p) override;
-
+  
 public:
 
   unsigned int
@@ -60,20 +56,14 @@ public:
   outData(PortIndex port) override;
 
   void
-  setInData(std::shared_ptr<NodeData>, int) override
-  { }
+  setInData(std::shared_ptr<NodeData>, int) override;
 
   QWidget *
-  embeddedWidget() override { return _lineEdit; }
-
-private slots:
-
-  void
-  onTextEdited(QString const &string);
+  embeddedWidget() override { return nullptr; }
 
 private:
 
-  std::shared_ptr<DecimalData> _number;
+  std::shared_ptr<DecimalData> _decimal;
+  std::shared_ptr<IntegerData> _integer;
 
-  QLineEdit * _lineEdit;
 };

--- a/examples/calculator/DecimalToIntegerModel.hpp
+++ b/examples/calculator/DecimalToIntegerModel.hpp
@@ -16,16 +16,16 @@ class DecimalToIntegerModel
   Q_OBJECT
 
 public:
-  DecimalToIntegerModel();
+  DecimalToIntegerModel() = default;
 
   virtual
-  ~DecimalToIntegerModel() {}
+  ~DecimalToIntegerModel() = default;
 
 public:
 
   QString
   caption() const override
-  { return QString("Decimal to integer"); }
+  { return QStringLiteral("Decimal to integer"); }
 
   bool
   captionVisible() const override
@@ -33,7 +33,7 @@ public:
 
   QString
   name() const override
-  { return QString("DecimalToInteger"); }
+  { return QStringLiteral("DecimalToInteger"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -7,7 +7,7 @@
 
 #include "MathOperationDataModel.hpp"
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -23,11 +23,11 @@ public:
   caption() const override
   { return QString("Division"); }
   
-  virtual bool
+  bool
   portCaptionVisible(PortType portType, PortIndex portIndex) const override
   { return true; }
 
-  virtual QString
+  QString
   portCaption(PortType portType, PortIndex portIndex) const override
   {
     switch (portType)
@@ -84,8 +84,8 @@ private:
     {
       modelValidationState = NodeValidationState::Valid;
       modelValidationError = QString("");
-      _result = std::make_shared<NumberData>(n1->number() /
-        n2->number());
+      _result = std::make_shared<DecimalData>(n1->number() /
+                                              n2->number());
     }
     else
     {

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -21,7 +21,7 @@ public:
 public:
   QString
   caption() const override
-  { return QString("Division"); }
+  { return QStringLiteral("Division"); }
   
   bool
   portCaptionVisible(PortType portType, PortIndex portIndex) const override
@@ -34,23 +34,23 @@ public:
     {
       case PortType::In:
         if (portIndex == 0)
-          return QString("Dividend");
+          return QStringLiteral("Dividend");
         else if (portIndex == 1)
-          return QString("Divisor");
+          return QStringLiteral("Divisor");
         break;
 
       case PortType::Out:
-        return QString("Result");
+        return QStringLiteral("Result");
 
       default:
         break;
     }
-    return QString("");
+    return QString();
   }
   
   QString
   name() const override
-  { return QString("Division"); }
+  { return QStringLiteral("Division"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
@@ -77,20 +77,20 @@ private:
     if (n2 && (n2->number() == 0.0))
     {
       modelValidationState = NodeValidationState::Error;
-      modelValidationError = QString("Division by zero error");
+      modelValidationError = QStringLiteral("Division by zero error");
       _result.reset();
     }
     else if (n1 && n2)
     {
       modelValidationState = NodeValidationState::Valid;
-      modelValidationError = QString("");
+      modelValidationError = QString();
       _result = std::make_shared<DecimalData>(n1->number() /
                                               n2->number());
     }
     else
     {
       modelValidationState = NodeValidationState::Warning;
-      modelValidationError = QString("Missing or incorrect inputs");
+      modelValidationError = QStringLiteral("Missing or incorrect inputs");
       _result.reset();
     }
     

--- a/examples/calculator/IntegerData.hpp
+++ b/examples/calculator/IntegerData.hpp
@@ -4,31 +4,31 @@
 
 /// The class can potentially incapsulate any user data which
 /// need to be transferred within the Node Editor graph
-class NumberData : public NodeData
+class IntegerData : public NodeData
 {
 public:
 
-  NumberData()
+  IntegerData()
     : _number(0.0)
   {}
 
-  NumberData(double const number)
+  IntegerData(int const number)
     : _number(number)
   {}
 
   NodeDataType type() const override
   {
-    return NodeDataType {"number",
-                         "Number"};
+    return NodeDataType {"integer",
+                         "Integer"};
   }
 
-  double number() const
+  int number() const
   { return _number; }
 
   QString numberAsText() const
-  { return QString::number(_number, 'f'); }
+  { return QString::number(_number); }
 
 private:
 
-  double _number;
+  int _number;
 };

--- a/examples/calculator/IntegerToDecimalModel.cpp
+++ b/examples/calculator/IntegerToDecimalModel.cpp
@@ -59,6 +59,7 @@ outData(PortIndex)
   return _decimal;
 }
 
+
 void
 IntegerToDecimalModel::
 setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)

--- a/examples/calculator/IntegerToDecimalModel.cpp
+++ b/examples/calculator/IntegerToDecimalModel.cpp
@@ -1,0 +1,80 @@
+#include "IntegerToDecimalModel.hpp"
+
+#include <QtGui/QDoubleValidator>
+
+#include "DecimalData.hpp"
+#include "IntegerData.hpp"
+
+IntegerToDecimalModel::
+IntegerToDecimalModel()
+{
+}
+
+
+void
+IntegerToDecimalModel::
+save(Properties &p) const
+{
+  p.put("model_name", IntegerToDecimalModel::name());
+}
+
+
+unsigned int
+IntegerToDecimalModel::
+nPorts(PortType portType) const
+{
+  unsigned int result = 1;
+
+  switch (portType)
+  {
+    case PortType::In:
+      result = 1;
+      break;
+
+    case PortType::Out:
+      result = 1;
+
+    default:
+      break;
+  }
+
+  return result;
+}
+
+
+NodeDataType
+IntegerToDecimalModel::
+dataType(PortType portType, PortIndex) const
+{
+  if (portType == PortType::In)
+    return IntegerData().type();
+  return DecimalData().type();
+}
+
+
+std::shared_ptr<NodeData>
+IntegerToDecimalModel::
+outData(PortIndex)
+{
+  return _decimal;
+}
+
+void
+IntegerToDecimalModel::
+setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
+{
+  auto numberData =
+    std::dynamic_pointer_cast<IntegerData>(data);
+
+  if (portIndex == 0)
+  {
+    _integer = numberData;
+  }
+
+  if (_integer)
+    _decimal = std::make_shared<DecimalData>(_integer->number());
+
+  PortIndex const outPortIndex = 0;
+
+  emit dataUpdated(outPortIndex);
+}

--- a/examples/calculator/IntegerToDecimalModel.cpp
+++ b/examples/calculator/IntegerToDecimalModel.cpp
@@ -5,11 +5,6 @@
 #include "DecimalData.hpp"
 #include "IntegerData.hpp"
 
-IntegerToDecimalModel::
-IntegerToDecimalModel()
-{
-}
-
 
 void
 IntegerToDecimalModel::

--- a/examples/calculator/IntegerToDecimalModel.hpp
+++ b/examples/calculator/IntegerToDecimalModel.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtWidgets/QLineEdit>
+
+#include <nodes/NodeDataModel>
+
+#include <iostream>
+
+class DecimalData;
+class IntegerData;
+
+class IntegerToDecimalModel
+  : public NodeDataModel
+{
+  Q_OBJECT
+
+public:
+  IntegerToDecimalModel();
+
+  virtual
+    ~IntegerToDecimalModel() {}
+
+public:
+
+  QString
+  caption() const override
+  { return QString("Integer to decimal"); }
+
+  bool
+  captionVisible() const override
+  { return false; }
+
+  QString
+  name() const override
+  { return QString("IntegerToDecimal"); }
+
+  std::unique_ptr<NodeDataModel>
+  clone() const override
+  { return std::make_unique<IntegerToDecimalModel>(); }
+
+public:
+
+  void
+  save(Properties &p) const override;
+  
+public:
+
+  unsigned int
+  nPorts(PortType portType) const override;
+
+  NodeDataType
+  dataType(PortType portType, PortIndex portIndex) const override;
+
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override;
+
+  void
+  setInData(std::shared_ptr<NodeData>, int) override;
+
+  QWidget *
+  embeddedWidget() override { return nullptr; }
+
+private:
+
+  std::shared_ptr<DecimalData> _decimal;
+  std::shared_ptr<IntegerData> _integer;
+
+};

--- a/examples/calculator/IntegerToDecimalModel.hpp
+++ b/examples/calculator/IntegerToDecimalModel.hpp
@@ -16,16 +16,16 @@ class IntegerToDecimalModel
   Q_OBJECT
 
 public:
-  IntegerToDecimalModel();
+  IntegerToDecimalModel() = default;
 
   virtual
-  ~IntegerToDecimalModel() {}
+  ~IntegerToDecimalModel() = default;
 
 public:
 
   QString
   caption() const override
-  { return QString("Integer to decimal"); }
+  { return QStringLiteral("Integer to decimal"); }
 
   bool
   captionVisible() const override
@@ -33,7 +33,7 @@ public:
 
   QString
   name() const override
-  { return QString("IntegerToDecimal"); }
+  { return QStringLiteral("IntegerToDecimal"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override

--- a/examples/calculator/IntegerToDecimalModel.hpp
+++ b/examples/calculator/IntegerToDecimalModel.hpp
@@ -19,7 +19,7 @@ public:
   IntegerToDecimalModel();
 
   virtual
-    ~IntegerToDecimalModel() {}
+  ~IntegerToDecimalModel() {}
 
 public:
 

--- a/examples/calculator/MathOperationDataModel.cpp
+++ b/examples/calculator/MathOperationDataModel.cpp
@@ -1,6 +1,6 @@
 #include "MathOperationDataModel.hpp"
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 unsigned int
 MathOperationDataModel::
@@ -21,7 +21,7 @@ NodeDataType
 MathOperationDataModel::
 dataType(PortType, PortIndex) const
 {
-  return NumberData().type();
+  return DecimalData().type();
 }
 
 
@@ -38,7 +38,7 @@ MathOperationDataModel::
 setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
 {
   auto numberData =
-    std::dynamic_pointer_cast<NumberData>(data);
+    std::dynamic_pointer_cast<DecimalData>(data);
 
   if (portIndex == 0)
   {

--- a/examples/calculator/MathOperationDataModel.hpp
+++ b/examples/calculator/MathOperationDataModel.hpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 
-class NumberData;
+class DecimalData;
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -42,10 +42,10 @@ protected:
 
 protected:
 
-  std::weak_ptr<NumberData> _number1;
-  std::weak_ptr<NumberData> _number2;
+  std::weak_ptr<DecimalData> _number1;
+  std::weak_ptr<DecimalData> _number2;
 
-  std::shared_ptr<NumberData> _result;
+  std::shared_ptr<DecimalData> _result;
 
   NodeValidationState modelValidationState = NodeValidationState::Warning;
   QString modelValidationError = QString("Missing or incorrect inputs");

--- a/examples/calculator/ModuloModel.cpp
+++ b/examples/calculator/ModuloModel.cpp
@@ -1,0 +1,119 @@
+#include "ModuloModel.hpp"
+
+#include <QtGui/QDoubleValidator>
+
+#include "IntegerData.hpp"
+
+ModuloModel::
+ModuloModel()
+{
+}
+
+
+void
+ModuloModel::
+save(Properties &p) const
+{
+  p.put("model_name", ModuloModel::name());
+}
+
+
+unsigned int
+ModuloModel::
+nPorts(PortType portType) const
+{
+  unsigned int result = 1;
+
+  switch (portType)
+  {
+    case PortType::In:
+      result = 2;
+      break;
+
+    case PortType::Out:
+      result = 1;
+
+    default:
+      break;
+  }
+
+  return result;
+}
+
+
+NodeDataType
+ModuloModel::
+dataType(PortType, PortIndex) const
+{
+  return IntegerData().type();
+}
+
+
+std::shared_ptr<NodeData>
+ModuloModel::
+outData(PortIndex)
+{
+  return _result;
+}
+
+void
+ModuloModel::
+setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
+{
+  auto numberData =
+    std::dynamic_pointer_cast<IntegerData>(data);
+
+  if (portIndex == 0)
+  {
+    _number1 = numberData;
+  }
+  else
+  {
+    _number2 = numberData;
+  }
+
+  {
+    PortIndex const outPortIndex = 0;
+
+    auto n1 = _number1.lock();
+    auto n2 = _number2.lock();
+
+    if (n2 && (n2->number() == 0.0))
+    {
+      modelValidationState = NodeValidationState::Error;
+      modelValidationError = QString("Division by zero error");
+      _result.reset();
+    }
+    else if (n1 && n2)
+    {
+      modelValidationState = NodeValidationState::Valid;
+      modelValidationError = QString("");
+      _result = std::make_shared<IntegerData>(n1->number() %
+                                              n2->number());
+    }
+    else
+    {
+      modelValidationState = NodeValidationState::Warning;
+      modelValidationError = QString("Missing or incorrect inputs");
+      _result.reset();
+    }
+
+    emit dataUpdated(outPortIndex);
+  }
+}
+
+
+NodeValidationState
+ModuloModel::
+validationState() const
+{
+  return modelValidationState;
+}
+
+
+QString
+ModuloModel::
+validationMessage() const
+{
+  return modelValidationError;
+}

--- a/examples/calculator/ModuloModel.cpp
+++ b/examples/calculator/ModuloModel.cpp
@@ -4,17 +4,12 @@
 
 #include "IntegerData.hpp"
 
-ModuloModel::
-ModuloModel()
-{
-}
-
 
 void
 ModuloModel::
 save(Properties &p) const
 {
-  p.put("model_name", ModuloModel::name());
+  p.put("model_name", name());
 }
 
 
@@ -82,20 +77,20 @@ setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
     if (n2 && (n2->number() == 0.0))
     {
       modelValidationState = NodeValidationState::Error;
-      modelValidationError = QString("Division by zero error");
+      modelValidationError = QStringLiteral("Division by zero error");
       _result.reset();
     }
     else if (n1 && n2)
     {
       modelValidationState = NodeValidationState::Valid;
-      modelValidationError = QString("");
+      modelValidationError = QString();
       _result = std::make_shared<IntegerData>(n1->number() %
                                               n2->number());
     }
     else
     {
       modelValidationState = NodeValidationState::Warning;
-      modelValidationError = QString("Missing or incorrect inputs");
+      modelValidationError = QStringLiteral("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/examples/calculator/ModuloModel.cpp
+++ b/examples/calculator/ModuloModel.cpp
@@ -56,6 +56,7 @@ outData(PortIndex)
   return _result;
 }
 
+
 void
 ModuloModel::
 setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)

--- a/examples/calculator/ModuloModel.hpp
+++ b/examples/calculator/ModuloModel.hpp
@@ -18,7 +18,7 @@ public:
   ModuloModel();
 
   virtual
-    ~ModuloModel() {}
+  ~ModuloModel() {}
 
 public:
 

--- a/examples/calculator/ModuloModel.hpp
+++ b/examples/calculator/ModuloModel.hpp
@@ -15,16 +15,16 @@ class ModuloModel
   Q_OBJECT
 
 public:
-  ModuloModel();
+  ModuloModel() = default;
 
   virtual
-  ~ModuloModel() {}
+  ~ModuloModel() = default;
 
 public:
 
   QString
   caption() const override
-  { return QString("Modulo"); }
+  { return QStringLiteral("Modulo"); }
 
   bool
   captionVisible() const override
@@ -32,9 +32,7 @@ public:
 
   bool
   portCaptionVisible(PortType portType, PortIndex portIndex) const override
-  {
-    return true;
-  }
+  { return true; }
 
   QString
   portCaption(PortType portType, PortIndex portIndex) const override
@@ -43,23 +41,23 @@ public:
     {
     case PortType::In:
       if (portIndex == 0)
-        return QString("Dividend");
+        return QStringLiteral("Dividend");
       else if (portIndex == 1)
-        return QString("Divisor");
+        return QStringLiteral("Divisor");
       break;
 
     case PortType::Out:
-      return QString("Result");
+      return QStringLiteral("Result");
 
     default:
       break;
     }
-    return QString("");
+    return QString();
   }
 
   QString
   name() const override
-  { return QString("Modulo"); }
+  { return QStringLiteral("Modulo"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
@@ -98,5 +96,5 @@ private:
   std::shared_ptr<IntegerData> _result;
 
   NodeValidationState modelValidationState = NodeValidationState::Warning;
-  QString modelValidationError = QString("Missing or incorrect inputs");
+  QString modelValidationError = QStringLiteral("Missing or incorrect inputs");
 };

--- a/examples/calculator/ModuloModel.hpp
+++ b/examples/calculator/ModuloModel.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtWidgets/QLineEdit>
+
+#include <nodes/NodeDataModel>
+
+#include <iostream>
+
+class IntegerData;
+
+class ModuloModel
+  : public NodeDataModel
+{
+  Q_OBJECT
+
+public:
+  ModuloModel();
+
+  virtual
+    ~ModuloModel() {}
+
+public:
+
+  QString
+  caption() const override
+  { return QString("Modulo"); }
+
+  bool
+  captionVisible() const override
+  { return true; }
+
+  bool
+  portCaptionVisible(PortType portType, PortIndex portIndex) const override
+  {
+    return true;
+  }
+
+  QString
+  portCaption(PortType portType, PortIndex portIndex) const override
+  {
+    switch (portType)
+    {
+    case PortType::In:
+      if (portIndex == 0)
+        return QString("Dividend");
+      else if (portIndex == 1)
+        return QString("Divisor");
+      break;
+
+    case PortType::Out:
+      return QString("Result");
+
+    default:
+      break;
+    }
+    return QString("");
+  }
+
+  QString
+  name() const override
+  { return QString("Modulo"); }
+
+  std::unique_ptr<NodeDataModel>
+  clone() const override
+  { return std::make_unique<ModuloModel>(); }
+
+public:
+
+  void
+  save(Properties &p) const override;
+
+public:
+
+  unsigned int
+  nPorts(PortType portType) const override;
+
+  NodeDataType
+  dataType(PortType portType, PortIndex portIndex) const override;
+
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override;
+
+  void
+  setInData(std::shared_ptr<NodeData>, int) override;
+
+  QWidget * embeddedWidget() override { return nullptr; }
+
+  NodeValidationState validationState() const override;
+
+  QString validationMessage() const override;
+
+private:
+
+  std::weak_ptr<IntegerData> _number1;
+  std::weak_ptr<IntegerData> _number2;
+
+  std::shared_ptr<IntegerData> _result;
+
+  NodeValidationState modelValidationState = NodeValidationState::Warning;
+  QString modelValidationError = QString("Missing or incorrect inputs");
+};

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -7,7 +7,7 @@
 
 #include "MathOperationDataModel.hpp"
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -54,8 +54,8 @@ private:
     {
       modelValidationState = NodeValidationState::Valid;
       modelValidationError = QString("");
-      _result = std::make_shared<NumberData>(n1->number() *
-                                             n2->number());
+      _result = std::make_shared<DecimalData>(n1->number() *
+                                              n2->number());
     }
     else
     {

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -22,11 +22,11 @@ public:
 
   QString
   caption() const override
-  { return QString("Multiplication"); }
+  { return QStringLiteral("Multiplication"); }
 
   QString
   name() const override
-  { return QString("Multiplication"); }
+  { return QStringLiteral("Multiplication"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
@@ -53,14 +53,14 @@ private:
     if (n1 && n2)
     {
       modelValidationState = NodeValidationState::Valid;
-      modelValidationError = QString("");
+      modelValidationError = QString();
       _result = std::make_shared<DecimalData>(n1->number() *
                                               n2->number());
     }
     else
     {
       modelValidationState = NodeValidationState::Warning;
-      modelValidationError = QString("Missing or incorrect inputs");
+      modelValidationError = QStringLiteral("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/examples/calculator/NumberDisplayDataModel.cpp
+++ b/examples/calculator/NumberDisplayDataModel.cpp
@@ -1,6 +1,6 @@
 #include "NumberDisplayDataModel.hpp"
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 NumberDisplayDataModel::
 NumberDisplayDataModel()
@@ -37,7 +37,7 @@ NodeDataType
 NumberDisplayDataModel::
 dataType(PortType, PortIndex) const
 {
-  return NumberData().type();
+  return DecimalData().type();
 }
 
 
@@ -54,7 +54,7 @@ void
 NumberDisplayDataModel::
 setInData(std::shared_ptr<NodeData> data, int)
 {
-  auto numberData = std::dynamic_pointer_cast<NumberData>(data);
+  auto numberData = std::dynamic_pointer_cast<DecimalData>(data);
 
   if (numberData)
   {

--- a/examples/calculator/NumberDisplayDataModel.cpp
+++ b/examples/calculator/NumberDisplayDataModel.cpp
@@ -59,13 +59,13 @@ setInData(std::shared_ptr<NodeData> data, int)
   if (numberData)
   {
     modelValidationState = NodeValidationState::Valid;
-    modelValidationError = QString("");
+    modelValidationError = QString();
     _label->setText(numberData->numberAsText());
   }
   else
   {
     modelValidationState = NodeValidationState::Warning;
-    modelValidationError = QString("Missing or incorrect inputs");
+    modelValidationError = QStringLiteral("Missing or incorrect inputs");
     _label->clear();
   }
 

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -23,7 +23,7 @@ public:
 
   QString
   caption() const override
-  { return QString("Result"); }
+  { return QStringLiteral("Result"); }
 
   bool
   captionVisible() const override
@@ -31,7 +31,7 @@ public:
 
   QString
   name() const override
-  { return QString("Result"); }
+  { return QStringLiteral("Result"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
@@ -42,7 +42,7 @@ public:
   void
   save(Properties &p) const override
   {
-    p.put("model_name", NumberDisplayDataModel::name());
+    p.put("model_name", name());
   }
 
 public:
@@ -72,7 +72,7 @@ public:
 private:
 
   NodeValidationState modelValidationState = NodeValidationState::Warning;
-  QString modelValidationError = QString("Missing or incorrect inputs");
+  QString modelValidationError = QStringLiteral("Missing or incorrect inputs");
 
   QLabel * _label;
 };

--- a/examples/calculator/NumberSourceDataModel.cpp
+++ b/examples/calculator/NumberSourceDataModel.cpp
@@ -23,7 +23,7 @@ void
 NumberSourceDataModel::
 save(Properties &p) const
 {
-  p.put("model_name", NumberSourceDataModel::name());
+  p.put("model_name", name());
 
   if (_number)
     p.put("number", _number->number());

--- a/examples/calculator/NumberSourceDataModel.cpp
+++ b/examples/calculator/NumberSourceDataModel.cpp
@@ -2,7 +2,7 @@
 
 #include <QtGui/QDoubleValidator>
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 NumberSourceDataModel::
 NumberSourceDataModel()
@@ -38,7 +38,7 @@ restore(Properties const &p)
 
   if (bool ok = p.get("number", &number))
   {
-    _number = std::make_shared<NumberData>(number);
+    _number = std::make_shared<DecimalData>(number);
     _lineEdit->setText(QString::number(number));
   }
 }
@@ -79,7 +79,7 @@ onTextEdited(QString const &string)
 
   if (ok)
   {
-    _number = std::make_shared<NumberData>(number);
+    _number = std::make_shared<DecimalData>(number);
 
     emit dataUpdated(0);
   }
@@ -94,7 +94,7 @@ NodeDataType
 NumberSourceDataModel::
 dataType(PortType, PortIndex) const
 {
-  return NumberData().type();
+  return DecimalData().type();
 }
 
 

--- a/examples/calculator/NumberSourceDataModel.hpp
+++ b/examples/calculator/NumberSourceDataModel.hpp
@@ -26,7 +26,7 @@ public:
 
   QString
   caption() const override
-  { return QString("Number Source"); }
+  { return QStringLiteral("Number Source"); }
 
   bool
   captionVisible() const override
@@ -34,7 +34,7 @@ public:
 
   QString
   name() const override
-  { return QString("NumberSource"); }
+  { return QStringLiteral("NumberSource"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -22,7 +22,7 @@ public:
 
   QString
   caption() const override
-  { return QString("Subtraction"); }
+  { return QStringLiteral("Subtraction"); }
 
   virtual bool
   portCaptionVisible(PortType portType, PortIndex portIndex) const override
@@ -35,23 +35,23 @@ public:
     {
     case PortType::In:
       if (portIndex == 0)
-        return QString("Minuend");
+        return QStringLiteral("Minuend");
       else if (portIndex == 1)
-        return QString("Subtrahend");
+        return QStringLiteral("Subtrahend");
       break;
 
     case PortType::Out:
-      return QString("Result");
+      return QStringLiteral("Result");
 
     default:
       break;
     }
-	return QString("");
+	return QString();
   }
 
   QString
   name() const override
-  { return QString("Subtraction"); }
+  { return QStringLiteral("Subtraction"); }
 
   std::unique_ptr<NodeDataModel>
   clone() const override
@@ -78,14 +78,14 @@ private:
     if (n1 && n2)
     {
       modelValidationState = NodeValidationState::Valid;
-      modelValidationError = QString("");
+      modelValidationError = QString();
       _result = std::make_shared<DecimalData>(n1->number() -
                                               n2->number());
     }
     else
     {
       modelValidationState = NodeValidationState::Warning;
-      modelValidationError = QString("Missing or incorrect inputs");
+      modelValidationError = QStringLiteral("Missing or incorrect inputs");
       _result.reset();
     }
 

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -7,7 +7,7 @@
 
 #include "MathOperationDataModel.hpp"
 
-#include "NumberData.hpp"
+#include "DecimalData.hpp"
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -79,8 +79,8 @@ private:
     {
       modelValidationState = NodeValidationState::Valid;
       modelValidationError = QString("");
-      _result = std::make_shared<NumberData>(n1->number() -
-                                             n2->number());
+      _result = std::make_shared<DecimalData>(n1->number() -
+                                              n2->number());
     }
     else
     {

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -14,6 +14,8 @@
 #include "SubtractionModel.hpp"
 #include "MultiplicationModel.hpp"
 #include "DivisionModel.hpp"
+#include "ModuloModel.hpp"
+#include "DecimalToIntegerModel.hpp"
 
 static std::shared_ptr<DataModelRegistry>
 registerDataModels()
@@ -30,6 +32,10 @@ registerDataModels()
   ret->registerModel<MultiplicationModel>();
 
   ret->registerModel<DivisionModel>();
+
+  ret->registerModel<ModuloModel>();
+
+  ret->registerModel<DecimalToIntegerModel, true>();
 
   return ret;
 }

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -1,6 +1,7 @@
 #include <nodes/NodeData>
 #include <nodes/FlowScene>
 #include <nodes/FlowView>
+#include <nodes/ConnectionStyle>
 
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QVBoxLayout>
@@ -16,6 +17,7 @@
 #include "DivisionModel.hpp"
 #include "ModuloModel.hpp"
 #include "DecimalToIntegerModel.hpp"
+#include "IntegerToDecimalModel.hpp"
 
 static std::shared_ptr<DataModelRegistry>
 registerDataModels()
@@ -37,7 +39,24 @@ registerDataModels()
 
   ret->registerModel<DecimalToIntegerModel, true>();
 
+  ret->registerModel<IntegerToDecimalModel, true>();
+
   return ret;
+}
+
+
+static
+void
+setStyle()
+{
+  ConnectionStyle::setConnectionStyle(
+  R"(
+  {
+    "ConnectionStyle": {
+      "UseDataDefinedColors": true
+    }
+  }
+  )");
 }
 
 
@@ -45,6 +64,8 @@ int
 main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
+
+  setStyle();
 
   QWidget mainWidget;
 

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -206,7 +206,7 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   auto node = ::locateNodeAt(event->scenePos(), _scene,
                              _scene.views()[0]->transform());
 
-  NodeConnectionInteraction interaction(*node, _connection);
+  NodeConnectionInteraction interaction(*node, _connection, _scene.registry(), _scene);
 
   if (node && interaction.tryConnect())
   {

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -206,7 +206,7 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   auto node = ::locateNodeAt(event->scenePos(), _scene,
                              _scene.views()[0]->transform());
 
-  NodeConnectionInteraction interaction(*node, _connection, _scene.registry(), _scene);
+  NodeConnectionInteraction interaction(*node, _connection, _scene);
 
   if (node && interaction.tryConnect())
   {

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -26,22 +26,17 @@ registeredModels() const
 }
 
 
-bool
+std::unique_ptr<NodeDataModel>
 DataModelRegistry::
-getTypeConverter(const QString & sourceTypeID, const QString & destTypeID, std::unique_ptr<NodeDataModel> & converterModel) const
+getTypeConverter(const QString & sourceTypeID, const QString & destTypeID) const
 {
-  auto converter = std::find_if(_registeredTypeConverters.begin(), _registeredTypeConverters.end(),
-    [&](const RegisteredTypeConvertersMap::value_type & m)
-    {
-      return m.second->SourceType.id == sourceTypeID && m.second->DestinationType.id == destTypeID;
-    });
-
-  if (converter == _registeredTypeConverters.end())
+  for (const auto& m : _registeredTypeConverters)
   {
-    return false;
+    if (m.second->SourceType.id == sourceTypeID && m.second->DestinationType.id == destTypeID)
+    {
+      return m.second->Model->clone();
+    }
   }
   
-  converterModel = converter->second->Model->clone();
-  
-  return true;
+  return nullptr;
 }

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -20,7 +20,28 @@ create(QString const &modelName)
 
 DataModelRegistry::RegisteredModelsMap const &
 DataModelRegistry::
-registeredModels()
+registeredModels() const
 {
   return _registeredModels;
+}
+
+
+bool
+DataModelRegistry::
+getTypeConverter(const QString & sourceTypeID, const QString & destTypeID, std::unique_ptr<NodeDataModel> & converterModel) const
+{
+  auto converter = std::find_if(_registeredTypeConverters.begin(), _registeredTypeConverters.end(),
+    [&](const RegisteredTypeConvertersMap::value_type & m)
+    {
+      return m.second->SourceType.id == sourceTypeID && m.second->DestinationType.id == destTypeID;
+    });
+
+  if (converter == _registeredTypeConverters.end())
+  {
+    return false;
+  }
+  
+  converterModel = converter->second->Model->clone();
+  
+  return true;
 }

--- a/src/DataModelRegistry.hpp
+++ b/src/DataModelRegistry.hpp
@@ -14,10 +14,19 @@ class NODE_EDITOR_PUBLIC DataModelRegistry
 {
 
 public:
-
+  
   using RegistryItemPtr     = std::unique_ptr<NodeDataModel>;
-  using RegisteredModelsMap =
-          std::unordered_map<QString, RegistryItemPtr>;
+  using RegisteredModelsMap = std::unordered_map<QString, RegistryItemPtr>;
+
+  struct TypeConverterItem
+  {
+    RegistryItemPtr Model;
+    NodeDataType    SourceType;
+    NodeDataType    DestinationType;
+  };
+
+  using TypeConverterItemPtr = std::unique_ptr<TypeConverterItem>;
+  using RegisteredTypeConvertersMap = std::unordered_map<QString, TypeConverterItemPtr>;
 
   DataModelRegistry()  = default;
   ~DataModelRegistry() = default;
@@ -32,9 +41,11 @@ public:
 
 public:
 
-  template<typename ModelType>
+  // TODO rewrite the TypeConverter hack to use a constexpr if once C++17 is supported enough. 
+  // (This probably could be done with enable_if, but that would be more redundant, and ugly.)
+  template<typename ModelType, bool TypeConverter = false>
   void
-  registerModel(std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>())
+  registerModel(std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>(), bool isTypeConverter = TypeConverter)
   {
     static_assert(std::is_base_of<NodeDataModel, ModelType>::value,
                   "Must pass a subclass of NodeDataModel to registerModel");
@@ -45,15 +56,30 @@ public:
     {
       _registeredModels[name] = std::move(uniqueModel);
     }
+
+    if (isTypeConverter && _registeredTypeConverters.count(name) == 0)
+    {
+      TypeConverterItemPtr converter = std::make_unique<TypeConverterItem>();
+      converter->Model = _registeredModels[name]->clone();
+      converter->SourceType = converter->Model->dataType(PortType::In, 0);
+      converter->DestinationType = converter->Model->dataType(PortType::Out, 0);
+      _registeredTypeConverters[name] = std::move(converter);
+    }
   }
 
   std::unique_ptr<NodeDataModel>
   create(QString const &modelName);
 
   RegisteredModelsMap const &
-  registeredModels();
+  registeredModels() const;
+
+  bool 
+  getTypeConverter(const QString & sourceTypeID, 
+                   const QString & destTypeID,
+                   std::unique_ptr<NodeDataModel> & converterModel) const;
 
 private:
 
   RegisteredModelsMap _registeredModels;
+  RegisteredTypeConvertersMap _registeredTypeConverters;
 };

--- a/src/DataModelRegistry.hpp
+++ b/src/DataModelRegistry.hpp
@@ -59,9 +59,13 @@ public:
     {
       std::unique_ptr<NodeDataModel>& registeredModelRef = _registeredModels[name];
 
-      //Type converter node should have exactly one input and output ports, if thats not the case, we skip the registration
-      if (registeredModelRef->nPorts(PortType::In) != 1 || registeredModelRef->nPorts(PortType::Out) != 1)
+      //Type converter node should have exactly one input and output ports, if thats not the case, we skip the registration.
+      //If the input and output type is the same, we also skip registration, because thats not a typecast node.
+      if (registeredModelRef->nPorts(PortType::In) != 1 || registeredModelRef->nPorts(PortType::Out) != 1 ||
+        registeredModelRef->dataType(PortType::In, 0).id == registeredModelRef->dataType(PortType::Out, 0).id)
+      {
         return;
+      }
 
       TypeConverterItemPtr converter = std::make_unique<TypeConverterItem>();
       converter->Model = registeredModelRef->clone();

--- a/src/DataModelRegistry.hpp
+++ b/src/DataModelRegistry.hpp
@@ -82,10 +82,9 @@ public:
   RegisteredModelsMap const &
   registeredModels() const;
 
-  bool 
+  std::unique_ptr<NodeDataModel>
   getTypeConverter(const QString & sourceTypeID, 
-                   const QString & destTypeID,
-                   std::unique_ptr<NodeDataModel> & converterModel) const;
+                   const QString & destTypeID) const;
 
 private:
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -84,9 +84,6 @@ createConnection(Node& nodeIn,
   // after this function connection points are set to node port
   connection->setGraphicsObject(std::move(cgo));
   
-  // trigger data propagation
-  nodeOut.onDataUpdated(portIndexOut);
-
   _connections[connection->id()] = connection;
   
   // trigger data propagation

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -84,11 +84,11 @@ createConnection(Node& nodeIn,
   // after this function connection points are set to node port
   connection->setGraphicsObject(std::move(cgo));
   
-  _connections[connection->id()] = connection;
-  
   // trigger data propagation
   nodeOut.onDataUpdated(portIndexOut);
 
+  _connections[connection->id()] = connection;
+  
   connectionCreated(*connection);
   
   return connection;

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -80,14 +80,14 @@ createConnection(Node& nodeIn,
 
   nodeIn.nodeState().setConnection(PortType::In, portIndexIn, *connection);
   nodeOut.nodeState().setConnection(PortType::Out, portIndexOut, *connection);
-
-  // trigger data propagation
-  nodeOut.onDataUpdated(portIndexOut);
-
+  
   // after this function connection points are set to node port
   connection->setGraphicsObject(std::move(cgo));
 
   _connections[connection->id()] = connection;
+  
+  // trigger data propagation
+  nodeOut.onDataUpdated(portIndexOut);
 
   connectionCreated(*connection);
   

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -80,7 +80,7 @@ createConnection(Node& nodeIn,
 
   nodeIn.nodeState().setConnection(PortType::In, portIndexIn, *connection);
   nodeOut.nodeState().setConnection(PortType::Out, portIndexOut, *connection);
-  
+
   // after this function connection points are set to node port
   connection->setGraphicsObject(std::move(cgo));
   
@@ -88,7 +88,7 @@ createConnection(Node& nodeIn,
   nodeOut.onDataUpdated(portIndexOut);
 
   _connections[connection->id()] = connection;
-  
+
   connectionCreated(*connection);
   
   return connection;

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -201,7 +201,7 @@ removeNode(Node& node)
 
 DataModelRegistry&
 FlowScene::
-registry()
+registry() const
 {
   return *_registry;
 }

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -60,7 +60,7 @@ public:
   removeNode(Node& node);
 
   DataModelRegistry&
-  registry();
+  registry() const;
 
   void
   setRegistry(std::shared_ptr<DataModelRegistry> registry);

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -56,10 +56,10 @@ contextMenuEvent(QContextMenuEvent *event)
 {
   QMenu modelMenu;
 
-  auto filterActionText = QString("skip me");
+  auto filterActionText = QStringLiteral("skip me");
 
   auto *txtBox = new QLineEdit(&modelMenu);
-  txtBox->setPlaceholderText(QString("Filter"));
+  txtBox->setPlaceholderText(QStringLiteral("Filter"));
   txtBox->setClearButtonEnabled(true);
 
   auto *txtBoxAction = new QWidgetAction(&modelMenu);

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -56,12 +56,40 @@ contextMenuEvent(QContextMenuEvent *event)
 {
   QMenu modelMenu;
 
+  auto filterActionText = QString("skip me");
+
+  auto *txtBox = new QLineEdit(&modelMenu);
+  txtBox->setPlaceholderText(QString("Filter"));
+  txtBox->setClearButtonEnabled(true);
+
+  auto *txtBoxAction = new QWidgetAction(&modelMenu);
+  txtBoxAction->setDefaultWidget(txtBox);
+  txtBoxAction->setText(filterActionText);
+
+  modelMenu.addAction(txtBoxAction);
+
+  connect(txtBox, &QLineEdit::textChanged, [&](const QString &text) 
+  {
+    for (auto action : modelMenu.actions())
+    {
+      auto actionText = action->text();
+      if (actionText != filterActionText && !actionText.contains(text, Qt::CaseInsensitive))
+      {
+        action->setVisible(false);
+      }
+      else
+      {
+        action->setVisible(true);
+      }
+    }
+  });
+
   for (auto const &modelRegistry : _scene->registry().registeredModels())
   {
     QString const &modelName = modelRegistry.first;
     modelMenu.addAction(modelName);
   }
-
+  
   if (QAction * action = modelMenu.exec(event->globalPos()))
   {
     QString modelName = action->text();

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -57,9 +57,9 @@ canConnect(PortIndex &portIndex, bool& typeConversionNeeded, std::unique_ptr<Nod
   {
     if (requiredPort == PortType::In)
     {
-      return typeConversionNeeded = _scene->registry().getTypeConverter(connectionDataType.id, candidateNodeDataType.id, converterModel);
+      return typeConversionNeeded = static_cast<bool>(converterModel = _scene->registry().getTypeConverter(connectionDataType.id, candidateNodeDataType.id));
     }
-    return typeConversionNeeded = _scene->registry().getTypeConverter(candidateNodeDataType.id, connectionDataType.id, converterModel);
+    return typeConversionNeeded = static_cast<bool>(converterModel = _scene->registry().getTypeConverter(candidateNodeDataType.id, connectionDataType.id));
   }
 
   return true;

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -57,9 +57,9 @@ canConnect(PortIndex &portIndex, bool& typeConversionNeeded, std::unique_ptr<Nod
   {
     if (requiredPort == PortType::In)
     {
-      return typeConversionNeeded = static_cast<bool>(converterModel = _scene->registry().getTypeConverter(connectionDataType.id, candidateNodeDataType.id));
+      return typeConversionNeeded = (converterModel = _scene->registry().getTypeConverter(connectionDataType.id, candidateNodeDataType.id)) != nullptr;
     }
-    return typeConversionNeeded = static_cast<bool>(converterModel = _scene->registry().getTypeConverter(candidateNodeDataType.id, connectionDataType.id));
+    return typeConversionNeeded = (converterModel = _scene->registry().getTypeConverter(candidateNodeDataType.id, connectionDataType.id)) != nullptr;
   }
 
   return true;

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -5,8 +5,12 @@
 #include "Node.hpp"
 #include "Connection.hpp"
 
+namespace QtNodes
+{
+
 class DataModelRegistry;
 class FlowScene;
+class NodeDataModel;
 
 /// Class performs various operations on the Node and Connection pair.
 /// An instance should be created on the stack and destroyed when
@@ -64,3 +68,4 @@ private:
   
   FlowScene* _scene;
 };
+}

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -5,6 +5,9 @@
 #include "Node.hpp"
 #include "Connection.hpp"
 
+class DataModelRegistry;
+class FlowScene;
+
 /// Class performs various operations on the Node and Connection pair.
 /// An instance should be created on the stack and destroyed when
 /// the operation is completed
@@ -12,23 +15,25 @@ class NodeConnectionInteraction
 {
 public:
   NodeConnectionInteraction(Node& node,
-                            Connection& connection)
-    : _node(&node)
-    , _connection(&connection)
-  {}
+                            Connection& connection,
+                            DataModelRegistry& dataRegistry,
+                            FlowScene& scene);
 
   /// Can connect when following conditions are met:
   /// 1) Connection 'requires' a port
   /// 2) Connection's vacant end is above the node port
   /// 3) Node port is vacant
-  /// 4) Connection type equals node port type
-  bool canConnect(PortIndex &portIndex) const;
+  /// 4) Connection type equals node port type, or there is a registered type conversion that can translate between the two
+  bool canConnect(PortIndex &portIndex, 
+                  bool& typeConversionNeeded,
+                  std::unique_ptr<NodeDataModel> & converterModel) const;
 
-  /// 1) Check conditions from 'canConnect'
-  /// 2) Assign node to required port in Connection
-  /// 3) Assign Connection to empty port in NodeState
-  /// 4) Adjust Connection geometry
-  /// 5) Poke model to intiate data transfer
+  /// 1)   Check conditions from 'canConnect'
+  /// 1.5) If the connection is possible but a type conversion is needed, add a converter node to the scene, and connect it properly
+  /// 2)   Assign node to required port in Connection
+  /// 3)   Assign Connection to empty port in NodeState
+  /// 4)   Adjust Connection geometry
+  /// 5)   Poke model to initiate data transfer
   bool tryConnect() const;
 
 
@@ -57,4 +62,8 @@ private:
   Node* _node;
 
   Connection* _connection;
+
+  DataModelRegistry* _dataRegistry;
+
+  FlowScene* _scene;
 };

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -16,7 +16,6 @@ class NodeConnectionInteraction
 public:
   NodeConnectionInteraction(Node& node,
                             Connection& connection,
-                            DataModelRegistry& dataRegistry,
                             FlowScene& scene);
 
   /// Can connect when following conditions are met:
@@ -62,8 +61,6 @@ private:
   Node* _node;
 
   Connection* _connection;
-
-  DataModelRegistry* _dataRegistry;
-
+  
   FlowScene* _scene;
 };

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -15,6 +15,7 @@ using QtNodes::NodeGeometry;
 using QtNodes::NodeDataModel;
 using QtNodes::PortIndex;
 using QtNodes::PortType;
+using QtNodes::Node;
 
 NodeGeometry::
 NodeGeometry(std::unique_ptr<NodeDataModel> const &dataModel)

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -195,7 +195,7 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
       {
         auto con = connections.begin()->second;
 
-        NodeConnectionInteraction interaction(_node, *con);
+        NodeConnectionInteraction interaction(_node, *con, _scene.registry(), _scene);
 
         interaction.disconnect(portToCheck);
       }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -195,7 +195,7 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
       {
         auto con = connections.begin()->second;
 
-        NodeConnectionInteraction interaction(_node, *con, _scene.registry(), _scene);
+        NodeConnectionInteraction interaction(_node, *con, _scene);
 
         interaction.disconnect(portToCheck);
       }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -145,7 +145,7 @@ paint(QPainter * painter,
 {
   painter->setClipRect(option->exposedRect);
 
-  NodePainter::paint(painter, _node);
+  NodePainter::paint(painter, _node, _scene);
 }
 
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -129,14 +129,13 @@ drawConnectionPoints(QPainter* painter,
         bool   typeConvertable = false;
 
         {
-          std::unique_ptr<NodeDataModel> converterModel;
           if (portType == PortType::In)
           {
-            typeConvertable = _scene.registry().getTypeConverter(state.reactingDataType().id, dataType.id, converterModel);
+            typeConvertable = static_cast<bool>(_scene.registry().getTypeConverter(state.reactingDataType().id, dataType.id));
           }
           else
           {
-            typeConvertable = _scene.registry().getTypeConverter(dataType.id, state.reactingDataType().id, converterModel);
+            typeConvertable = static_cast<bool>(_scene.registry().getTypeConverter(dataType.id, state.reactingDataType().id));
           }
         }
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -131,11 +131,11 @@ drawConnectionPoints(QPainter* painter,
         {
           if (portType == PortType::In)
           {
-            typeConvertable = static_cast<bool>(_scene.registry().getTypeConverter(state.reactingDataType().id, dataType.id));
+            typeConvertable = _scene.registry().getTypeConverter(state.reactingDataType().id, dataType.id) != nullptr;
           }
           else
           {
-            typeConvertable = static_cast<bool>(_scene.registry().getTypeConverter(dataType.id, state.reactingDataType().id));
+            typeConvertable = _scene.registry().getTypeConverter(dataType.id, state.reactingDataType().id) != nullptr;
           }
         }
 

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -10,6 +10,7 @@ class NodeState;
 class Node;
 class NodeDataModel;
 class FlowItemEntry;
+class FlowScene;
 
 class NodePainter
 {
@@ -22,7 +23,8 @@ public:
   static
   void
   paint(QPainter* painter,
-        Node& node);
+        Node & node,
+        FlowScene const& _scene);
 
   static
   void
@@ -48,7 +50,8 @@ public:
   drawConnectionPoints(QPainter* painter,
                        NodeGeometry const& geom,
                        NodeState const& state,
-                       NodeDataModel* const model);
+                       NodeDataModel* const model,
+                       FlowScene const& _scene);
 
   static
   void


### PR DESCRIPTION
Modification of the system to handle the concept of typecasting nodes, and insert them automatically when a connection is made between two node with different types that are convertible. (The idea comes from UE4's blueprint system.) Typecast nodes are regular nodes with exactly one input and output ports, with differing types. If a nodes fullfills these criterias, and registered with an extra true bool parameter like this `ret->registerModel<IntegerToDecimalModel, true>();`, the system will start to insert it automatically when a conversion is needed. This is a bigger chunk of code, especially the examples, so thorough reviewing is needed.
![example](https://cloud.githubusercontent.com/assets/7118075/22405914/c7e986c8-e649-11e6-8dd1-3669d3fcd7a3.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paceholder/nodeeditor/52)
<!-- Reviewable:end -->
