### PR TITLE
Implement Json serialization

### DIFF
--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <QtCore/QObject>
+
 #include <QtWidgets/QLabel>
 
 #include <nodes/NodeDataModel>
 
 #include "MathOperationDataModel.hpp"
-
 #include "DecimalData.hpp"
 
 /// The model dictates the number of inputs and outputs for the Node.
@@ -31,14 +31,6 @@ public:
   std::unique_ptr<NodeDataModel>
   clone() const override
   { return std::make_unique<AdditionModel>(); }
-
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", AdditionModel::name());
-  }
 
 private:
 

--- a/examples/calculator/DecimalToIntegerModel.cpp
+++ b/examples/calculator/DecimalToIntegerModel.cpp
@@ -5,12 +5,15 @@
 #include "DecimalData.hpp"
 #include "IntegerData.hpp"
 
-
-void
+QJsonObject
 DecimalToIntegerModel::
-save(Properties &p) const
+save() const
 {
-  p.put("model_name", DecimalToIntegerModel::name());
+  QJsonObject modelJson;
+
+  modelJson["name"] = name();
+
+  return modelJson;
 }
 
 
@@ -43,6 +46,7 @@ dataType(PortType portType, PortIndex) const
 {
   if (portType == PortType::In)
     return DecimalData().type();
+
   return IntegerData().type();
 }
 

--- a/examples/calculator/DecimalToIntegerModel.hpp
+++ b/examples/calculator/DecimalToIntegerModel.hpp
@@ -12,7 +12,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 
 class DecimalData;
 class IntegerData;
@@ -48,9 +47,9 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override;
-  
+  QJsonObject
+  save() const override;
+
 public:
 
   unsigned int
@@ -72,5 +71,4 @@ private:
 
   std::shared_ptr<DecimalData> _decimal;
   std::shared_ptr<IntegerData> _integer;
-
 };

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -22,7 +22,7 @@ public:
   QString
   caption() const override
   { return QStringLiteral("Division"); }
-  
+
   bool
   portCaptionVisible(PortType portType, PortIndex portIndex) const override
   { return true; }
@@ -37,6 +37,7 @@ public:
           return QStringLiteral("Dividend");
         else if (portIndex == 1)
           return QStringLiteral("Divisor");
+
         break;
 
       case PortType::Out:
@@ -47,7 +48,7 @@ public:
     }
     return QString();
   }
-  
+
   QString
   name() const override
   { return QStringLiteral("Division"); }
@@ -55,14 +56,6 @@ public:
   std::unique_ptr<NodeDataModel>
   clone() const override
   { return std::make_unique<DivisionModel>(); }
-
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", DivisionModel::name());
-  }
 
 private:
 
@@ -93,7 +86,7 @@ private:
       modelValidationError = QStringLiteral("Missing or incorrect inputs");
       _result.reset();
     }
-    
+
     emit dataUpdated(outPortIndex);
   }
 };

--- a/examples/calculator/IntegerToDecimalModel.cpp
+++ b/examples/calculator/IntegerToDecimalModel.cpp
@@ -5,12 +5,15 @@
 #include "DecimalData.hpp"
 #include "IntegerData.hpp"
 
-
-void
+QJsonObject
 IntegerToDecimalModel::
-save(Properties &p) const
+save() const
 {
-  p.put("model_name", IntegerToDecimalModel::name());
+  QJsonObject modelJson;
+
+  modelJson["name"] = name();
+
+  return modelJson;
 }
 
 
@@ -43,6 +46,7 @@ dataType(PortType portType, PortIndex) const
 {
   if (portType == PortType::In)
     return IntegerData().type();
+
   return DecimalData().type();
 }
 

--- a/examples/calculator/IntegerToDecimalModel.hpp
+++ b/examples/calculator/IntegerToDecimalModel.hpp
@@ -12,7 +12,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 
 class DecimalData;
 class IntegerData;
@@ -48,9 +47,9 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override;
-  
+  QJsonObject
+  save() const override;
+
 public:
 
   unsigned int
@@ -72,5 +71,4 @@ private:
 
   std::shared_ptr<DecimalData> _decimal;
   std::shared_ptr<IntegerData> _integer;
-
 };

--- a/examples/calculator/MathOperationDataModel.hpp
+++ b/examples/calculator/MathOperationDataModel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QtCore/QObject>
+#include <QtCore/QJsonObject>
 #include <QtWidgets/QLabel>
 
 #include <nodes/NodeDataModel>
@@ -14,9 +15,7 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
-
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -26,28 +25,37 @@ class MathOperationDataModel : public NodeDataModel
 
 public:
 
-  virtual ~MathOperationDataModel() {}
+  virtual
+  ~MathOperationDataModel() {}
 
 public:
 
-  unsigned int nPorts(PortType portType) const override;
+  unsigned int
+  nPorts(PortType portType) const override;
 
-  NodeDataType dataType(PortType portType,
-                        PortIndex portIndex) const override;
+  NodeDataType
+  dataType(PortType portType,
+           PortIndex portIndex) const override;
 
-  std::shared_ptr<NodeData> outData(PortIndex port) override;
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override;
 
-  void setInData(std::shared_ptr<NodeData> data, PortIndex portIndex) override;
+  void
+  setInData(std::shared_ptr<NodeData> data, PortIndex portIndex) override;
 
-  QWidget * embeddedWidget() override { return nullptr; }
+  QWidget *
+  embeddedWidget() override { return nullptr; }
 
-  NodeValidationState validationState() const override;
+  NodeValidationState
+  validationState() const override;
 
-  QString validationMessage() const override;
+  QString
+  validationMessage() const override;
 
 protected:
 
-  virtual void compute() = 0;
+  virtual void
+  compute() = 0;
 
 protected:
 

--- a/examples/calculator/ModuloModel.cpp
+++ b/examples/calculator/ModuloModel.cpp
@@ -4,12 +4,15 @@
 
 #include "IntegerData.hpp"
 
-
-void
+QJsonObject
 ModuloModel::
-save(Properties &p) const
+save() const
 {
-  p.put("model_name", name());
+  QJsonObject modelJson;
+
+  modelJson["name"] = name();
+
+  return modelJson;
 }
 
 

--- a/examples/calculator/ModuloModel.hpp
+++ b/examples/calculator/ModuloModel.hpp
@@ -12,7 +12,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
 
 class IntegerData;
@@ -39,7 +38,7 @@ public:
   { return true; }
 
   bool
-  portCaptionVisible(PortType portType, PortIndex portIndex) const override
+  portCaptionVisible(PortType, PortIndex ) const override
   { return true; }
 
   QString
@@ -47,18 +46,19 @@ public:
   {
     switch (portType)
     {
-    case PortType::In:
-      if (portIndex == 0)
-        return QStringLiteral("Dividend");
-      else if (portIndex == 1)
-        return QStringLiteral("Divisor");
-      break;
+      case PortType::In:
+        if (portIndex == 0)
+          return QStringLiteral("Dividend");
+        else if (portIndex == 1)
+          return QStringLiteral("Divisor");
 
-    case PortType::Out:
-      return QStringLiteral("Result");
+        break;
 
-    default:
-      break;
+      case PortType::Out:
+        return QStringLiteral("Result");
+
+      default:
+        break;
     }
     return QString();
   }
@@ -73,8 +73,8 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override;
+  QJsonObject
+  save() const override;
 
 public:
 
@@ -90,11 +90,14 @@ public:
   void
   setInData(std::shared_ptr<NodeData>, int) override;
 
-  QWidget * embeddedWidget() override { return nullptr; }
+  QWidget *
+  embeddedWidget() override { return nullptr; }
 
-  NodeValidationState validationState() const override;
+  NodeValidationState
+  validationState() const override;
 
-  QString validationMessage() const override;
+  QString
+  validationMessage() const override;
 
 private:
 

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -32,14 +32,6 @@ public:
   clone() const override
   { return std::make_unique<MultiplicationModel>(); }
 
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", MultiplicationModel::name());
-  }
-
 private:
 
   void

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -12,7 +12,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
 
 /// The model dictates the number of inputs and outputs for the Node.
@@ -47,14 +46,6 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", name());
-  }
-
-public:
-
   unsigned int
   nPorts(PortType portType) const override;
 
@@ -71,10 +62,10 @@ public:
   QWidget *
   embeddedWidget() override { return _label; }
 
-  NodeValidationState 
+  NodeValidationState
   validationState() const override;
 
-  QString 
+  QString
   validationMessage() const override;
 
 private:

--- a/examples/calculator/NumberSourceDataModel.cpp
+++ b/examples/calculator/NumberSourceDataModel.cpp
@@ -1,5 +1,6 @@
 #include "NumberSourceDataModel.hpp"
 
+#include <QtCore/QJsonValue>
 #include <QtGui/QDoubleValidator>
 
 #include "DecimalData.hpp"
@@ -19,27 +20,36 @@ NumberSourceDataModel()
 }
 
 
-void
+QJsonObject
 NumberSourceDataModel::
-save(Properties &p) const
+save() const
 {
-  p.put("model_name", name());
+  QJsonObject modelJson = NodeDataModel::save();
 
   if (_number)
-    p.put("number", _number->number());
+    modelJson["number"] = QString::number(_number->number());
+
+  return modelJson;
 }
 
 
 void
 NumberSourceDataModel::
-restore(Properties const &p)
+restore(QJsonObject const &p)
 {
-  double number;
+  QJsonValue v = p["number"];
 
-  if (bool ok = p.get("number", &number))
+  if (!v.isUndefined())
   {
-    _number = std::make_shared<DecimalData>(number);
-    _lineEdit->setText(QString::number(number));
+    QString strNum = v.toString();
+
+    bool   ok;
+    double d = strNum.toDouble(&ok);
+    if (ok)
+    {
+      _number = std::make_shared<DecimalData>(d);
+      _lineEdit->setText(strNum);
+    }
   }
 }
 

--- a/examples/calculator/NumberSourceDataModel.hpp
+++ b/examples/calculator/NumberSourceDataModel.hpp
@@ -14,7 +14,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
 
 /// The model dictates the number of inputs and outputs for the Node.
@@ -50,11 +49,11 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override;
+  QJsonObject
+  save() const override;
 
   void
-  restore(Properties const &p) override;
+  restore(QJsonObject const &p) override;
 
 public:
 

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -33,20 +33,21 @@ public:
   {
     switch (portType)
     {
-    case PortType::In:
-      if (portIndex == 0)
-        return QStringLiteral("Minuend");
-      else if (portIndex == 1)
-        return QStringLiteral("Subtrahend");
-      break;
+      case PortType::In:
+        if (portIndex == 0)
+          return QStringLiteral("Minuend");
+        else if (portIndex == 1)
+          return QStringLiteral("Subtrahend");
 
-    case PortType::Out:
-      return QStringLiteral("Result");
+        break;
 
-    default:
-      break;
+      case PortType::Out:
+        return QStringLiteral("Result");
+
+      default:
+        break;
     }
-	return QString();
+    return QString();
   }
 
   QString
@@ -56,14 +57,6 @@ public:
   std::unique_ptr<NodeDataModel>
   clone() const override
   { return std::make_unique<SubtractionModel>(); }
-
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", SubtractionModel::name());
-  }
 
 private:
 

--- a/examples/connection_colors/models.hpp
+++ b/examples/connection_colors/models.hpp
@@ -12,7 +12,6 @@ using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
 using QtNodes::PortType;
 using QtNodes::PortIndex;
-using QtNodes::Properties;
 
 /// The class can potentially incapsulate any user data which
 /// need to be transferred within the Node Editor graph
@@ -20,7 +19,8 @@ class MyNodeData : public NodeData
 {
 public:
 
-  NodeDataType type() const override
+  NodeDataType
+  type() const override
   {
     return NodeDataType {"MyNodeData",
                          "My Node Data"};
@@ -31,7 +31,8 @@ class SimpleNodeData : public NodeData
 {
 public:
 
-  NodeDataType type() const override
+  NodeDataType
+  type() const override
   {
     return NodeDataType {"SimpleData",
                          "Simple Data"};
@@ -53,27 +54,24 @@ public:
 
 public:
 
-  QString caption() const override
+  QString
+  caption() const override
   {
     return QString("Naive Data Model");
   }
 
-  QString name() const override
+  QString
+  name() const override
   { return QString("NaiveDataModel"); }
 
-  std::unique_ptr<NodeDataModel>clone() const override
+  std::unique_ptr<NodeDataModel>
+  clone() const override
   { return std::make_unique<NaiveDataModel>(); }
 
 public:
 
-  void save(Properties &p) const override
-  {
-    p.put("model_name", NaiveDataModel::name());
-  }
-
-public:
-
-  unsigned int nPorts(PortType portType) const override
+  unsigned int
+  nPorts(PortType portType) const override
   {
     unsigned int result = 1;
 
@@ -93,8 +91,9 @@ public:
     return result;
   }
 
-  NodeDataType dataType(PortType portType,
-                        PortIndex portIndex) const override
+  NodeDataType
+  dataType(PortType portType,
+           PortIndex portIndex) const override
   {
     switch (portType)
     {
@@ -129,7 +128,8 @@ public:
     }
   }
 
-  std::shared_ptr<NodeData> outData(PortIndex port) override
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override
   {
     if (port < 1)
       return std::make_shared<MyNodeData>();
@@ -137,10 +137,12 @@ public:
     return std::make_shared<SimpleNodeData>();
   }
 
-  void setInData(std::shared_ptr<NodeData>, int) override
+  void
+  setInData(std::shared_ptr<NodeData>, int) override
   {
     //
   }
 
-  QWidget *embeddedWidget() override { return nullptr; }
+  QWidget *
+  embeddedWidget() override { return nullptr; }
 };

--- a/examples/example2/TextDisplayDataModel.hpp
+++ b/examples/example2/TextDisplayDataModel.hpp
@@ -13,7 +13,6 @@ using QtNodes::PortType;
 using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -43,14 +42,6 @@ public:
   std::unique_ptr<NodeDataModel>
   clone() const override
   { return std::make_unique<TextDisplayDataModel>(); }
-
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", TextDisplayDataModel::name());
-  }
 
 public:
 

--- a/examples/example2/TextSourceDataModel.hpp
+++ b/examples/example2/TextSourceDataModel.hpp
@@ -13,7 +13,6 @@ using QtNodes::PortType;
 using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
@@ -29,40 +28,43 @@ public:
 
 public:
 
-  QString caption() const override
+  QString
+  caption() const override
   { return QString("Text Source"); }
 
-  bool captionVisible() const override { return false; }
+  bool
+  captionVisible() const override { return false; }
 
-  QString name() const override
+  QString
+  name() const override
   { return QString("TextSourceDataModel"); }
 
-  std::unique_ptr<NodeDataModel>clone() const override
+  std::unique_ptr<NodeDataModel>
+  clone() const override
   { return std::make_unique<TextSourceDataModel>(); }
 
 public:
 
-  void save(Properties &p) const override
-  {
-    p.put("model_name", TextSourceDataModel::name());
-  }
+  unsigned int
+  nPorts(PortType portType) const override;
 
-public:
+  NodeDataType
+  dataType(PortType portType, PortIndex portIndex) const override;
 
-  unsigned int nPorts(PortType portType) const override;
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override;
 
-  NodeDataType dataType(PortType portType, PortIndex portIndex) const override;
-
-  std::shared_ptr<NodeData>outData(PortIndex port) override;
-
-  void setInData(std::shared_ptr<NodeData>, int) override
+  void
+  setInData(std::shared_ptr<NodeData>, int) override
   { }
 
-  QWidget *embeddedWidget() override { return _lineEdit; }
+  QWidget *
+  embeddedWidget() override { return _lineEdit; }
 
 private slots:
 
-  void onTextEdited(QString const &string);
+  void
+  onTextEdited(QString const &string);
 
 private:
 

--- a/examples/images/ImageLoaderModel.hpp
+++ b/examples/images/ImageLoaderModel.hpp
@@ -15,7 +15,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
 
 /// The model dictates the number of inputs and outputs for the Node.
@@ -42,14 +41,6 @@ public:
   std::unique_ptr<NodeDataModel>
   clone() const override
   { return std::make_unique<ImageLoaderModel>(); }
-
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", ImageLoaderModel::name());
-  }
 
 public:
 

--- a/examples/images/ImageShowModel.hpp
+++ b/examples/images/ImageShowModel.hpp
@@ -13,7 +13,6 @@ using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
 
 /// The model dictates the number of inputs and outputs for the Node.
@@ -41,14 +40,6 @@ public:
   std::unique_ptr<NodeDataModel>
   clone() const override
   { return std::make_unique<ImageShowModel>(); }
-
-public:
-
-  void
-  save(Properties &p) const override
-  {
-    p.put("model_name", ImageShowModel::name());
-  }
 
 public:
 

--- a/examples/styles/models.hpp
+++ b/examples/styles/models.hpp
@@ -7,13 +7,11 @@
 
 #include <memory>
 
-
 using QtNodes::PortType;
 using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
-using QtNodes::Properties;
 using QtNodes::NodeValidationState;
 
 /// The class can potentially incapsulate any user data which
@@ -62,10 +60,14 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override
+  QJsonObject
+  save() const override
   {
-    p.put("model_name", MyDataModel::name());
+    QJsonObject modelJson;
+
+    modelJson["name"] = name();
+
+    return modelJson;
   }
 
 public:

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -27,7 +27,6 @@ using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::ConnectionGraphicsObject;
 using QtNodes::ConnectionGeometry;
-using QtNodes::Properties;
 
 Connection::
 Connection(PortType portType,
@@ -80,18 +79,22 @@ Connection::
 }
 
 
-void
+QJsonObject
 Connection::
-save(Properties &p) const
+save() const
 {
+  QJsonObject connectionJson;
+
   if (_inNode && _outNode)
   {
-    p.put("in_id", _inNode->id());
-    p.put("out_id", _outNode->id());
+    connectionJson["in_id"] = _inNode->id().toString();
+    connectionJson["in_index"] = _inPortIndex;
 
-    p.put("in_index", _inPortIndex);
-    p.put("out_index", _outPortIndex);
+    connectionJson["out_id"] = _outNode->id().toString();
+    connectionJson["out_index"] = _outPortIndex;
   }
+
+  return connectionJson;
 }
 
 

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -62,8 +62,8 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override;
+  QJsonObject
+  save() const override;
 
 public:
 

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -36,51 +36,69 @@ public:
 
 public:
 
-  std::shared_ptr<Connection>createConnection(PortType connectedPort,
-                                              Node& node,
-                                              PortIndex portIndex);
+  std::shared_ptr<Connection>
+  createConnection(PortType connectedPort,
+                   Node& node,
+                   PortIndex portIndex);
 
-  std::shared_ptr<Connection>createConnection(Node& nodeIn,
-                                              PortIndex portIndexIn,
-                                              Node& nodeOut,
-                                              PortIndex portIndexOut);
+  std::shared_ptr<Connection>
+  createConnection(Node& nodeIn,
+                   PortIndex portIndexIn,
+                   Node& nodeOut,
+                   PortIndex portIndexOut);
 
-  std::shared_ptr<Connection>restoreConnection(Properties const &p);
+  std::shared_ptr<Connection>
+  restoreConnection(QJsonObject const &connectionJson);
 
-  void deleteConnection(Connection& connection);
+  void
+  deleteConnection(Connection& connection);
 
-  Node&createNode(std::unique_ptr<NodeDataModel> && dataModel);
+  Node&
+  createNode(std::unique_ptr<NodeDataModel> && dataModel);
 
-  Node&restoreNode(Properties const &p);
+  Node&
+  restoreNode(QJsonObject const& nodeJson);
 
-  void removeNode(Node& node);
+  void
+  removeNode(Node& node);
 
-  DataModelRegistry& registry() const;
+  DataModelRegistry&
+  registry() const;
 
-  void setRegistry(std::shared_ptr<DataModelRegistry> registry);
+  void
+  setRegistry(std::shared_ptr<DataModelRegistry> registry);
 
-  void iterateOverNodes(std::function<void(Node*)> visitor);
+  void
+  iterateOverNodes(std::function<void(Node*)> visitor);
 
 public:
 
-  std::unordered_map<QUuid, std::unique_ptr<Node> > const &nodes() const;
+  std::unordered_map<QUuid, std::unique_ptr<Node> > const &
+  nodes() const;
 
-  std::unordered_map<QUuid, std::shared_ptr<Connection> > const &connections() const;
+  std::unordered_map<QUuid, std::shared_ptr<Connection> > const &
+  connections() const;
 
 public:
 
-  void save() const;
+  void
+  save() const;
 
-  void load();
+  void
+  load();
 
 signals:
 
-  void nodeCreated(Node &n);
+  void
+  nodeCreated(Node &n);
 
-  void nodeDeleted(Node &n);
+  void
+  nodeDeleted(Node &n);
 
-  void connectionCreated(Connection &c);
-  void connectionDeleted(Connection &c);
+  void
+  connectionCreated(Connection &c);
+  void
+  connectionDeleted(Connection &c);
 
 private:
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -19,7 +19,6 @@ using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDataModel;
 using QtNodes::NodeGraphicsObject;
-using QtNodes::Properties;
 using QtNodes::PortIndex;
 using QtNodes::PortType;
 
@@ -46,32 +45,38 @@ Node::
 }
 
 
-void
+QJsonObject
 Node::
-save(Properties &p) const
+save() const
 {
-  // save unique object id
-  p.put("id", _id);
+  QJsonObject nodeJson;
 
-  // save data model name
-  _nodeDataModel->save(p);
+  nodeJson["id"] = _id.toString();
 
-  // save node graphics position
-  p.put("position", _nodeGraphicsObject->pos());
+  nodeJson["model"] = _nodeDataModel->save();
+
+  nodeJson["position"] = QJsonObject
+  {
+    { "x" , _nodeGraphicsObject->pos().x() },
+    { "y" , _nodeGraphicsObject->pos().y() }
+  };
+
+  return nodeJson;
 }
 
 
 void
 Node::
-restore(Properties const &p)
+restore(QJsonObject const& json)
 {
-  p.get("id", &_id);
+  _id = QUuid(json["id"].toString());
 
-  QPointF point;
-  p.get("position", &point);
-  _nodeGraphicsObject->setPos(point );
+  QJsonObject positionJson = json["position"].toObject();
+  QPointF     point(positionJson["x"].toDouble(),
+                    positionJson["y"].toDouble());
+  _nodeGraphicsObject->setPos(point);
 
-  _nodeDataModel->restore(p);
+  _nodeDataModel->restore(json["model"].toObject());
 }
 
 

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -39,11 +39,11 @@ public:
 
 public:
 
-  void
-  save(Properties &p) const override;
+  QJsonObject
+  save() const override;
 
   void
-  restore(Properties const &p) override;
+  restore(QJsonObject const &json) override;
 
 public:
 
@@ -113,5 +113,4 @@ private:
 
   std::unique_ptr<NodeGraphicsObject> _nodeGraphicsObject;
 };
-
 }

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -57,6 +57,18 @@ public:
 
 public:
 
+  QJsonObject
+  save() const override
+  {
+    QJsonObject modelJson;
+
+    modelJson["name"] = name();
+
+    return modelJson;
+  }
+
+public:
+
   virtual
   unsigned int
   nPorts(PortType portType) const = 0;

--- a/src/Serializable.hpp
+++ b/src/Serializable.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Properties.hpp"
+#include <QtCore/QJsonObject>
 
 namespace QtNodes
 {
@@ -12,10 +12,11 @@ public:
   virtual
   ~Serializable() = default;
 
-  virtual void
-  save(Properties & p) const = 0;
+  virtual
+  QJsonObject
+  save() const = 0;
 
   virtual void
-  restore(Properties const & /*p*/) {}
+  restore(QJsonObject const & /*p*/) {}
 };
 }


### PR DESCRIPTION
I did not implement any sophisticated general-purpose super-duper-abstract serialization mechanism.
- Serialization is complex by itself.
- Hard to predict what would be a client's serialization system (boost? Qt's JSON? binary data?)

Thus,  there is just JSON that just works.

The output is an UTF-8 text file:

```
{
    "connections": [
        {
            "in_id": "{3c827191-1458-48ec-9a47-2c50e640e129}",
            "in_index": 0,
            "out_id": "{52d330bc-9970-426e-8679-1a2bb26a8d68}",
            "out_index": 0
        }
    ],
    "nodes": [
        {
            "id": "{3c827191-1458-48ec-9a47-2c50e640e129}",
            "model": {
                "name": "Result"
            },
            "position": {
                "x": 489,
                "y": 264
            }
        },
        {
            "id": "{52d330bc-9970-426e-8679-1a2bb26a8d68}",
            "model": {
                "name": "NumberSource",
                "number": "34"
            },
            "position": {
                "x": 135,
                "y": 136
            }
        }
    ]
}
```