### PR TITLE
Various fixes and additions

### DIFF
--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -28,23 +28,23 @@ static std::shared_ptr<DataModelRegistry>
 registerDataModels()
 {
   auto ret = std::make_shared<DataModelRegistry>();
-  ret->registerModel<NumberSourceDataModel>();
+  ret->registerModel<NumberSourceDataModel>("Sources");
 
-  ret->registerModel<NumberDisplayDataModel>();
+  ret->registerModel<NumberDisplayDataModel>("Displays");
 
-  ret->registerModel<AdditionModel>();
+  ret->registerModel<AdditionModel>("Operators");
 
-  ret->registerModel<SubtractionModel>();
+  ret->registerModel<SubtractionModel>("Operators");
 
-  ret->registerModel<MultiplicationModel>();
+  ret->registerModel<MultiplicationModel>("Operators");
 
-  ret->registerModel<DivisionModel>();
+  ret->registerModel<DivisionModel>("Operators");
 
-  ret->registerModel<ModuloModel>();
+  ret->registerModel<ModuloModel>("Operators");
 
-  ret->registerModel<DecimalToIntegerModel, true>();
+  ret->registerModel<DecimalToIntegerModel, true>("Type converters");
 
-  ret->registerModel<IntegerToDecimalModel, true>();
+  ret->registerModel<IntegerToDecimalModel, true>("Type converters");
 
   return ret;
 }

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -47,7 +47,7 @@ categories() const
 
 std::unique_ptr<NodeDataModel>
 DataModelRegistry::
-getTypeConverter(const QString & sourceTypeID, const QString & destTypeID) const
+getTypeConverter(QString const &sourceTypeID, QString const &destTypeID) const
 {
   auto typeConverterKey = std::make_pair(sourceTypeID, destTypeID);
   auto converter = _registeredTypeConverters.find(typeConverterKey);

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -29,6 +29,22 @@ registeredModels() const
 }
 
 
+DataModelRegistry::RegisteredModelsCategoryMap const &
+DataModelRegistry::
+registeredModelsCategoryAssociation() const
+{
+  return _registeredModelsCategory;
+}
+
+
+DataModelRegistry::CategoriesSet const &
+DataModelRegistry::
+categories() const
+{
+  return _categories;
+}
+
+
 std::unique_ptr<NodeDataModel>
 DataModelRegistry::
 getTypeConverter(const QString & sourceTypeID, const QString & destTypeID) const

--- a/src/DataModelRegistry.hpp
+++ b/src/DataModelRegistry.hpp
@@ -50,7 +50,7 @@ public:
 
   template<typename ModelType, bool TypeConverter = false>
   void
-  registerModel(std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>(), const QString& category = "Nodes")
+  registerModel(std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>(), QString const &category = "Nodes")
   {
     static_assert(std::is_base_of<NodeDataModel, ModelType>::value,
                   "Must pass a subclass of NodeDataModel to registerModel");
@@ -89,7 +89,7 @@ public:
   //Parameter order alias, so a category can be set without forcing to manually pass a model instance
   template<typename ModelType, bool TypeConverter = false>
   void
-  registerModel(const QString& category, std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>())
+  registerModel(QString const &category, std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>())
   {
     registerModel<ModelType, TypeConverter>(std::move(uniqueModel), category);
   }
@@ -107,8 +107,8 @@ public:
   categories() const;
 
   std::unique_ptr<NodeDataModel>
-  getTypeConverter(const QString & sourceTypeID, 
-                   const QString & destTypeID) const;
+  getTypeConverter(QString const &sourceTypeID,
+                   QString const &destTypeID) const;
 
 private:
 

--- a/src/DataModelRegistry.hpp
+++ b/src/DataModelRegistry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <set>
 #include <memory>
 
 #include <QtCore/QString>
@@ -18,8 +19,10 @@ class NODE_EDITOR_PUBLIC DataModelRegistry
 
 public:
   
-  using RegistryItemPtr     = std::unique_ptr<NodeDataModel>;
-  using RegisteredModelsMap = std::unordered_map<QString, RegistryItemPtr>;
+  using RegistryItemPtr             = std::unique_ptr<NodeDataModel>;
+  using RegisteredModelsMap         = std::unordered_map<QString, RegistryItemPtr>;
+  using RegisteredModelsCategoryMap = std::unordered_map<QString, QString>;
+  using CategoriesSet               = std::set<QString>;
 
   struct TypeConverterItem
   {
@@ -47,7 +50,7 @@ public:
 
   template<typename ModelType, bool TypeConverter = false>
   void
-  registerModel(std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>())
+  registerModel(std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>(), const QString& category = "Nodes")
   {
     static_assert(std::is_base_of<NodeDataModel, ModelType>::value,
                   "Must pass a subclass of NodeDataModel to registerModel");
@@ -57,6 +60,8 @@ public:
     if (_registeredModels.count(name) == 0)
     {
       _registeredModels[name] = std::move(uniqueModel);
+      _categories.insert(category);
+      _registeredModelsCategory[name] = category;
     }
 
     if (TypeConverter)
@@ -81,11 +86,25 @@ public:
     }
   }
 
+  //Parameter order alias, so a category can be set without forcing to manually pass a model instance
+  template<typename ModelType, bool TypeConverter = false>
+  void
+  registerModel(const QString& category, std::unique_ptr<ModelType> uniqueModel = std::make_unique<ModelType>())
+  {
+    registerModel<ModelType, TypeConverter>(std::move(uniqueModel), category);
+  }
+
   std::unique_ptr<NodeDataModel>
   create(QString const &modelName);
 
   RegisteredModelsMap const &
   registeredModels() const;
+  
+  RegisteredModelsCategoryMap const &
+  registeredModelsCategoryAssociation() const;
+  
+  CategoriesSet const &
+  categories() const;
 
   std::unique_ptr<NodeDataModel>
   getTypeConverter(const QString & sourceTypeID, 
@@ -93,6 +112,8 @@ public:
 
 private:
 
+  RegisteredModelsCategoryMap _registeredModelsCategory;
+  CategoriesSet _categories;
   RegisteredModelsMap _registeredModels;
   RegisteredTypeConvertersMap _registeredTypeConverters;
 };

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -395,8 +395,18 @@ void
 FlowScene::
 load()
 {
-  _connections.clear();
-  _nodes.clear();
+  //Manual node cleanup. Simply clearing the holding datastructures doesn't work, the code crashes when
+  // there are both nodes and connections in the scene. (The data propagation internal logic tries to propagate 
+  // data through already freed connections.)
+  std::vector<Node*> nodesToDelete;
+  for (auto& node : _nodes)
+  {
+    nodesToDelete.push_back(node.second.get());
+  }
+  for (auto& node : nodesToDelete)
+  {
+    removeNode(*node);
+  }
 
   //-------------
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -230,6 +230,17 @@ iterateOverNodes(std::function<void(Node*)> visitor)
 }
 
 
+void
+FlowScene::
+iterateOverNodes(std::function<void(NodeDataModel*)> visitor)
+{
+  for (const auto& _node : _nodes)
+  {
+    visitor(_node.second->nodeDataModel());
+  }
+}
+
+
 std::unordered_map<QUuid, std::unique_ptr<Node> > const &
 FlowScene::
 nodes() const

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -307,9 +307,10 @@ getNodePosition(const Node& node) const
 
 void
 FlowScene::
-getNodePosition(Node& node, const QPointF& pos) const
+setNodePosition(Node& node, const QPointF& pos) const
 {
   node.nodeGraphicsObject().setPos(pos);
+  node.nodeGraphicsObject().moveConnections();
 }
 
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -232,7 +232,7 @@ iterateOverNodes(std::function<void(Node*)> visitor)
 
 void
 FlowScene::
-iterateOverNodes(std::function<void(NodeDataModel*)> visitor)
+iterateOverNodeData(std::function<void(NodeDataModel*)> visitor)
 {
   for (const auto& _node : _nodes)
   {

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -297,6 +297,30 @@ iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> visitor)
 }
 
 
+QPointF
+FlowScene::
+getNodePosition(const Node& node) const
+{
+  return node.nodeGraphicsObject().pos();
+}
+
+
+void
+FlowScene::
+getNodePosition(Node& node, const QPointF& pos) const
+{
+  node.nodeGraphicsObject().setPos(pos);
+}
+
+
+QSizeF
+FlowScene::
+getNodeSize(const Node& node) const
+{
+  return QSizeF(node.nodeGeometry().width(), node.nodeGeometry().height());
+}
+
+
 std::unordered_map<QUuid, std::unique_ptr<Node> > const &
 FlowScene::
 nodes() const

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -71,6 +71,8 @@ public:
   void
   iterateOverNodes(std::function<void(Node*)> visitor);
 
+  void
+  iterateOverNodes(std::function<void(NodeDataModel*)> visitor);
 public:
 
   std::unordered_map<QUuid, std::unique_ptr<Node> > const &

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -76,6 +76,15 @@ public:
 
   void
   iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> visitor);
+
+  QPointF
+  getNodePosition(const Node& node) const;
+
+  void
+  getNodePosition(Node& node, const QPointF& pos) const;
+  
+  QSizeF
+  getNodeSize(const Node& node) const;
 public:
 
   std::unordered_map<QUuid, std::unique_ptr<Node> > const &

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -72,7 +72,7 @@ public:
   iterateOverNodes(std::function<void(Node*)> visitor);
 
   void
-  iterateOverNodes(std::function<void(NodeDataModel*)> visitor);
+  iterateOverNodeData(std::function<void(NodeDataModel*)> visitor);
 public:
 
   std::unordered_map<QUuid, std::unique_ptr<Node> > const &

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -73,6 +73,9 @@ public:
 
   void
   iterateOverNodeData(std::function<void(NodeDataModel*)> visitor);
+
+  void
+  iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> visitor);
 public:
 
   std::unordered_map<QUuid, std::unique_ptr<Node> > const &

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -81,7 +81,7 @@ public:
   getNodePosition(const Node& node) const;
 
   void
-  getNodePosition(Node& node, const QPointF& pos) const;
+  setNodePosition(Node& node, const QPointF& pos) const;
   
   QSizeF
   getNodeSize(const Node& node) const;

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -221,12 +221,12 @@ keyPressEvent(QKeyEvent *event)
         if (auto c = dynamic_cast<ConnectionGraphicsObject*>(item))
           connectionsToDelete.push_back(&c->connection());
       }
+	  
+	  for (auto & c : connectionsToDelete)
+		  _scene->deleteConnection(*c);
 
       for( auto & n : nodesToDelete )
         _scene->removeNode(*n);
-
-      for( auto & c : connectionsToDelete )
-        _scene->deleteConnection(*c);
 
     }
 


### PR DESCRIPTION
- Fixed a crash, that happened when the user tried to delete multiple selected nodes and connections
- Fixed a crash, that happened when the user tried to load a scene from file into a non-empty scene
- Added functions to FlowScene for node position manipulation, and size readback. Before this, this data were only accessible through types that are not exported from the library, but on the other hand moving nodes in code is useful for automatic graph generation. (Like generating a basic graph that the user edits, instead of giving them an empty scene.)
- Added functions to Flowscene for iterating through the existing nodes. iterateOverNodeData just iterates through the nodes, passing the node data to the visitor lambda. iterateOverNodeDataDependentOrder iterates through the nodes in a specific order, it always visits a nodes all input nodes, before visiting the node itself. The latter is useful for codegeneration from the graph, where the order of the generated statements are important, and statements that feed other statements must be before them.
- Redid the context menu to be usable with a larger number of node types. Instead of dumping all the types into the menu, now all of them are put into a treewidget, under the categories that are passed during type registration. (A sideeffect is, that the filtering is noticably faster now, with the old way, filtering in the list on the picture froze the ui for a few moment after the first character inputed.) To illustrate the problem, and the solution:
![comp](https://cloud.githubusercontent.com/assets/7118075/23680380/508ce6ba-038b-11e7-9a24-19aa9cbb29c4.jpg)
