### PR TITLE
Compilation fix for VS2013

### DIFF
--- a/src/make_unique.hpp
+++ b/src/make_unique.hpp
@@ -4,15 +4,17 @@
 
 
 #if (!defined(_MSC_VER) && (__cplusplus < 201300)) || \
-    ( defined(_MSC_VER) && (_MSC_VER < 1900))
+    ( defined(_MSC_VER) && (_MSC_VER < 1800)) 
+//_MSC_VER == 1800 is Visual Studio 2013, which is already somewhat C++14 compilant, 
+// and it has make_unique in it's standard library implementation
 
 namespace std
 {
-    template<typename T, typename... Args>
-    std::unique_ptr<T> make_unique(Args&&... args)
-    {
-        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-    }
+  template<typename T, typename... Args>
+  std::unique_ptr<T> make_unique(Args&&... args)
+  {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+  }
 }
 
 #endif


### PR DESCRIPTION
Changed the make_unique 'emulation' conditions, so that it doesn't match VS2013. (VS2013 already has make_unique in std, the standard compliance of VS versions are all over the place.)