### PR TITLE
Save/load graph from memory

### DIFF
--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -101,7 +101,13 @@ public:
   void
   load();
 
-signals:
+  QByteArray 
+  saveToMemory() const;
+
+  void 
+  loadFromMemory(const QByteArray& data);
+
+  signals:
 
   void
   nodeCreated(Node &n);


### PR DESCRIPTION
Added saveToMemory/loadFromMemory functions, so the users can implement their own method of getting the data, that will be loaded into the graph. The original save/load are refactored to use the new functions.