### PR TITLE
Add corner decorators

### DIFF
--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include <QtWidgets/QWidget>
+#include <QIcon>
 
 #include "PortType.hpp"
 #include "NodeData.hpp"
@@ -54,6 +55,10 @@ public:
   /// Function creates instances of a model stored in DataModelRegistry
   virtual std::unique_ptr<NodeDataModel>
   clone() const = 0;
+
+  /// Set the decorator icon for that corner
+  virtual QIcon
+  cornerDecorator(Qt::Corner corner) const { return QIcon(); }
 
 public:
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -43,6 +43,8 @@ paint(QPainter* painter,
 
   drawConnectionPoints(painter, geom, state, model, scene);
 
+  drawNodeDecorators(painter, geom, model);
+
   drawFilledConnectionPoints(painter, geom, state, model);
 
   drawModelName(painter, geom, state, model);
@@ -97,6 +99,38 @@ drawNodeRect(QPainter* painter,
   painter->drawRoundedRect(boundary, radius, radius);
 }
 
+void
+NodePainter::
+drawNodeDecorators(QPainter* painter,
+                          NodeGeometry const& location,
+                          NodeDataModel* const model) {
+
+  QSize size(16, 16);
+
+  // draw upper left
+  QIcon upperLeftIcon = model->cornerDecorator(Qt::TopLeftCorner);
+  if (!upperLeftIcon.isNull()) {
+    upperLeftIcon.paint(painter, QRect(QPoint(-size.width(), -size.height()), size));
+  }
+
+  // draw upper right
+  QIcon upperRightIcon = model->cornerDecorator(Qt::TopRightCorner);
+  if (!upperRightIcon.isNull()) {
+    upperRightIcon.paint(painter, QRect(QPoint(location.width(), -size.height()), size));
+  }
+
+  // draw lower left
+  QIcon lowerLeftIcon = model->cornerDecorator(Qt::BottomLeftCorner);
+  if (!lowerLeftIcon.isNull()) {
+    lowerLeftIcon.paint(painter, QRect(QPoint(-size.width(), location.height()), size));
+  }
+
+  // draw lower right
+  QIcon lowerRightIcon = model->cornerDecorator(Qt::BottomRightCorner);
+  if (!lowerRightIcon.isNull()) {
+    lowerRightIcon.paint(painter, QRect(QPoint(location.width(), location.height()), size));
+  }
+}
 
 void
 NodePainter::

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -33,6 +33,11 @@ public:
                     NodeGraphicsObject const & graphicsObject);
 
   static
+  void drawNodeDecorators(QPainter* painter,
+                          NodeGeometry const& location,
+                          NodeDataModel* const model);
+
+  static
   void drawModelName(QPainter* painter,
                      NodeGeometry const& geom,
                      NodeState const& state,


### PR DESCRIPTION
This allows people to add `QIcon`s to the corners of nodes. 

Here's a screenshot:

![image](https://cloud.githubusercontent.com/assets/7105082/23777894/ad4c7216-04f4-11e7-8428-9c8a79f0e4c0.png)

Users just need to override the `cornerDecorator` function in `NodeDataModel`