### PR TITLE
Add selectedNodes() function to FlowScene

### DIFF
--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -351,6 +351,24 @@ connections() const
   return _connections;
 }
 
+std::vector<Node*>
+FlowScene::selectedNodes() const {
+  QList<QGraphicsItem*> graphicsItems = selectedItems();
+
+  std::vector<Node*> ret;
+  ret.reserve(graphicsItems.size());
+
+  for (QGraphicsItem* item : graphicsItems) {
+    auto ngo = qgraphicsitem_cast<NodeGraphicsObject*>(item);
+
+    if (ngo != nullptr) {
+      ret.push_back(&ngo->node());
+    }
+  }
+
+  return ret;
+}
+
 
 //------------------------------------------------------------------------------
 

--- a/src/FlowScene.hpp
+++ b/src/FlowScene.hpp
@@ -93,6 +93,9 @@ public:
   std::unordered_map<QUuid, std::shared_ptr<Connection> > const &
   connections() const;
 
+  std::vector<Node*>
+  selectedNodes() const;
+
 public:
 
   void

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -105,6 +105,7 @@ embedQWidget()
   }
 }
 
+
 QRectF
 NodeGraphicsObject::
 boundingRect() const

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -105,7 +105,6 @@ embedQWidget()
   }
 }
 
-
 QRectF
 NodeGraphicsObject::
 boundingRect() const

--- a/src/NodeGraphicsObject.hpp
+++ b/src/NodeGraphicsObject.hpp
@@ -43,6 +43,10 @@ public:
   void
   moveConnections() const;
 
+  enum { Type = UserType + 1 };
+  int
+  type() const override { return Type; }
+
 protected:
   void
   paint(QPainter*                       painter,
@@ -76,6 +80,7 @@ protected:
 private:
   void
   embedQWidget();
+
 
 private:
 

--- a/src/NodeGraphicsObject.hpp
+++ b/src/NodeGraphicsObject.hpp
@@ -81,7 +81,6 @@ private:
   void
   embedQWidget();
 
-
 private:
 
   FlowScene & _scene;


### PR DESCRIPTION
I also had to add `type()` override to `NodeGraphicsObject` to allow for [qgraphicsitem_cast](http://doc.qt.io/qt-5/qgraphicsitem.html#qgraphicsitem_cast) to work