### PR TITLE
Fix crash when deleting nodes in a marquee selection

### DIFF
--- a/src/ConnectionGraphicsObject.hpp
+++ b/src/ConnectionGraphicsObject.hpp
@@ -30,6 +30,10 @@ public:
   virtual
   ~ConnectionGraphicsObject();
 
+  enum { Type = UserType + 2 };
+  int
+  type() const override { return Type; }
+
 public:
 
   Connection&

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -214,14 +214,14 @@ keyPressEvent(QKeyEvent *event)
       // delete the nodes, this will delete many of the connections
       for (QGraphicsItem * item : _scene->selectedItems())
       {
-        if (auto n = dynamic_cast<NodeGraphicsObject*>(item))
+        if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
           _scene->removeNode(n->node());
 
       }
 
       for (QGraphicsItem * item : _scene->selectedItems())
       {
-        if (auto c = dynamic_cast<ConnectionGraphicsObject*>(item))
+        if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
           _scene->deleteConnection(c->connection());
       }
 

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -211,22 +211,19 @@ keyPressEvent(QKeyEvent *event)
 
     case Qt::Key_Delete:
     {
-      std::vector<Node*> nodesToDelete;
-      std::vector<Connection*> connectionsToDelete;
+      // delete the nodes, this will delete many of the connections
       for (QGraphicsItem * item : _scene->selectedItems())
       {
         if (auto n = dynamic_cast<NodeGraphicsObject*>(item))
-          nodesToDelete.push_back(&n->node());
+          _scene->removeNode(n->node());
 
-        if (auto c = dynamic_cast<ConnectionGraphicsObject*>(item))
-          connectionsToDelete.push_back(&c->connection());
       }
-	  
-	  for (auto & c : connectionsToDelete)
-		  _scene->deleteConnection(*c);
 
-      for( auto & n : nodesToDelete )
-        _scene->removeNode(*n);
+      for (QGraphicsItem * item : _scene->selectedItems())
+      {
+        if (auto c = dynamic_cast<ConnectionGraphicsObject*>(item))
+          _scene->deleteConnection(c->connection());
+      }
 
     }
 


### PR DESCRIPTION
Steps to reproduce this crash:
1. Make a graph with at least 2 nodes and 1 connection between them
2. Select a node and the connection with the marquee selection tool
3. Press delete

This fixes that crash. The problem was the connections that were to be deleted were stored, but then they were deleted when nodes were deleted, therefore they were "deleted" after they had already been deleted (double free sort of thing). This fixes it by deleting all the nodes, then all the connections.