### PR TITLE
Add onPaint callback to NodeDataModel for custom painting

### DIFF
--- a/include/nodes/NodeGeometry
+++ b/include/nodes/NodeGeometry
@@ -1,0 +1,2 @@
+#include "../../src/NodeGeometry.hpp"
+

--- a/include/nodes/NodePainterDelegate
+++ b/include/nodes/NodePainterDelegate
@@ -1,0 +1,1 @@
+#include "../../src/NodePainterDelegate.hpp"

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -8,6 +8,7 @@
 #include "NodeData.hpp"
 #include "Serializable.hpp"
 #include "NodeGeometry.hpp"
+#include "NodePainterDelegate.hpp"
 
 #include "Export.hpp"
 
@@ -107,7 +108,7 @@ public:
   validationMessage() const { return QString(""); }
 
   virtual
-  void onPaint(QPainter* painter, const NodeGeometry& geometry) const {}
+  NodePainterDelegate* painterDelegate() const { return  nullptr; }
 
 signals:
 

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -7,6 +7,7 @@
 #include "PortType.hpp"
 #include "NodeData.hpp"
 #include "Serializable.hpp"
+#include "NodeGeometry.hpp"
 
 #include "Export.hpp"
 
@@ -104,6 +105,9 @@ public:
   virtual
   QString
   validationMessage() const { return QString(""); }
+
+  virtual
+  void onPaint(QPainter* painter, const NodeGeometry& geometry) const {}
 
 signals:
 

--- a/src/NodeGeometry.hpp
+++ b/src/NodeGeometry.hpp
@@ -8,6 +8,7 @@
 #include <QtGui/QFontMetrics>
 
 #include "PortType.hpp"
+#include "Export.hpp"
 
 namespace QtNodes
 {
@@ -16,7 +17,7 @@ class NodeState;
 class NodeDataModel;
 class Node;
 
-class NodeGeometry
+class NODE_EDITOR_PUBLIC NodeGeometry
 {
 public:
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -53,7 +53,11 @@ paint(QPainter* painter,
 
   drawValidationRect(painter, geom, model, graphicsObject);
 
-  model->onPaint(painter, geom);
+  /// call custom painter
+  auto painterDelegate = model->painterDelegate();
+  if (painterDelegate != nullptr) {
+    painterDelegate->paint(painter, geom, state, model);
+  }
 }
 
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -54,8 +54,8 @@ paint(QPainter* painter,
   drawValidationRect(painter, geom, model, graphicsObject);
 
   /// call custom painter
-  auto painterDelegate = model->painterDelegate();
-  if (painterDelegate != nullptr) {
+  if (auto painterDelegate = model->painterDelegate())
+  {
     painterDelegate->paint(painter, geom, model);
   }
 }

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -56,7 +56,7 @@ paint(QPainter* painter,
   /// call custom painter
   auto painterDelegate = model->painterDelegate();
   if (painterDelegate != nullptr) {
-    painterDelegate->paint(painter, geom, state, model);
+    painterDelegate->paint(painter, geom, model);
   }
 }
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -52,6 +52,8 @@ paint(QPainter* painter,
   drawResizeRect(painter, geom, model);
 
   drawValidationRect(painter, geom, model, graphicsObject);
+
+  model->onPaint(painter, geom);
 }
 
 

--- a/src/NodePainterDelegate.hpp
+++ b/src/NodePainterDelegate.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QPainter>
+
+#include "NodeGeometry.hpp"
+#include "NodeDataModel.hpp"
+#include "Export.hpp"
+
+namespace QtNodes {
+
+/// Class to allow for custom painting
+class NODE_EDITOR_PUBLIC NodePainterDelegate {
+public:
+  virtual ~NodePainterDelegate() = default;
+
+  virtual void paint(QPainter* painter,
+                     NodeGeometry const& geom,
+                     NodeDataModel* const model) = 0;
+};
+
+}


### PR DESCRIPTION
I also exposed NodeGeometry to the public API, which had to be done because it'd be hard to expose painting things without knowing where you are. 

If you have a better way to do this, I'm all ears.

I decided to go with a simple virtual function because it does basically the same thing as a delegate, but it's simpler and more concise.