### PR TITLE
Remove overriden functions that just called the base version

### DIFF
--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -320,19 +320,3 @@ showEvent(QShowEvent *event)
   _scene->setSceneRect(this->rect());
   QGraphicsView::showEvent(event);
 }
-
-
-void
-FlowView::
-mousePressEvent(QMouseEvent* event)
-{
-  QGraphicsView::mousePressEvent(event);
-}
-
-
-void
-FlowView::
-mouseMoveEvent(QMouseEvent* event)
-{
-  QGraphicsView::mouseMoveEvent(event);
-}

--- a/src/FlowView.hpp
+++ b/src/FlowView.hpp
@@ -36,10 +36,6 @@ protected:
 
   void showEvent(QShowEvent *event) override;
 
-  void mouseMoveEvent(QMouseEvent* event) override;
-
-  void mousePressEvent(QMouseEvent* event) override;
-
 private:
 
   FlowScene* _scene;


### PR DESCRIPTION
The code should do exactly the same thing now, just with less code.