### PR TITLE
fixing a problem with the Z level that affects proxywidgets too

### DIFF
--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -314,14 +314,18 @@ void
 NodeGraphicsObject::
 hoverEnterEvent(QGraphicsSceneHoverEvent * event)
 {
-  // bring all the nodes to background
-  for(auto& it: _scene.nodes() )
+  // bring all the colliding nodes to background
+  QList<QGraphicsItem *> overlapItems = this->collidingItems();
+
+  foreach (QGraphicsItem *item, overlapItems)
   {
-      Node* node = it.second.get();
-      node->nodeGraphicsObject().setZValue(0.0);
+      if (item->zValue() > 0.0 )
+      {
+          item->setZValue(0.0);
+      }
   }
-  // bring this node to front
-  setZValue(1.0);
+  // bring this node forward
+  this->setZValue(1.0);
 
   _node.nodeGeometry().setHovered(true);
   update();

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -54,6 +54,8 @@ NodeGraphicsObject(FlowScene &scene,
 
   setAcceptHoverEvents(true);
 
+  setZValue(0);
+
   embedQWidget();
 
   // connect to the move signals to emit the move signals in FlowScene
@@ -312,6 +314,15 @@ void
 NodeGraphicsObject::
 hoverEnterEvent(QGraphicsSceneHoverEvent * event)
 {
+  // bring all the nodes to background
+  for(auto& it: _scene.nodes() )
+  {
+      Node* node = it.second.get();
+      node->nodeGraphicsObject().setZValue(0.0);
+  }
+  // bring this node to front
+  setZValue(1.0);
+
   _node.nodeGeometry().setHovered(true);
   update();
   _scene.nodeHovered(node(), event->screenPos());

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -315,14 +315,14 @@ NodeGraphicsObject::
 hoverEnterEvent(QGraphicsSceneHoverEvent * event)
 {
   // bring all the colliding nodes to background
-  QList<QGraphicsItem *> overlapItems = this->collidingItems();
+  QList<QGraphicsItem *> overlapItems = collidingItems();
 
-  foreach (QGraphicsItem *item, overlapItems)
+  for (QGraphicsItem *item : overlapItems)
   {
-      if (item->zValue() > 0.0 )
-      {
-          item->setZValue(0.0);
-      }
+    if (item->zValue() > 0.0)
+    {
+      item->setZValue(0.0);
+    }
   }
   // bring this node forward
   setZValue(1.0);

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -325,7 +325,7 @@ hoverEnterEvent(QGraphicsSceneHoverEvent * event)
       }
   }
   // bring this node forward
-  this->setZValue(1.0);
+  setZValue(1.0);
 
   _node.nodeGeometry().setHovered(true);
   update();


### PR DESCRIPTION
![nodeeditor_zvalue](https://cloud.githubusercontent.com/assets/2822888/24949639/9dea3a30-1f6e-11e7-8384-ca402a8b4be6.png)

Hi,

 am having a problem with a CombBox hidden behind other NodeGraphiObjects.
I realized that in general the order in Z might be annoying in some cases because is related to the creation order.

This PR proposes a solution to this problem.

NOTE: if you prefer, the increase in Zvalue can be done in **hoverEnterEvent** instead of **mousePressEvent**. I would personally prefer hoverEnterEvent.
