### PR TITLE
allow the ability to lock a node/connection in the editor

### DIFF
--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -135,6 +135,13 @@ move()
   moveEndPoint(PortType::Out);
 }
 
+void ConnectionGraphicsObject::lock(bool locked)
+{
+  setFlag(QGraphicsItem::ItemIsMovable, !locked);
+  setFlag(QGraphicsItem::ItemIsFocusable, !locked);
+  setFlag(QGraphicsItem::ItemIsSelectable, !locked);
+}
+
 
 void
 ConnectionGraphicsObject::

--- a/src/ConnectionGraphicsObject.hpp
+++ b/src/ConnectionGraphicsObject.hpp
@@ -52,6 +52,9 @@ public:
   void
   move();
 
+  void
+  lock(bool locked);
+
 protected:
 
   void

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -14,6 +14,7 @@
 #include "NodeGeometry.hpp"
 #include "NodeData.hpp"
 #include "NodeGraphicsObject.hpp"
+#include "ConnectionGraphicsObject.hpp"
 #include "Serializable.hpp"
 
 namespace QtNodes

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -28,6 +28,7 @@ NodeGraphicsObject(FlowScene &scene,
   : _scene(scene)
   , _node(node)
   , _proxyWidget(nullptr)
+  , _locked(false)
 {
   _scene.addItem(this);
 
@@ -81,6 +82,13 @@ node()
   return _node;
 }
 
+
+Node const&
+NodeGraphicsObject::
+node() const
+{
+  return _node;
+}
 
 void
 NodeGraphicsObject::
@@ -149,6 +157,14 @@ moveConnections() const
   moveConnections(PortType::Out);
 }
 
+void NodeGraphicsObject::lock(bool locked)
+{
+  _locked = locked;
+  setFlag(QGraphicsItem::ItemIsMovable, !locked);
+  setFlag(QGraphicsItem::ItemIsFocusable, !locked);
+  setFlag(QGraphicsItem::ItemIsSelectable, !locked);
+}
+
 
 void
 NodeGraphicsObject::
@@ -179,6 +195,8 @@ void
 NodeGraphicsObject::
 mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
+  if(_locked) return;
+
   // deselect all other items after this one is selected
   if (!isSelected() &&
       !(event->modifiers() & Qt::ControlModifier))

--- a/src/NodeGraphicsObject.hpp
+++ b/src/NodeGraphicsObject.hpp
@@ -32,6 +32,9 @@ public:
   Node&
   node();
 
+  Node const&
+  node() const;
+
   QRectF
   boundingRect() const override;
 
@@ -47,6 +50,9 @@ public:
 
   int
   type() const override { return Type; }
+
+  void
+  lock(bool locked);
 
 protected:
   void
@@ -87,6 +93,8 @@ private:
   FlowScene & _scene;
 
   Node& _node;
+
+  bool _locked;
 
   // either nullptr or owned by parent QGraphicsItem
   QGraphicsProxyWidget * _proxyWidget;


### PR DESCRIPTION
This PR allow the user to "lock" a node or connection, i.e. to prevent the user from moving and/or deleting it.