### PR TITLE
Correct -Wall and -Wextra warnings for GCC7.1.1 and Clang++ 4.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_definitions(-Wall -Wextra)
 
 #############################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,16 @@ find_package(Qt5 COMPONENTS
 add_definitions(${Qt5Widgets_DEFINITIONS})
 set(CMAKE_CXX_FLAGS "${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 
-IF (MSVC)
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
-ENDIF (MSVC)
+if(MSVC)
+  add_definitions(/Wall /EHsc)
+else()
+  add_definitions(-Wall -Wextra)
+endif(MSVC)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_definitions(-Wall -Wextra)
 
 #############################################################
 

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -24,7 +24,7 @@ public:
   { return QStringLiteral("Division"); }
 
   bool
-  portCaptionVisible(PortType portType, PortIndex portIndex) const override
+  portCaptionVisible(PortType, PortIndex) const override
   { return true; }
 
   QString

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -25,7 +25,7 @@ public:
   { return QStringLiteral("Subtraction"); }
 
   virtual bool
-  portCaptionVisible(PortType portType, PortIndex portIndex) const override
+  portCaptionVisible(PortType, PortIndex) const override
   { return true; }
 
   virtual QString

--- a/src/ConnectionBlurEffect.cpp
+++ b/src/ConnectionBlurEffect.cpp
@@ -7,8 +7,7 @@ using QtNodes::ConnectionBlurEffect;
 using QtNodes::ConnectionGraphicsObject;
 
 ConnectionBlurEffect::
-ConnectionBlurEffect(ConnectionGraphicsObject* object)
-  : _object(object)
+ConnectionBlurEffect(ConnectionGraphicsObject*)
 {
   //
 }

--- a/src/ConnectionBlurEffect.hpp
+++ b/src/ConnectionBlurEffect.hpp
@@ -18,7 +18,5 @@ public:
   draw(QPainter* painter) override;
 
 private:
-
-  ConnectionGraphicsObject* _object;
 };
 }

--- a/src/FlowItemInterface.cpp
+++ b/src/FlowItemInterface.cpp
@@ -2,7 +2,7 @@
 
 void
 FlowItemInterface::
-inputDataChanged(QString inSignature, QVariant data)
+inputDataChanged(QString, QVariant)
 {
   //
 }

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -29,8 +29,8 @@ using QtNodes::FlowScene;
 FlowView::
 FlowView(FlowScene *scene)
   : QGraphicsView(scene)
-  , _scene(scene)
   , _clickPos(QPointF())
+  , _scene(scene)
 {
   setDragMode(QGraphicsView::ScrollHandDrag);
   setRenderHint(QPainter::Antialiasing);
@@ -126,7 +126,7 @@ contextMenuEvent(QContextMenuEvent *event)
 
   treeView->expandAll();
 
-  connect(treeView, &QTreeWidget::itemClicked, [&](QTreeWidgetItem *item, int column)
+  connect(treeView, &QTreeWidget::itemClicked, [&](QTreeWidgetItem *item, int)
   {
     QString modelName = item->data(0, Qt::UserRole).toString();
 

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -27,8 +27,8 @@ NodeGraphicsObject(FlowScene &scene,
                    Node& node)
   : _scene(scene)
   , _node(node)
-  , _proxyWidget(nullptr)
   , _locked(false)
+  , _proxyWidget(nullptr)
 {
   _scene.addItem(this);
 

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -13,8 +13,8 @@ using QtNodes::Connection;
 
 NodeState::
 NodeState(std::unique_ptr<NodeDataModel> const &model)
-  : _outConnections(model->nPorts(PortType::Out))
-  , _inConnections(model->nPorts(PortType::In))
+  : _inConnections(model->nPorts(PortType::In))
+  , _outConnections(model->nPorts(PortType::Out))
   , _reaction(NOT_REACTING)
   , _reactingPortType(PortType::None)
   , _resizing(false)


### PR DESCRIPTION
We are using your project as a sub-module in CANdevStudio. As the project is build with -Wall and -Wextra flags compilation of your code produces few minor warnings - unused variables and order of initialisation. If you would like to enable these flags in your project also this PR will do it for you :-)

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@mobica.com>