### PR TITLE
change _scene visibility to protected

### DIFF
--- a/src/FlowView.hpp
+++ b/src/FlowView.hpp
@@ -49,13 +49,13 @@ protected:
 
   void showEvent(QShowEvent *event) override;
 
+  FlowScene* _scene;
+
 private:
 
   QAction* _clearSelectionAction;
   QAction* _deleteSelectionAction;
 
   QPointF _clickPos;
-
-  FlowScene* _scene;
 };
 }


### PR DESCRIPTION
Handy when deriving from FlowView to change behavior, e.g. implement own context menu or interaction with the scene from external widgets.