### PR TITLE
Support inclusion of FlowView via Qt Designer

### DIFF
--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -29,9 +29,9 @@ using QtNodes::FlowScene;
 FlowView::
 FlowView(QWidget *parent)
   : QGraphicsView(parent)
-  , _scene(Q_NULLPTR)
   , _clearSelectionAction(Q_NULLPTR)
   , _deleteSelectionAction(Q_NULLPTR)
+  , _scene(Q_NULLPTR)
 {
   setDragMode(QGraphicsView::ScrollHandDrag);
   setRenderHint(QPainter::Antialiasing);

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -69,17 +69,6 @@ init()
   setCacheMode(QGraphicsView::CacheBackground);
 
   //setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers)));
-
-  // setup actions
-  _clearSelectionAction = new QAction(QStringLiteral("Clear Selection"), this);
-  _clearSelectionAction->setShortcut(Qt::Key_Escape);
-  connect(_clearSelectionAction, &QAction::triggered, _scene, &QGraphicsScene::clearSelection);
-  addAction(_clearSelectionAction);
-
-  _deleteSelectionAction = new QAction(QStringLiteral("Delete Selection"), this);
-  _deleteSelectionAction->setShortcut(Qt::Key_Delete);
-  connect(_deleteSelectionAction, &QAction::triggered, this, &FlowView::deleteSelectedNodes);
-  addAction(_deleteSelectionAction);
 }
 
 
@@ -96,6 +85,27 @@ FlowView::
 deleteSelectionAction() const
 {
   return _deleteSelectionAction;
+}
+
+
+void
+FlowView::setScene(FlowScene *scene)
+{
+  _scene = scene;
+  QGraphicsView::setScene(_scene);
+
+  // setup actions
+  delete _clearSelectionAction;
+  _clearSelectionAction = new QAction(QStringLiteral("Clear Selection"), this);
+  _clearSelectionAction->setShortcut(Qt::Key_Escape);
+  connect(_clearSelectionAction, &QAction::triggered, _scene, &QGraphicsScene::clearSelection);
+  addAction(_clearSelectionAction);
+
+  delete _deleteSelectionAction;
+  _deleteSelectionAction = new QAction(QStringLiteral("Delete Selection"), this);
+  _deleteSelectionAction->setShortcut(Qt::Key_Delete);
+  connect(_deleteSelectionAction, &QAction::triggered, this, &FlowView::deleteSelectedNodes);
+  addAction(_deleteSelectionAction);
 }
 
 

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -30,28 +30,9 @@ FlowView::
 FlowView(QWidget *parent)
   : QGraphicsView(parent)
   , _scene(Q_NULLPTR)
+  , _clearSelectionAction(Q_NULLPTR)
+  , _deleteSelectionAction(Q_NULLPTR)
 {
-  init();
-}
-
-
-FlowView::
-FlowView(FlowScene *scene, QWidget *parent)
-  : QGraphicsView(scene, parent)
-{
-  init();
-  setScene(scene);
-}
-
-
-void
-FlowView::
-init()
-{
-  _clickPos = QPointF();
-  _clearSelectionAction = Q_NULLPTR;
-  _deleteSelectionAction = Q_NULLPTR;
-
   setDragMode(QGraphicsView::ScrollHandDrag);
   setRenderHint(QPainter::Antialiasing);
 
@@ -69,6 +50,14 @@ init()
   setCacheMode(QGraphicsView::CacheBackground);
 
   //setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers)));
+}
+
+
+FlowView::
+FlowView(FlowScene *scene, QWidget *parent)
+  : FlowView(parent)
+{
+  setScene(scene);
 }
 
 

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -27,11 +27,31 @@ using QtNodes::FlowView;
 using QtNodes::FlowScene;
 
 FlowView::
-FlowView(FlowScene *scene)
-  : QGraphicsView(scene)
-  , _clickPos(QPointF())
-  , _scene(scene)
+FlowView(QWidget *parent)
+  : QGraphicsView(parent)
+  , _scene(Q_NULLPTR)
 {
+  init();
+}
+
+
+FlowView::
+FlowView(FlowScene *scene, QWidget *parent)
+  : QGraphicsView(scene, parent)
+{
+  init();
+  setScene(scene);
+}
+
+
+void
+FlowView::
+init()
+{
+  _clickPos = QPointF();
+  _clearSelectionAction = Q_NULLPTR;
+  _deleteSelectionAction = Q_NULLPTR;
+
   setDragMode(QGraphicsView::ScrollHandDrag);
   setRenderHint(QPainter::Antialiasing);
 

--- a/src/FlowView.hpp
+++ b/src/FlowView.hpp
@@ -14,7 +14,8 @@ class NODE_EDITOR_PUBLIC FlowView
 {
 public:
 
-  FlowView(FlowScene *scene);
+  FlowView(QWidget *parent = Q_NULLPTR);
+  FlowView(FlowScene *scene = Q_NULLPTR, QWidget *parent = Q_NULLPTR);
 
   FlowView(const FlowView&) = delete;
   FlowView operator=(const FlowView&) = delete;
@@ -50,6 +51,8 @@ protected:
   void showEvent(QShowEvent *event) override;
 
 private:
+
+  void init();
 
   QAction* _clearSelectionAction;
   QAction* _deleteSelectionAction;

--- a/src/FlowView.hpp
+++ b/src/FlowView.hpp
@@ -58,8 +58,6 @@ protected:
 
 private:
 
-  void init();
-
   QAction* _clearSelectionAction;
   QAction* _deleteSelectionAction;
 

--- a/src/FlowView.hpp
+++ b/src/FlowView.hpp
@@ -24,6 +24,8 @@ public:
 
   QAction* deleteSelectionAction() const;
 
+  void setScene(FlowScene *scene);
+
 public slots:
 
   void scaleUp();

--- a/src/FlowView.hpp
+++ b/src/FlowView.hpp
@@ -15,7 +15,7 @@ class NODE_EDITOR_PUBLIC FlowView
 public:
 
   FlowView(QWidget *parent = Q_NULLPTR);
-  FlowView(FlowScene *scene = Q_NULLPTR, QWidget *parent = Q_NULLPTR);
+  FlowView(FlowScene *scene, QWidget *parent = Q_NULLPTR);
 
   FlowView(const FlowView&) = delete;
   FlowView operator=(const FlowView&) = delete;


### PR DESCRIPTION
To be able to fit this widget in the typical .ui file workflow, we need to be able to construct it with a parent widget and set the scene after UI setup.