### PR TITLE
Update to use modelview philosophy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - travis_retry git clone https://github.com/catchorg/Catch2.git # Install Catch2
   - |
     pushd Catch2
-    git checkout tags/v2.2.2
+    git checkout tags/v2.3.0
     mkdir build && cd build
   - cmake .. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${DEPS_DIR}/install"
   - cmake --build . -- install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ set(CPP_SOURCE_FILES
   src/ConnectionStyle.cpp
   src/DataModelRegistry.cpp
   src/FlowScene.cpp
+  src/FlowSceneModel.cpp
+  src/DataFlowScene.cpp
   src/FlowView.cpp
   src/FlowViewStyle.cpp
   src/Node.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CPP_SOURCE_FILES
   src/ConnectionPainter.cpp
   src/ConnectionState.cpp
   src/ConnectionStyle.cpp
+  src/DataFlowModel.cpp
   src/DataModelRegistry.cpp
   src/FlowScene.cpp
   src/FlowSceneModel.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,3 +7,5 @@ add_subdirectory(calculator)
 add_subdirectory(images)
 
 add_subdirectory(styles)
+
+add_subdirectory(headless)

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -1,5 +1,5 @@
 #include <nodes/NodeData>
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 #include <nodes/ConnectionStyle>
 #include <nodes/TypeConverter>
@@ -21,7 +21,7 @@
 
 
 using QtNodes::DataModelRegistry;
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 using QtNodes::FlowView;
 using QtNodes::ConnectionStyle;
 using QtNodes::TypeConverter;
@@ -100,16 +100,16 @@ main(int argc, char *argv[])
   QVBoxLayout *l = new QVBoxLayout(&mainWidget);
 
   l->addWidget(menuBar);
-  auto scene = new FlowScene(registerDataModels(), &mainWidget);
+  auto scene = new DataFlowScene(registerDataModels(), &mainWidget);
   l->addWidget(new FlowView(scene));
   l->setContentsMargins(0, 0, 0, 0);
   l->setSpacing(0);
 
   QObject::connect(saveAction, &QAction::triggered,
-                   scene, &FlowScene::save);
+                   scene, &DataFlowScene::save);
 
   QObject::connect(loadAction, &QAction::triggered,
-                   scene, &FlowScene::load);
+                   scene, &DataFlowScene::load);
 
   mainWidget.setWindowTitle("Dataflow tools: simplest calculator");
   mainWidget.resize(800, 600);

--- a/examples/connection_colors/main.cpp
+++ b/examples/connection_colors/main.cpp
@@ -1,7 +1,7 @@
 #include <QtWidgets/QApplication>
 
 #include <nodes/NodeData>
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 #include <nodes/DataModelRegistry>
 #include <nodes/ConnectionStyle>
@@ -9,7 +9,7 @@
 #include "models.hpp"
 
 using QtNodes::DataModelRegistry;
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 using QtNodes::FlowView;
 using QtNodes::ConnectionStyle;
 
@@ -57,7 +57,7 @@ main(int argc, char* argv[])
 
   setStyle();
 
-  FlowScene scene(registerDataModels());
+  DataFlowScene scene(registerDataModels());
 
   FlowView view(&scene);
 

--- a/examples/example2/main.cpp
+++ b/examples/example2/main.cpp
@@ -1,5 +1,5 @@
 #include <nodes/NodeData>
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 
 #include <QtWidgets/QApplication>
@@ -11,7 +11,7 @@
 
 using QtNodes::DataModelRegistry;
 using QtNodes::FlowView;
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 
 static std::shared_ptr<DataModelRegistry>
 registerDataModels()
@@ -31,7 +31,7 @@ main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
 
-  FlowScene scene(registerDataModels());
+  DataFlowScene scene(registerDataModels());
 
   FlowView view(&scene);
 

--- a/examples/headless/CMakeLists.txt
+++ b/examples/headless/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB_RECURSE CPPS  ./*.cpp )
+
+add_executable(headless ${CPPS})
+
+target_link_libraries(headless nodes)

--- a/examples/headless/main.cpp
+++ b/examples/headless/main.cpp
@@ -1,0 +1,32 @@
+
+#include <nodes/DataFlowModel>
+#include <nodes/Node>
+
+#include "models.hpp"
+
+using QtNodes::DataModelRegistry;
+using QtNodes::DataFlowModel;
+
+static std::shared_ptr<DataModelRegistry>
+registerDataModels()
+{
+  auto ret = std::make_shared<DataModelRegistry>();
+
+  ret->registerModel<Source>();
+  ret->registerModel<Sink>();
+
+  return ret;
+}
+
+int
+main()
+{
+  DataFlowModel model(registerDataModels());
+
+  auto source = model.nodeIndex(model.addNode("Source", {0, 0}));
+  auto sink = model.nodeIndex(model.addNode("Sink", {10, 0}));
+
+  model.addConnection(source, 0, sink, 0);
+
+  Q_ASSERT(static_cast<Sink*>(model.nodes()[sink.id()]->nodeDataModel())->data == "Hello World!");
+}

--- a/examples/headless/models.cpp
+++ b/examples/headless/models.cpp
@@ -1,0 +1,4 @@
+#include "models.hpp"
+
+// For some reason CMake could not generate moc-files correctly
+// without having a cpp for an QObject from hpp.

--- a/examples/headless/models.hpp
+++ b/examples/headless/models.hpp
@@ -1,0 +1,144 @@
+#include <nodes/NodeData>
+#include <nodes/NodeDataModel>
+
+using QtNodes::NodeData;
+using QtNodes::NodeDataType;
+using QtNodes::NodeDataModel;
+using QtNodes::PortType;
+using QtNodes::PortIndex;
+
+class StringData : public NodeData {
+public:
+  StringData(std::string str) : data(str) {}
+
+  NodeDataType
+  type() const override
+  {
+    return NodeDataType {"String",
+                         "String"};
+  }
+
+  std::string data;
+};
+
+class Source : public NodeDataModel
+{
+  Q_OBJECT
+
+public:
+
+  virtual
+  ~Source() {}
+
+public:
+
+  QString
+  caption() const override
+  {
+    return QString("Data Source");
+  }
+
+  QString
+  name() const override
+  { return QString("Source"); }
+
+public:
+
+  unsigned int
+  nPorts(PortType portType) const override
+  {
+    switch (portType) {
+      case PortType::In: return 0;
+      case PortType::Out: return 1;
+    }
+    Q_UNREACHABLE();
+  }
+
+  NodeDataType
+  dataType(PortType portType,
+           PortIndex portIndex) const override
+  {
+    Q_ASSERT(portType == PortType::Out);
+
+    return NodeDataType { "String", "String" };
+  }
+
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override
+  {
+    return std::make_shared<StringData>("Hello World!");
+  }
+
+  void
+  setInData(std::shared_ptr<NodeData>, int) override
+  {
+    Q_UNREACHABLE();
+  }
+
+  QWidget *
+  embeddedWidget() override { return nullptr; }
+};
+
+
+class Sink : public NodeDataModel
+{
+  Q_OBJECT
+
+public:
+
+  virtual
+  ~Sink() {}
+
+public:
+
+  QString
+  caption() const override
+  {
+    return QString("Data Sink");
+  }
+
+  QString
+  name() const override
+  { return QString("Sink"); }
+
+public:
+
+  unsigned int
+  nPorts(PortType portType) const override
+  {
+    switch (portType) {
+      case PortType::In: return 1;
+      case PortType ::Out: return 0;
+    }
+    Q_UNREACHABLE();
+  }
+
+  NodeDataType
+  dataType(PortType portType,
+           PortIndex portIndex) const override
+  {
+    Q_ASSERT(portType == PortType::In);
+
+    return NodeDataType { "String", "String" };
+  }
+
+  std::shared_ptr<NodeData>
+  outData(PortIndex port) override
+  {
+    Q_UNREACHABLE();
+  }
+
+  void
+  setInData(std::shared_ptr<NodeData> in, int) override
+  {
+    if (!in) { data = ""; }
+    else { data = std::static_pointer_cast<StringData>(in)->data; }
+  }
+
+  QWidget *
+  embeddedWidget() override { return nullptr; }
+
+public:
+  std::string data;
+};
+

--- a/examples/images/main.cpp
+++ b/examples/images/main.cpp
@@ -1,5 +1,5 @@
 #include <nodes/NodeData>
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 
 #include <QtWidgets/QApplication>
@@ -8,7 +8,7 @@
 #include "ImageLoaderModel.hpp"
 
 using QtNodes::DataModelRegistry;
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 using QtNodes::FlowView;
 
 static std::shared_ptr<DataModelRegistry>
@@ -28,7 +28,7 @@ main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
 
-  FlowScene scene(registerDataModels());
+  DataFlowScene scene(registerDataModels());
 
   FlowView view(&scene);
 

--- a/examples/styles/main.cpp
+++ b/examples/styles/main.cpp
@@ -1,7 +1,7 @@
 #include <QtWidgets/QApplication>
 
 #include <nodes/NodeData>
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 #include <nodes/DataModelRegistry>
 #include <nodes/NodeStyle>
@@ -11,7 +11,7 @@
 #include "models.hpp"
 
 using QtNodes::DataModelRegistry;
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 using QtNodes::FlowView;
 using QtNodes::FlowViewStyle;
 using QtNodes::NodeStyle;
@@ -95,7 +95,7 @@ main(int argc, char* argv[])
 
   setStyle();
 
-  FlowScene scene(registerDataModels());
+  DataFlowScene scene(registerDataModels());
 
   FlowView view(&scene);
 

--- a/include/nodes/DataFlowModel
+++ b/include/nodes/DataFlowModel
@@ -1,0 +1,1 @@
+#include "internal/DataFlowModel.hpp"

--- a/include/nodes/DataFlowScene
+++ b/include/nodes/DataFlowScene
@@ -1,0 +1,1 @@
+#include "internal/DataFlowScene.hpp"

--- a/include/nodes/FlowSceneModel
+++ b/include/nodes/FlowSceneModel
@@ -1,0 +1,1 @@
+#include "internal/FlowSceneModel.hpp"

--- a/include/nodes/NodeGraphicsObject
+++ b/include/nodes/NodeGraphicsObject
@@ -1,0 +1,1 @@
+#include "internal/NodeGraphicsObject.hpp"

--- a/include/nodes/NodeIndex
+++ b/include/nodes/NodeIndex
@@ -1,0 +1,1 @@
+#include "internal/NodeIndex.hpp"

--- a/include/nodes/internal/Connection.hpp
+++ b/include/nodes/internal/Connection.hpp
@@ -14,6 +14,7 @@
 #include "QUuidStdHash.hpp"
 #include "Export.hpp"
 #include "memory.hpp"
+#include "ConnectionID.hpp"
 
 class QPointF;
 
@@ -24,7 +25,9 @@ class Node;
 class NodeData;
 class ConnectionGraphicsObject;
 
-///
+/// Connection is a representation in DataFlowScene of a connection
+/// It is part of the model, and not the rendering system.
+/// This class is not to be used if you're implementing FlowScene model yourself
 class NODE_EDITOR_PUBLIC Connection
   : public QObject
   , public Serializable
@@ -33,13 +36,6 @@ class NODE_EDITOR_PUBLIC Connection
   Q_OBJECT
 
 public:
-
-  /// New Connection is attached to the port of the given Node.
-  /// The port has parameters (portType, portIndex).
-  /// The opposite connection end will require anothre port.
-  Connection(PortType portType,
-             Node& node,
-             PortIndex portIndex);
 
   Connection(Node& nodeIn,
              PortIndex portIndexIn,
@@ -60,57 +56,21 @@ public:
 
 public:
 
-  QUuid
+  ConnectionID
   id() const;
-
-  /// Remembers the end being dragged.
-  /// Invalidates Node address.
-  /// Grabs mouse.
-  void
-  setRequiredPort(PortType portType);
-  PortType
-  requiredPort() const;
-
-  void
-  setGraphicsObject(std::unique_ptr<ConnectionGraphicsObject>&& graphics);
-
-  /// Assigns a node to the required port.
-  /// It is assumed that there is a required port, no extra checks
-  void
-  setNodeToPort(Node& node,
-                PortType portType,
-                PortIndex portIndex);
-
-  void
-  removeFromNodes() const;
-
-public:
-
-  ConnectionGraphicsObject&
-  getConnectionGraphicsObject() const;
-
-  ConnectionState const &
-  connectionState() const;
-  ConnectionState&
-  connectionState();
-
-  ConnectionGeometry&
-  connectionGeometry();
-
-  ConnectionGeometry const&
-  connectionGeometry() const;
 
   Node*
   getNode(PortType portType) const;
 
+private:
+
   Node*&
-  getNode(PortType portType);
+  getNodePtrRef(PortType portType);
+
+public:
 
   PortIndex
   getPortIndex(PortType portType) const;
-
-  void
-  clearNode(PortType portType);
 
   NodeDataType
   dataType(PortType portType) const;
@@ -131,6 +91,11 @@ private:
   QUuid _uid;
 
 private:
+  
+  void 
+  setNodeToPort(Node& node,
+                PortType portType,
+                PortIndex portIndex);
 
   Node* _outNode = nullptr;
   Node* _inNode  = nullptr;

--- a/include/nodes/internal/Connection.hpp
+++ b/include/nodes/internal/Connection.hpp
@@ -45,7 +45,8 @@ public:
                TypeConverter{});
 
   Connection(const Connection&) = delete;
-  Connection operator=(const Connection&) = delete;
+  Connection
+  operator=(const Connection&) = delete;
 
   ~Connection();
 
@@ -91,8 +92,8 @@ private:
   QUuid _uid;
 
 private:
-  
-  void 
+
+  void
   setNodeToPort(Node& node,
                 PortType portType,
                 PortIndex portIndex);
@@ -105,7 +106,7 @@ private:
 
 private:
 
-  ConnectionState    _connectionState;
+  ConnectionState _connectionState;
   ConnectionGeometry _connectionGeometry;
 
   std::unique_ptr<ConnectionGraphicsObject>_connectionGraphicsObject;

--- a/include/nodes/internal/ConnectionGraphicsObject.hpp
+++ b/include/nodes/internal/ConnectionGraphicsObject.hpp
@@ -26,32 +26,62 @@ class ConnectionGraphicsObject
 
 public:
 
-  ConnectionGraphicsObject(
-    NodeIndex const& leftNode,
-    PortIndex leftPortIndex,
-    NodeIndex const& rightNode,
-    PortIndex rightPortIndex,
-    FlowScene& scene);
+  ConnectionGraphicsObject(NodeIndex const& leftNode,
+                           PortIndex leftPortIndex,
+                           NodeIndex const& rightNode,
+                           PortIndex rightPortIndex,
+                           FlowScene& scene);
 
   virtual
   ~ConnectionGraphicsObject();
 
   enum { Type = UserType + 2 };
   int
-  type() const override { return Type; }
+  type() const override
+  {
+    return Type;
+  }
 
 public:
 
-  NodeIndex node(PortType pType) const { return pType == PortType::In ? _rightNode : _leftNode; }
-  PortIndex portIndex(PortType pType) const { return pType == PortType::In ? _rightPortIndex : _leftPortIndex; }
-  
-  FlowScene& flowScene() const { return _scene; }
+  NodeIndex
+  node(PortType pType) const
+  {
+    return pType == PortType::In ? _rightNode : _leftNode;
+  }
+  PortIndex
+  portIndex(PortType pType) const
+  {
+    return pType == PortType::In ? _rightPortIndex : _leftPortIndex;
+  }
 
-  ConnectionGeometry const& geometry() const { return _geometry; }
-  ConnectionGeometry& geometry() { return _geometry; }
-  
-  ConnectionState const& state() const { return _state; }
-  ConnectionState& state() { return _state; }
+  FlowScene&
+  flowScene() const
+  {
+    return _scene;
+  }
+
+  ConnectionGeometry const&
+  geometry() const
+  {
+    return _geometry;
+  }
+  ConnectionGeometry&
+  geometry()
+  {
+    return _geometry;
+  }
+
+  ConnectionState const&
+  state() const
+  {
+    return _state;
+  }
+  ConnectionState&
+  state()
+  {
+    return _state;
+  }
 
   QRectF
   boundingRect() const override;
@@ -65,7 +95,8 @@ public:
   ConnectionID
   id() const;
 
-  NodeDataType dataType(PortType ty) const;
+  NodeDataType
+  dataType(PortType ty) const;
 
   /// Updates the position of both ends
   void
@@ -75,10 +106,16 @@ public:
   lock(bool locked);
 
   const FlowScene&
-  scene() const { return _scene; }
+  scene() const
+  {
+    return _scene;
+  }
 
   FlowScene&
-  scene() { return _scene; }
+  scene()
+  {
+    return _scene;
+  }
 
 protected:
 
@@ -113,7 +150,7 @@ private:
 
   ConnectionGeometry _geometry;
   ConnectionState _state;
-  
+
   NodeIndex _leftNode;
   NodeIndex _rightNode;
 

--- a/include/nodes/internal/ConnectionGraphicsObject.hpp
+++ b/include/nodes/internal/ConnectionGraphicsObject.hpp
@@ -16,7 +16,7 @@ namespace QtNodes
 {
 
 class FlowScene;
-class ConnectionID;
+struct ConnectionID;
 
 /// Graphic Object for connection.
 class ConnectionGraphicsObject

--- a/include/nodes/internal/ConnectionGraphicsObject.hpp
+++ b/include/nodes/internal/ConnectionGraphicsObject.hpp
@@ -4,17 +4,21 @@
 
 #include <QtWidgets/QGraphicsObject>
 
+#include "PortType.hpp"
+#include "NodeData.hpp"
+#include "NodeIndex.hpp"
+#include "ConnectionGeometry.hpp"
+#include "ConnectionState.hpp"
+
 class QGraphicsSceneMouseEvent;
 
 namespace QtNodes
 {
 
 class FlowScene;
-class Connection;
-class ConnectionGeometry;
-class Node;
+class ConnectionID;
 
-/// Graphic Object for connection. Adds itself to scene
+/// Graphic Object for connection.
 class ConnectionGraphicsObject
   : public QGraphicsObject
 {
@@ -22,8 +26,12 @@ class ConnectionGraphicsObject
 
 public:
 
-  ConnectionGraphicsObject(FlowScene &scene,
-                           Connection &connection);
+  ConnectionGraphicsObject(
+    NodeIndex const& leftNode,
+    PortIndex leftPortIndex,
+    NodeIndex const& rightNode,
+    PortIndex rightPortIndex,
+    FlowScene& scene);
 
   virtual
   ~ConnectionGraphicsObject();
@@ -34,8 +42,16 @@ public:
 
 public:
 
-  Connection&
-  connection();
+  NodeIndex node(PortType pType) const { return pType == PortType::In ? _rightNode : _leftNode; }
+  PortIndex portIndex(PortType pType) const { return pType == PortType::In ? _rightPortIndex : _leftPortIndex; }
+  
+  FlowScene& flowScene() const { return _scene; }
+
+  ConnectionGeometry const& geometry() const { return _geometry; }
+  ConnectionGeometry& geometry() { return _geometry; }
+  
+  ConnectionState const& state() const { return _state; }
+  ConnectionState& state() { return _state; }
 
   QRectF
   boundingRect() const override;
@@ -46,12 +62,23 @@ public:
   void
   setGeometryChanged();
 
+  ConnectionID
+  id() const;
+
+  NodeDataType dataType(PortType ty) const;
+
   /// Updates the position of both ends
   void
   move();
 
   void
   lock(bool locked);
+
+  const FlowScene&
+  scene() const { return _scene; }
+
+  FlowScene&
+  scene() { return _scene; }
 
 protected:
 
@@ -84,6 +111,14 @@ private:
 
   FlowScene & _scene;
 
-  Connection& _connection;
+  ConnectionGeometry _geometry;
+  ConnectionState _state;
+  
+  NodeIndex _leftNode;
+  NodeIndex _rightNode;
+
+  PortIndex _leftPortIndex;
+  PortIndex _rightPortIndex;
+
 };
 }

--- a/include/nodes/internal/ConnectionID.hpp
+++ b/include/nodes/internal/ConnectionID.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "NodeIndex.hpp"
+#include "PortType.hpp"
+
+#include <utility>
+
+namespace QtNodes {
+struct ConnectionID {
+  QUuid lNodeID;
+  QUuid rNodeID;
+
+  PortIndex lPortID;
+  PortIndex rPortID;
+};
+
+inline bool operator==(ConnectionID const& lhs, ConnectionID const& rhs) {
+  return lhs.lNodeID == rhs.lNodeID &&
+         lhs.rNodeID == rhs.rNodeID &&
+         lhs.lPortID == rhs.lPortID &&
+         lhs.rPortID == rhs.rPortID;
+}
+
+} // namespace QtNodes
+
+// hash for ConnectionID
+namespace std {
+
+template<>
+struct hash<::QtNodes::ConnectionID> {
+  size_t operator()(::QtNodes::ConnectionID const& toHash) const {
+    return qHash(toHash.rNodeID) ^ qHash(toHash.lNodeID) ^ std::hash<QtNodes::PortIndex>()(toHash.lPortID) ^ std::hash<QtNodes::PortIndex>()(toHash.rPortID);
+  }
+};
+
+} // namespace std
+

--- a/include/nodes/internal/ConnectionID.hpp
+++ b/include/nodes/internal/ConnectionID.hpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 namespace QtNodes {
-struct ConnectionID {
+class ConnectionID {
   QUuid lNodeID;
   QUuid rNodeID;
 

--- a/include/nodes/internal/ConnectionID.hpp
+++ b/include/nodes/internal/ConnectionID.hpp
@@ -5,8 +5,11 @@
 
 #include <utility>
 
-namespace QtNodes {
-class ConnectionID {
+namespace QtNodes
+{
+
+struct ConnectionID
+{
   QUuid lNodeID;
   QUuid rNodeID;
 
@@ -14,7 +17,9 @@ class ConnectionID {
   PortIndex rPortID;
 };
 
-inline bool operator==(ConnectionID const& lhs, ConnectionID const& rhs) {
+inline bool
+operator==(ConnectionID const& lhs, ConnectionID const& rhs)
+{
   return lhs.lNodeID == rhs.lNodeID &&
          lhs.rNodeID == rhs.rNodeID &&
          lhs.lPortID == rhs.lPortID &&
@@ -24,11 +29,15 @@ inline bool operator==(ConnectionID const& lhs, ConnectionID const& rhs) {
 } // namespace QtNodes
 
 // hash for ConnectionID
-namespace std {
+namespace std
+{
 
 template<>
-struct hash<::QtNodes::ConnectionID> {
-  size_t operator()(::QtNodes::ConnectionID const& toHash) const {
+struct hash<::QtNodes::ConnectionID>
+{
+  size_t
+  operator()(::QtNodes::ConnectionID const& toHash) const
+  {
     return qHash(toHash.rNodeID) ^ qHash(toHash.lNodeID) ^ std::hash<QtNodes::PortIndex>()(toHash.lPortID) ^ std::hash<QtNodes::PortIndex>()(toHash.rPortID);
   }
 };

--- a/include/nodes/internal/ConnectionState.hpp
+++ b/include/nodes/internal/ConnectionState.hpp
@@ -22,35 +22,43 @@ public:
   {}
 
   ConnectionState(const ConnectionState&) = delete;
-  ConnectionState operator=(const ConnectionState&) = delete;
+  ConnectionState
+  operator=(const ConnectionState&) = delete;
 
   ~ConnectionState();
 
 public:
 
-  void setRequiredPort(PortType end)
+  void
+  setRequiredPort(PortType end)
   { _requiredPort = end; }
 
-  PortType requiredPort() const
+  PortType
+  requiredPort() const
   { return _requiredPort; }
 
-  bool requiresPort() const
+  bool
+  requiresPort() const
   { return _requiredPort != PortType::None; }
 
-  void setNoRequiredPort()
+  void
+  setNoRequiredPort()
   { _requiredPort = PortType::None; }
 
 public:
 
-  void interactWithNode(NodeGraphicsObject* node);
+  void
+  interactWithNode(NodeGraphicsObject* node);
 
-  void setLastHoveredNode(NodeGraphicsObject* node);
+  void
+  setLastHoveredNode(NodeGraphicsObject* node);
 
   NodeGraphicsObject*
   lastHoveredNode() const
   { return _lastHoveredNode; }
 
-  void resetLastHoveredNode();
+  void
+  resetLastHoveredNode();
 
 private:
 

--- a/include/nodes/internal/ConnectionState.hpp
+++ b/include/nodes/internal/ConnectionState.hpp
@@ -9,7 +9,7 @@ class QPointF;
 namespace QtNodes
 {
 
-class Node;
+class NodeGraphicsObject;
 
 /// Stores currently draggind end.
 /// Remembers last hovered Node.
@@ -42,11 +42,11 @@ public:
 
 public:
 
-  void interactWithNode(Node* node);
+  void interactWithNode(NodeGraphicsObject* node);
 
-  void setLastHoveredNode(Node* node);
+  void setLastHoveredNode(NodeGraphicsObject* node);
 
-  Node*
+  NodeGraphicsObject*
   lastHoveredNode() const
   { return _lastHoveredNode; }
 
@@ -56,6 +56,6 @@ private:
 
   PortType _requiredPort;
 
-  Node* _lastHoveredNode{nullptr};
+  NodeGraphicsObject* _lastHoveredNode{nullptr};
 };
 }

--- a/include/nodes/internal/ConnectionStyle.hpp
+++ b/include/nodes/internal/ConnectionStyle.hpp
@@ -18,30 +18,51 @@ public:
 
 public:
 
-  static void setConnectionStyle(QString jsonText);
+  static void
+  setConnectionStyle(QString jsonText);
 
 private:
 
-  void loadJsonText(QString jsonText) override;
+  void
+  loadJsonText(QString jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void
+  loadJsonFile(QString fileName) override;
 
-  void loadJsonFromByteArray(QByteArray const &byteArray) override;
+  void
+  loadJsonFromByteArray(QByteArray const &byteArray) override;
 
 public:
 
-  QColor constructionColor() const;
-  QColor normalColor() const;
-  QColor normalColor(QString typeId) const;
-  QColor selectedColor() const;
-  QColor selectedHaloColor() const;
-  QColor hoveredColor() const;
+  QColor
+  constructionColor() const;
 
-  float lineWidth() const;
-  float constructionLineWidth() const;
-  float pointDiameter() const;
+  QColor
+  normalColor() const;
 
-  bool useDataDefinedColors() const;
+  QColor
+  normalColor(QString typeId) const;
+
+  QColor
+  selectedColor() const;
+
+  QColor
+  selectedHaloColor() const;
+
+  QColor
+  hoveredColor() const;
+
+  float
+  lineWidth() const;
+
+  float
+  constructionLineWidth() const;
+
+  float
+  pointDiameter() const;
+
+  bool
+  useDataDefinedColors() const;
 
 private:
 

--- a/include/nodes/internal/DataFlowModel.hpp
+++ b/include/nodes/internal/DataFlowModel.hpp
@@ -22,7 +22,7 @@ public:
   modelRegistry() const override;
 
   QString
-  nodeTypeCatergory(QString const& name) const override;
+  nodeTypeCategory(QString const& name) const override;
 
   bool
   getTypeConvertable(TypeConverterId const& id ) const override;

--- a/include/nodes/internal/DataFlowModel.hpp
+++ b/include/nodes/internal/DataFlowModel.hpp
@@ -1,0 +1,107 @@
+#include "FlowSceneModel.hpp"
+#include "DataModelRegistry.hpp"
+#include "ConnectionID.hpp"
+#include "QUuidStdHash.hpp"
+
+namespace QtNodes {
+
+class Node;
+class Connection;
+
+/// Model for simple data flow
+class DataFlowModel : public FlowSceneModel
+{
+public:
+
+  DataFlowModel(std::shared_ptr<DataModelRegistry> reg);
+
+  // FlowSceneModel read interface
+  QStringList
+  modelRegistry() const override;
+
+  QString
+  nodeTypeCatergory(QString const& name) const override;
+
+  bool
+  getTypeConvertable(TypeConverterId const& id ) const override;
+
+  QList<QUuid>
+  nodeUUids() const override;
+
+  NodeIndex
+  nodeIndex(const QUuid& ID) const override;
+
+  QString
+  nodeTypeIdentifier(NodeIndex const& index) const override;
+
+  QString
+  nodeCaption(NodeIndex const& index) const override;
+
+  QPointF
+  nodeLocation(NodeIndex const& index) const override;
+
+  QWidget*
+  nodeWidget(NodeIndex const& index) const override;
+
+  bool
+  nodeResizable(NodeIndex const& index) const override;
+
+  NodeValidationState
+  nodeValidationState(NodeIndex const& index) const override;
+
+  QString
+  nodeValidationMessage(NodeIndex const& index) const override;
+
+  NodePainterDelegate*
+  nodePainterDelegate(NodeIndex const& index) const override;
+
+  unsigned int
+  nodePortCount(NodeIndex const& index, PortType portType) const override;
+
+  QString
+  nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  NodeDataType
+  nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  ConnectionPolicy
+  nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  std::vector<std::pair<NodeIndex, PortIndex> >
+  nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const override;
+
+  // FlowSceneModel write interface
+  bool
+  removeConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
+  bool
+  addConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
+  bool
+  removeNode(NodeIndex const& index) override;
+  QUuid
+  addNode(QString const& typeID, QPointF const& location) override;
+  bool
+  moveNode(NodeIndex const& index, QPointF newLocation) override;
+
+  // convenience functions
+  QUuid
+  addNode(QString const& typeID, QPointF const& location, QUuid const& uuid);
+  QUuid
+  addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& uuid = QUuid::createUuid());
+  ConnectionID
+  addConnection(Node* left, PortIndex leftIdx, Node* right, PortIndex rightIdx, TypeConverter converter);
+
+  using SharedConnection = std::shared_ptr<Connection>;
+  using UniqueNode       = std::unique_ptr<Node>;
+
+  std::unordered_map<ConnectionID, SharedConnection>& connections() { return _connections; }
+  std::unordered_map<QUuid, UniqueNode>& nodes() { return _nodes; }
+  DataModelRegistry& registry() { return *_registry; }
+  void setRegistry(std::shared_ptr<DataModelRegistry> registry) {
+    _registry = std::move(registry);
+  }
+
+private:
+
+  std::unordered_map<QUuid, UniqueNode>              _nodes;
+  std::unordered_map<ConnectionID, SharedConnection> _connections;
+  std::shared_ptr<DataModelRegistry>                 _registry;
+};
+
+}

--- a/include/nodes/internal/DataFlowModel.hpp
+++ b/include/nodes/internal/DataFlowModel.hpp
@@ -2,6 +2,7 @@
 #include "DataModelRegistry.hpp"
 #include "ConnectionID.hpp"
 #include "QUuidStdHash.hpp"
+#include "Export.hpp"
 
 namespace QtNodes {
 
@@ -9,7 +10,8 @@ class Node;
 class Connection;
 
 /// Model for simple data flow
-class DataFlowModel : public FlowSceneModel
+class NODE_EDITOR_PUBLIC DataFlowModel 
+  : public FlowSceneModel
 {
 public:
 

--- a/include/nodes/internal/DataFlowScene.hpp
+++ b/include/nodes/internal/DataFlowScene.hpp
@@ -13,7 +13,7 @@
 #include <unordered_map>
 
 namespace QtNodes {
-  
+
 class Connection;
 class DataModelRegistry;
 class NodeDataModel;
@@ -21,13 +21,15 @@ class Node;
 
 /// A FlowScene that uses a simple data flow model.
 /// This class is a drop-in replacement for the old FlowScene
-class NODE_EDITOR_PUBLIC DataFlowScene : public FlowScene {
+class NODE_EDITOR_PUBLIC DataFlowScene : public FlowScene
+{
   Q_OBJECT
 
 public:
 
-  explicit DataFlowScene(std::shared_ptr<DataModelRegistry> registry = std::make_shared<DataModelRegistry>(),
-                         QObject* parent = Q_NULLPTR);
+  explicit
+  DataFlowScene(std::shared_ptr<DataModelRegistry> registry = std::make_shared<DataModelRegistry>(),
+                QObject* parent                             = Q_NULLPTR);
 
   std::shared_ptr<Connection>
   createConnection(Node& nodeIn,
@@ -36,76 +38,106 @@ public:
                    PortIndex portIndexOut,
                    TypeConverter const& converter = TypeConverter());
 
-  std::shared_ptr<Connection>restoreConnection(QJsonObject const &connectionJson);
+  std::shared_ptr<Connection>
+  restoreConnection(QJsonObject const &connectionJson);
 
-  void deleteConnection(Connection& connection);
+  void
+  deleteConnection(Connection& connection);
 
-  Node& createNode(std::unique_ptr<NodeDataModel> && dataModel);
+  Node&
+  createNode(std::unique_ptr<NodeDataModel> && dataModel);
 
-  Node& restoreNode(QJsonObject const& nodeJson);
+  Node&
+  restoreNode(QJsonObject const& nodeJson);
 
-  void removeNode(Node& node);
+  void
+  removeNode(Node& node);
 
-  DataModelRegistry& registry() const;
+  DataModelRegistry&
+  registry() const;
 
-  void setRegistry(std::shared_ptr<DataModelRegistry> registry);
+  void
+  setRegistry(std::shared_ptr<DataModelRegistry> registry);
 
-  void iterateOverNodes(std::function<void(Node*)> const& visitor);
+  void
+  iterateOverNodes(std::function<void(Node*)> const& visitor);
 
-  void iterateOverNodeData(std::function<void(NodeDataModel*)> const& visitor);
+  void
+  iterateOverNodeData(std::function<void(NodeDataModel*)> const& visitor);
 
-  void iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& visitor);
+  void
+  iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& visitor);
 
-  QPointF getNodePosition(Node const& node) const;
+  QPointF
+  getNodePosition(Node const& node) const;
 
-  void setNodePosition(Node& node, QPointF const& pos) const;
+  void
+  setNodePosition(Node& node, QPointF const& pos) const;
 
 public:
 
-  std::unordered_map<QUuid, std::unique_ptr<Node> > const &nodes() const;
+  std::unordered_map<QUuid, std::unique_ptr<Node> > const &
+  nodes() const;
 
-  std::unordered_map<ConnectionID, std::shared_ptr<Connection> > const &connections() const;
+  std::unordered_map<ConnectionID, std::shared_ptr<Connection> > const &
+  connections() const;
 
-  std::vector<Node*> selectedNodes() const;
+  std::vector<Node*>
+  selectedNodes() const;
 
 public:
 
-  void clearScene();
+  void
+  clearScene();
 
-  void save() const;
+  void
+  save() const;
 
-  void load();
+  void
+  load();
 
-  QByteArray saveToMemory() const;
+  QByteArray
+  saveToMemory() const;
 
-  void loadFromMemory(const QByteArray& data);
+  void
+  loadFromMemory(const QByteArray& data);
 
 signals:
 
-  void nodeCreated(Node &n);
+  void
+  nodeCreated(Node &n);
 
-  void nodeDeleted(Node &n);
+  void
+  nodeDeleted(Node &n);
 
-  void connectionCreated(Connection &c);
-  void connectionDeleted(Connection &c);
+  void
+  connectionCreated(Connection &c);
+  void
+  connectionDeleted(Connection &c);
 
-  void nodeMoved(Node& n, const QPointF& newLocation);
+  void
+  nodeMoved(Node& n, const QPointF& newLocation);
 
-  void nodeDoubleClicked(Node& n);
+  void
+  nodeDoubleClicked(Node& n);
 
-  void connectionHovered(Connection& c, QPoint screenPos);
+  void
+  connectionHovered(Connection& c, QPoint screenPos);
 
-  void nodeHovered(Node& n, QPoint screenPos);
+  void
+  nodeHovered(Node& n, QPoint screenPos);
 
-  void connectionHoverLeft(Connection& c);
+  void
+  connectionHoverLeft(Connection& c);
 
-  void nodeHoverLeft(Node& n);
-  
+  void
+  nodeHoverLeft(Node& n);
+
 private:
-  
+
   // default model class
   class DataFlowModel;
-  
+
   DataFlowModel* _dataFlowModel;
 
 };

--- a/include/nodes/internal/DataFlowScene.hpp
+++ b/include/nodes/internal/DataFlowScene.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "FlowScene.hpp"
+#include "PortType.hpp"
+#include "FlowSceneModel.hpp"
+#include "QUuidStdHash.hpp"
+#include "ConnectionID.hpp"
+#include "Export.hpp"
+#include "TypeConverter.hpp"
+
+#include <memory>
+#include <functional>
+#include <unordered_map>
+
+namespace QtNodes {
+  
+class Connection;
+class DataModelRegistry;
+class NodeDataModel;
+class Node;
+
+/// A FlowScene that uses a simple data flow model.
+/// This class is a drop-in replacement for the old FlowScene
+class NODE_EDITOR_PUBLIC DataFlowScene : public FlowScene {
+  Q_OBJECT
+
+public:
+
+  explicit DataFlowScene(std::shared_ptr<DataModelRegistry> registry = std::make_shared<DataModelRegistry>(),
+                         QObject* parent = Q_NULLPTR);
+
+  std::shared_ptr<Connection>
+  createConnection(Node& nodeIn,
+                   PortIndex portIndexIn,
+                   Node& nodeOut,
+                   PortIndex portIndexOut,
+                   TypeConverter const& converter = TypeConverter());
+
+  std::shared_ptr<Connection>restoreConnection(QJsonObject const &connectionJson);
+
+  void deleteConnection(Connection& connection);
+
+  Node& createNode(std::unique_ptr<NodeDataModel> && dataModel);
+
+  Node& restoreNode(QJsonObject const& nodeJson);
+
+  void removeNode(Node& node);
+
+  DataModelRegistry& registry() const;
+
+  void setRegistry(std::shared_ptr<DataModelRegistry> registry);
+
+  void iterateOverNodes(std::function<void(Node*)> const& visitor);
+
+  void iterateOverNodeData(std::function<void(NodeDataModel*)> const& visitor);
+
+  void iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& visitor);
+
+  QPointF getNodePosition(Node const& node) const;
+
+  void setNodePosition(Node& node, QPointF const& pos) const;
+
+public:
+
+  std::unordered_map<QUuid, std::unique_ptr<Node> > const &nodes() const;
+
+  std::unordered_map<ConnectionID, std::shared_ptr<Connection> > const &connections() const;
+
+  std::vector<Node*> selectedNodes() const;
+
+public:
+
+  void clearScene();
+
+  void save() const;
+
+  void load();
+
+  QByteArray saveToMemory() const;
+
+  void loadFromMemory(const QByteArray& data);
+
+signals:
+
+  void nodeCreated(Node &n);
+
+  void nodeDeleted(Node &n);
+
+  void connectionCreated(Connection &c);
+  void connectionDeleted(Connection &c);
+
+  void nodeMoved(Node& n, const QPointF& newLocation);
+
+  void nodeDoubleClicked(Node& n);
+
+  void connectionHovered(Connection& c, QPoint screenPos);
+
+  void nodeHovered(Node& n, QPoint screenPos);
+
+  void connectionHoverLeft(Connection& c);
+
+  void nodeHoverLeft(Node& n);
+  
+private:
+  
+  // default model class
+  class DataFlowModel;
+  
+  DataFlowModel* _dataFlowModel;
+
+};
+
+} // namespace QtNodes

--- a/include/nodes/internal/DataFlowScene.hpp
+++ b/include/nodes/internal/DataFlowScene.hpp
@@ -18,6 +18,7 @@ class Connection;
 class DataModelRegistry;
 class NodeDataModel;
 class Node;
+class DataFlowModel;
 
 /// A FlowScene that uses a simple data flow model.
 /// This class is a drop-in replacement for the old FlowScene
@@ -134,9 +135,6 @@ signals:
   nodeHoverLeft(Node& n);
 
 private:
-
-  // default model class
-  class DataFlowModel;
 
   DataFlowModel* _dataFlowModel;
 

--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -27,7 +27,7 @@ class NODE_EDITOR_PUBLIC FlowScene
   : public QGraphicsScene
 {
   Q_OBJECT
-  
+
   friend NodeGraphicsObject;
   friend ConnectionGraphicsObject;
 public:
@@ -38,27 +38,46 @@ public:
 
 public:
 
-  FlowSceneModel* model() const { return _model; }
+  FlowSceneModel*
+  model() const { return _model; }
 
-  NodeGraphicsObject* nodeGraphicsObject(const NodeIndex& index);
-  
-  std::vector<NodeIndex> selectedNodes() const;
+  NodeGraphicsObject*
+  nodeGraphicsObject(const NodeIndex& index);
+
+  std::vector<NodeIndex>
+  selectedNodes() const;
 
 private slots:
 
-  void nodeRemoved(const QUuid& id);
-  void nodeAdded(const QUuid& newID);
-  void nodePortUpdated(NodeIndex const& id);
-  void nodeValidationUpdated(NodeIndex const& id);
-  void connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
-  void connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
-  void nodeMoved(NodeIndex const& index);
-  
+  void
+  nodeRemoved(const QUuid& id);
+
+  void
+  nodeAdded(const QUuid& newID);
+
+  void
+  nodePortUpdated(NodeIndex const& id);
+
+  void
+  nodeValidationUpdated(NodeIndex const& id);
+
+  void
+  connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID,
+                    NodeIndex const& rightNode, PortIndex rightPortID);
+
+  void
+  connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID,
+                  NodeIndex const& rightNode, PortIndex rightPortID);
+
+  void
+  nodeMoved(NodeIndex const& index);
+
 private:
 
   FlowSceneModel* _model;
-  
+
   std::unordered_map<QUuid, NodeGraphicsObject*> _nodeGraphicsObjects;
+
   std::unordered_map<ConnectionID, ConnectionGraphicsObject*> _connGraphicsObjects;
 
   // This is for when you're creating a connection

--- a/include/nodes/internal/FlowSceneModel.hpp
+++ b/include/nodes/internal/FlowSceneModel.hpp
@@ -20,7 +20,8 @@ class NodeIndex;
 struct NodeDataType;
 class NodePainterDelegate;
 
-enum class ConnectionPolicy {
+enum class ConnectionPolicy
+{
   One,
   Many
 };
@@ -37,136 +38,174 @@ using TypeConverterId =
   std::pair<NodeDataType, NodeDataType>;
 
 
-class NODE_EDITOR_PUBLIC FlowSceneModel : public QObject {
+class NODE_EDITOR_PUBLIC FlowSceneModel : public QObject
+{
   Q_OBJECT
 
 public:
 
-  FlowSceneModel();
+  FlowSceneModel() = default;
 
   // Scene specific functions
-  virtual QStringList modelRegistry() const = 0;
+  virtual QStringList
+  modelRegistry() const = 0;
 
   /// Get the catergory for a node type
   /// name will be from `modelRegistry()`
-  virtual QString nodeTypeCatergory(QString const& /*name*/) const { return {}; }
+  virtual QString
+  nodeTypeCatergory(QString const& /*name*/) const { return {}; }
 
   /// Get if two types are convertable
-  virtual bool getTypeConvertable(TypeConverterId const& /*id*/) const { return false; }
+  virtual bool
+  getTypeConvertable(TypeConverterId const& /*id*/) const { return false; }
 
   // Retrieval functions
   //////////////////////
 
   /// Get the list of node IDs
-  virtual QList<QUuid> nodeUUids() const = 0;
+  virtual QList<QUuid>
+  nodeUUids() const = 0;
 
   /// Create a NodeIndex for a node
-  virtual NodeIndex nodeIndex(const QUuid& ID) const = 0;
+  virtual NodeIndex
+  nodeIndex(const QUuid& ID) const = 0;
 
   /// Get the type ID for the node
-  virtual QString nodeTypeIdentifier(NodeIndex const& index) const = 0;
+  virtual QString
+  nodeTypeIdentifier(NodeIndex const& index) const = 0;
 
   /// Get the caption for the node
-  virtual QString nodeCaption(NodeIndex const& index) const = 0;
+  virtual QString
+  nodeCaption(NodeIndex const& index) const = 0;
 
   /// Get the location of a node
-  virtual QPointF nodeLocation(NodeIndex const& index) const = 0;
+  virtual QPointF
+  nodeLocation(NodeIndex const& index) const = 0;
 
   /// Get the embedded widget
-  virtual QWidget* nodeWidget(NodeIndex const& index) const = 0;
-  
+  virtual QWidget*
+  nodeWidget(NodeIndex const& index) const = 0;
+
   /// Get if it's resizable
-  virtual bool nodeResizable(NodeIndex const& index) const = 0;
-  
+  virtual bool
+  nodeResizable(NodeIndex const& index) const = 0;
+
   /// Get the validation state
-  virtual NodeValidationState nodeValidationState(NodeIndex const& index) const = 0;
-  
+  virtual NodeValidationState
+  nodeValidationState(NodeIndex const& index) const = 0;
+
   /// Get the validation error/warning
-  virtual QString nodeValidationMessage(NodeIndex const& index) const = 0;
+  virtual QString
+  nodeValidationMessage(NodeIndex const& index) const = 0;
 
   /// Get the painter delegate
-  virtual NodePainterDelegate* nodePainterDelegate(NodeIndex const& index) const = 0;
-  
+  virtual NodePainterDelegate*
+  nodePainterDelegate(NodeIndex const& index) const = 0;
+
   /// Get the style - {} for default
-  virtual NodeStyle nodeStyle(NodeIndex const& /*index*/) const { return {}; }
-  
+  virtual NodeStyle
+  nodeStyle(NodeIndex const& /*index*/) const { return {}; }
+
   /// Get the count of DataPorts
-  virtual unsigned int nodePortCount(NodeIndex const& index, PortType portType) const = 0;
+  virtual unsigned int
+  nodePortCount(NodeIndex const& index, PortType portType) const = 0;
 
   /// Get the port caption
-  virtual QString nodePortCaption(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
+  virtual QString
+  nodePortCaption(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
 
   /// Get the port data type
-  virtual NodeDataType nodePortDataType(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
+  virtual NodeDataType
+  nodePortDataType(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
 
   /// Port Policy
-  virtual ConnectionPolicy nodePortConnectionPolicy(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
+  virtual ConnectionPolicy
+  nodePortConnectionPolicy(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
 
   /// Get a connection at a port
   /// Returns the remote node and the remote port index for that node
-  virtual std::vector<std::pair<NodeIndex, PortIndex>> nodePortConnections(NodeIndex const& index, PortIndex portID, PortType portTypes) const = 0;
+  virtual std::vector<std::pair<NodeIndex, PortIndex> >
+  nodePortConnections(NodeIndex const& index, PortIndex portID, PortType portTypes) const = 0;
 
   // Mutation functions
   /////////////////////
 
   /// Remove a connection
-  virtual bool removeConnection(NodeIndex const& /*leftNode*/, 
-                                PortIndex /*leftPortID*/, 
-                                NodeIndex const& /*rightNode*/, 
-                                PortIndex /*rightPortID*/) 
+  virtual bool
+  removeConnection(NodeIndex const& /*leftNode*/,
+                   PortIndex /*leftPortID*/,
+                   NodeIndex const& /*rightNode*/,
+                   PortIndex /*rightPortID*/)
   { return false; }
 
   /// Add a connection
-  virtual bool addConnection(NodeIndex const& /*leftNode*/, 
-                             PortIndex /*leftPortID*/, 
-                             NodeIndex const& /*rightNode*/, 
-                             PortIndex /*rightPortID*/) 
+  virtual bool
+  addConnection(NodeIndex const& /*leftNode*/,
+                PortIndex /*leftPortID*/,
+                NodeIndex const& /*rightNode*/,
+                PortIndex /*rightPortID*/)
   { return false; }
 
   /// Remove a node
-  virtual bool removeNode(NodeIndex const& /*index*/) { return false; }
+  virtual bool
+  removeNode(NodeIndex const& /*index*/) { return false; }
 
   /// Add a  -- return {} if it fails
-  virtual QUuid addNode(QString const& /*typeID*/, QPointF const& /*pos*/) { return QUuid{}; }
+  virtual QUuid
+  addNode(QString const& /*typeID*/, QPointF const& /*pos*/) { return QUuid{}; }
 
   /// Move a node to a new location
-  virtual bool moveNode(NodeIndex const& /*index*/, QPointF /*newLocation*/) { return false; }
-  
+  virtual bool
+  moveNode(NodeIndex const& /*index*/, QPointF /*newLocation*/) { return false; }
+
 public:
-  
+
   /// Helper functions
   ////////////////////
-  
+
   // try to remove all connections and then the node
-  bool removeNodeWithConnections(NodeIndex const& index);
-  
+  bool
+  removeNodeWithConnections(NodeIndex const& index);
+
 public:
-  
-  
+
+
   /// Notifications
   /////////////////
-  
-  virtual void connectionHovered(NodeIndex const& /*lhs*/, PortIndex /*lPortIndex*/, NodeIndex const& /*rhs*/, PortIndex /*rPortIndex*/, QPoint const& /*pos*/, bool /*entered*/) {}
-  
-  virtual void nodeHovered(NodeIndex const& /*index*/, QPoint const& /*pos*/, bool /*entered*/) {}
-  
-  virtual void nodeDoubleClicked(NodeIndex const& /*index*/, QPoint const& /*pos*/) {}
 
-  virtual void nodeContextMenu(NodeIndex const& /*index*/, QPoint const& /*pos*/) {}
+  virtual void
+  connectionHovered(NodeIndex const& /*lhs*/, PortIndex /*lPortIndex*/, NodeIndex const& /*rhs*/, PortIndex /*rPortIndex*/, QPoint const& /*pos*/, bool /*entered*/) {}
+
+  virtual void
+  nodeHovered(NodeIndex const& /*index*/, QPoint const& /*pos*/, bool /*entered*/) {}
+
+  virtual void
+  nodeDoubleClicked(NodeIndex const& /*index*/, QPoint const& /*pos*/) {}
+
+  virtual void
+  nodeContextMenu(NodeIndex const& /*index*/, QPoint const& /*pos*/) {}
 
 signals:
 
-  void nodeRemoved(const QUuid& id);
-  void nodeAdded(const QUuid& newID);
-  void nodePortUpdated(NodeIndex const& id);
-  void nodeValidationUpdated(NodeIndex const& id);
-  void connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
-  void connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
-  void nodeMoved(NodeIndex const& index);
+  void
+  nodeRemoved(const QUuid& id);
+  void
+  nodeAdded(const QUuid& newID);
+  void
+  nodePortUpdated(NodeIndex const& id);
+  void
+  nodeValidationUpdated(NodeIndex const& id);
+  void
+  connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
+  void
+  connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
+  void
+  nodeMoved(NodeIndex const& index);
 
 protected:
 
-  NodeIndex createIndex(const QUuid& id, void* internalPointer) const;
+  NodeIndex
+  createIndex(const QUuid& id, void* internalPointer) const;
 
 };
 

--- a/include/nodes/internal/FlowSceneModel.hpp
+++ b/include/nodes/internal/FlowSceneModel.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+#include "PortType.hpp"
+#include "Export.hpp"
+#include "NodeStyle.hpp"
+
+#include <cstddef>
+
+#include <QString>
+#include <QPointF>
+#include <QObject>
+#include <QUuid>
+#include <QList>
+
+
+namespace QtNodes
+{
+
+class NodeIndex;
+struct NodeDataType;
+class NodePainterDelegate;
+
+enum class ConnectionPolicy {
+  One,
+  Many
+};
+
+enum class NodeValidationState
+{
+  Valid,
+  Warning,
+  Error
+};
+
+// data-type-in, data-type-out
+using TypeConverterId =
+  std::pair<NodeDataType, NodeDataType>;
+
+
+class NODE_EDITOR_PUBLIC FlowSceneModel : public QObject {
+  Q_OBJECT
+
+public:
+
+  FlowSceneModel();
+
+  // Scene specific functions
+  virtual QStringList modelRegistry() const = 0;
+
+  /// Get the catergory for a node type
+  /// name will be from `modelRegistry()`
+  virtual QString nodeTypeCatergory(QString const& /*name*/) const { return {}; }
+
+  /// Get if two types are convertable
+  virtual bool getTypeConvertable(TypeConverterId const& /*id*/) const { return false; }
+
+  // Retrieval functions
+  //////////////////////
+
+  /// Get the list of node IDs
+  virtual QList<QUuid> nodeUUids() const = 0;
+
+  /// Create a NodeIndex for a node
+  virtual NodeIndex nodeIndex(const QUuid& ID) const = 0;
+
+  /// Get the type ID for the node
+  virtual QString nodeTypeIdentifier(NodeIndex const& index) const = 0;
+
+  /// Get the caption for the node
+  virtual QString nodeCaption(NodeIndex const& index) const = 0;
+
+  /// Get the location of a node
+  virtual QPointF nodeLocation(NodeIndex const& index) const = 0;
+
+  /// Get the embedded widget
+  virtual QWidget* nodeWidget(NodeIndex const& index) const = 0;
+  
+  /// Get if it's resizable
+  virtual bool nodeResizable(NodeIndex const& index) const = 0;
+  
+  /// Get the validation state
+  virtual NodeValidationState nodeValidationState(NodeIndex const& index) const = 0;
+  
+  /// Get the validation error/warning
+  virtual QString nodeValidationMessage(NodeIndex const& index) const = 0;
+
+  /// Get the painter delegate
+  virtual NodePainterDelegate* nodePainterDelegate(NodeIndex const& index) const = 0;
+  
+  /// Get the style - {} for default
+  virtual NodeStyle nodeStyle(NodeIndex const& /*index*/) const { return {}; }
+  
+  /// Get the count of DataPorts
+  virtual unsigned int nodePortCount(NodeIndex const& index, PortType portType) const = 0;
+
+  /// Get the port caption
+  virtual QString nodePortCaption(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
+
+  /// Get the port data type
+  virtual NodeDataType nodePortDataType(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
+
+  /// Port Policy
+  virtual ConnectionPolicy nodePortConnectionPolicy(NodeIndex const& index, PortIndex portID, PortType portType) const = 0;
+
+  /// Get a connection at a port
+  /// Returns the remote node and the remote port index for that node
+  virtual std::vector<std::pair<NodeIndex, PortIndex>> nodePortConnections(NodeIndex const& index, PortIndex portID, PortType portTypes) const = 0;
+
+  // Mutation functions
+  /////////////////////
+
+  /// Remove a connection
+  virtual bool removeConnection(NodeIndex const& /*leftNode*/, 
+                                PortIndex /*leftPortID*/, 
+                                NodeIndex const& /*rightNode*/, 
+                                PortIndex /*rightPortID*/) 
+  { return false; }
+
+  /// Add a connection
+  virtual bool addConnection(NodeIndex const& /*leftNode*/, 
+                             PortIndex /*leftPortID*/, 
+                             NodeIndex const& /*rightNode*/, 
+                             PortIndex /*rightPortID*/) 
+  { return false; }
+
+  /// Remove a node
+  virtual bool removeNode(NodeIndex const& /*index*/) { return false; }
+
+  /// Add a  -- return {} if it fails
+  virtual QUuid addNode(QString const& /*typeID*/, QPointF const& /*pos*/) { return QUuid{}; }
+
+  /// Move a node to a new location
+  virtual bool moveNode(NodeIndex const& /*index*/, QPointF /*newLocation*/) { return false; }
+  
+public:
+  
+  /// Helper functions
+  ////////////////////
+  
+  // try to remove all connections and then the node
+  bool removeNodeWithConnections(NodeIndex const& index);
+  
+public:
+  
+  
+  /// Notifications
+  /////////////////
+  
+  virtual void connectionHovered(NodeIndex const& /*lhs*/, PortIndex /*lPortIndex*/, NodeIndex const& /*rhs*/, PortIndex /*rPortIndex*/, QPoint const& /*pos*/, bool /*entered*/) {}
+  
+  virtual void nodeHovered(NodeIndex const& /*index*/, QPoint const& /*pos*/, bool /*entered*/) {}
+  
+  virtual void nodeDoubleClicked(NodeIndex const& /*index*/, QPoint const& /*pos*/) {}
+
+  virtual void nodeContextMenu(NodeIndex const& /*index*/, QPoint const& /*pos*/) {}
+
+signals:
+
+  void nodeRemoved(const QUuid& id);
+  void nodeAdded(const QUuid& newID);
+  void nodePortUpdated(NodeIndex const& id);
+  void nodeValidationUpdated(NodeIndex const& id);
+  void connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
+  void connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID);
+  void nodeMoved(NodeIndex const& index);
+
+protected:
+
+  NodeIndex createIndex(const QUuid& id, void* internalPointer) const;
+
+};
+
+} // namespace QtNodes

--- a/include/nodes/internal/FlowSceneModel.hpp
+++ b/include/nodes/internal/FlowSceneModel.hpp
@@ -50,10 +50,10 @@ public:
   virtual QStringList
   modelRegistry() const = 0;
 
-  /// Get the catergory for a node type
+  /// Get the category for a node type
   /// name will be from `modelRegistry()`
   virtual QString
-  nodeTypeCatergory(QString const& /*name*/) const { return {}; }
+  nodeTypeCategory(QString const& /*name*/) const { return {}; }
 
   /// Get if two types are convertable
   virtual bool

--- a/include/nodes/internal/FlowView.hpp
+++ b/include/nodes/internal/FlowView.hpp
@@ -15,47 +15,63 @@ class NODE_EDITOR_PUBLIC FlowView
   Q_OBJECT
 public:
 
-  FlowView(QWidget *parent = Q_NULLPTR);
+  FlowView(QWidget *parent                   = Q_NULLPTR);
   FlowView(FlowScene *scene, QWidget *parent = Q_NULLPTR);
 
   FlowView(const FlowView&) = delete;
-  FlowView operator=(const FlowView&) = delete;
+  FlowView
+  operator=(const FlowView&) = delete;
 
-  QAction* clearSelectionAction() const;
+  QAction*
+  clearSelectionAction() const;
 
-  QAction* deleteSelectionAction() const;
+  QAction*
+  deleteSelectionAction() const;
 
-  void setScene(FlowScene *scene);
+  void
+  setScene(FlowScene *scene);
 
 public slots:
 
-  void scaleUp();
+  void
+  scaleUp();
 
-  void scaleDown();
+  void
+  scaleDown();
 
-  void deleteSelectedNodes();
-
-protected:
-
-  void contextMenuEvent(QContextMenuEvent *event) override;
-
-  void wheelEvent(QWheelEvent *event) override;
-
-  void keyPressEvent(QKeyEvent *event) override;
-
-  void keyReleaseEvent(QKeyEvent *event) override;
-
-  void mousePressEvent(QMouseEvent *event) override;
-
-  void mouseMoveEvent(QMouseEvent *event) override;
-
-  void drawBackground(QPainter* painter, const QRectF& r) override;
-
-  void showEvent(QShowEvent *event) override;
+  void
+  deleteSelectedNodes();
 
 protected:
 
-  FlowScene * scene();
+  void
+  contextMenuEvent(QContextMenuEvent *event) override;
+
+  void
+  wheelEvent(QWheelEvent *event) override;
+
+  void
+  keyPressEvent(QKeyEvent *event) override;
+
+  void
+  keyReleaseEvent(QKeyEvent *event) override;
+
+  void
+  mousePressEvent(QMouseEvent *event) override;
+
+  void
+  mouseMoveEvent(QMouseEvent *event) override;
+
+  void
+  drawBackground(QPainter* painter, const QRectF& r) override;
+
+  void
+  showEvent(QShowEvent *event) override;
+
+protected:
+
+  FlowScene *
+  scene();
 
 private:
 

--- a/include/nodes/internal/FlowViewStyle.hpp
+++ b/include/nodes/internal/FlowViewStyle.hpp
@@ -18,15 +18,19 @@ public:
 
 public:
 
-  static void setStyle(QString jsonText);
+  static void
+  setStyle(QString jsonText);
 
 private:
 
-  void loadJsonText(QString jsonText) override;
+  void
+  loadJsonText(QString jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void
+  loadJsonFile(QString fileName) override;
 
-  void loadJsonFromByteArray(QByteArray const &byteArray) override;
+  void
+  loadJsonFromByteArray(QByteArray const &byteArray) override;
 
 public:
 

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -34,7 +34,8 @@ class NODE_EDITOR_PUBLIC Node
 public:
 
   /// NodeDataModel should be an rvalue and is moved into the Node
-  Node(std::unique_ptr<NodeDataModel> && dataModel);
+  Node(std::unique_ptr<NodeDataModel> && dataModel,
+       QUuid const& id);
 
   virtual
   ~Node();
@@ -52,38 +53,22 @@ public:
   QUuid
   id() const;
 
-  void reactToPossibleConnection(PortType,
-                                 NodeDataType const &,
-                                 QPointF const & scenePoint);
+  QPointF
+  position() const;
 
   void
-  resetReactionToConnection();
+  setPosition(QPointF const& newPos);
 
 public:
 
-  NodeGraphicsObject const &
-  nodeGraphicsObject() const;
-
-  NodeGraphicsObject &
-  nodeGraphicsObject();
-
-  void
-  setGraphicsObject(std::unique_ptr<NodeGraphicsObject>&& graphics);
-
-  NodeGeometry&
-  nodeGeometry();
-
-  NodeGeometry const&
-  nodeGeometry() const;
-
-  NodeState const &
-  nodeState() const;
-
-  NodeState &
-  nodeState();
-
   NodeDataModel*
   nodeDataModel() const;
+
+  std::vector<Connection*> const&
+  connections(PortType pType, PortIndex pIdx) const;
+
+  std::vector<Connection*>&
+  connections(PortType pType, PortIndex pIdx);
 
 public slots: // data propagation
 
@@ -97,6 +82,10 @@ public slots: // data propagation
   void
   onDataUpdated(PortIndex index);
 
+signals:
+
+  void positionChanged(QPointF const& newPos);
+
 private:
 
   // addressing
@@ -104,15 +93,8 @@ private:
   QUuid _uid;
 
   // data
-
   std::unique_ptr<NodeDataModel> _nodeDataModel;
-
-  NodeState _nodeState;
-
-  // painting
-
-  NodeGeometry _nodeGeometry;
-
-  std::unique_ptr<NodeGraphicsObject> _nodeGraphicsObject;
+  std::vector<std::vector<Connection*>> _inConnections, _outConnections;
+  QPointF _pos;
 };
 }

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -84,7 +84,8 @@ public slots: // data propagation
 
 signals:
 
-  void positionChanged(QPointF const& newPos);
+  void
+  positionChanged(QPointF const& newPos);
 
 private:
 
@@ -94,7 +95,7 @@ private:
 
   // data
   std::unique_ptr<NodeDataModel> _nodeDataModel;
-  std::vector<std::vector<Connection*>> _inConnections, _outConnections;
+  std::vector<std::vector<Connection*> > _inConnections, _outConnections;
   QPointF _pos;
 };
 }

--- a/include/nodes/internal/NodeData.hpp
+++ b/include/nodes/internal/NodeData.hpp
@@ -20,14 +20,17 @@ class NODE_EDITOR_PUBLIC NodeData
 {
 public:
 
-  virtual ~NodeData() = default;
+  virtual
+  ~NodeData() = default;
 
-  virtual bool sameType(NodeData const &nodeData) const
+  virtual bool
+  sameType(NodeData const &nodeData) const
   {
     return (this->type().id == nodeData.type().id);
   }
 
   /// Type for inner use
-  virtual NodeDataType type() const = 0;
+  virtual NodeDataType
+  type() const = 0;
 };
 }

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -11,16 +11,10 @@
 #include "NodePainterDelegate.hpp"
 #include "Export.hpp"
 #include "memory.hpp"
+#include "FlowSceneModel.hpp"
 
 namespace QtNodes
 {
-
-enum class NodeValidationState
-{
-  Valid,
-  Warning,
-  Error
-};
 
 class StyleCollection;
 
@@ -72,12 +66,6 @@ public:
 
 public:
 
-  enum class ConnectionPolicy
-  {
-    One,
-    Many,
-  };
-
   virtual
   ConnectionPolicy
   portOutConnectionPolicy(PortIndex) const
@@ -90,7 +78,7 @@ public:
 
   void
   setNodeStyle(NodeStyle const& style);
-
+  
 public:
 
   /// Triggers the algorithm

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -59,10 +59,12 @@ public:
 public:
 
   virtual
-  unsigned int nPorts(PortType portType) const = 0;
+  unsigned int
+  nPorts(PortType portType) const = 0;
 
   virtual
-  NodeDataType dataType(PortType portType, PortIndex portIndex) const = 0;
+  NodeDataType
+  dataType(PortType portType, PortIndex portIndex) const = 0;
 
 public:
 
@@ -78,7 +80,7 @@ public:
 
   void
   setNodeStyle(NodeStyle const& style);
-  
+
 public:
 
   /// Triggers the algorithm
@@ -108,7 +110,8 @@ public:
   validationMessage() const { return QString(""); }
 
   virtual
-  NodePainterDelegate* painterDelegate() const { return nullptr; }
+  NodePainterDelegate*
+  painterDelegate() const { return nullptr; }
 
 signals:
 

--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -110,11 +110,11 @@ public:
 
   unsigned int
   validationWidth() const;
-  
-  static 
-  QPointF 
-  calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, NodeGraphicsObject const& targetNode, 
-                                        PortIndex sourcePortIndex, PortType sourcePort, NodeGraphicsObject const& sourceNode, 
+
+  static
+  QPointF
+  calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, NodeGraphicsObject const& targetNode,
+                                        PortIndex sourcePortIndex, PortType sourcePort, NodeGraphicsObject const& sourceNode,
                                         NodeGeometry const& newNodeGeom);
 private:
 

--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -8,19 +8,18 @@
 #include "PortType.hpp"
 #include "Export.hpp"
 #include "memory.hpp"
+#include "NodeIndex.hpp"
 
 namespace QtNodes
 {
 
-class NodeState;
-class NodeDataModel;
-class Node;
+class NodeGraphicsObject;
 
 class NODE_EDITOR_PUBLIC NodeGeometry
 {
 public:
 
-  NodeGeometry(std::unique_ptr<NodeDataModel> const &dataModel);
+  NodeGeometry(NodeIndex const& index);
 
 public:
   unsigned int
@@ -114,9 +113,9 @@ public:
   
   static 
   QPointF 
-  calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, Node* targetNode,
-                                        PortIndex sourcePortIndex, PortType sourcePort, Node* sourceNode,
-                                        Node& newNode);
+  calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, NodeGraphicsObject const& targetNode, 
+                                        PortIndex sourcePortIndex, PortType sourcePort, NodeGraphicsObject const& sourceNode, 
+                                        NodeGeometry const& newNodeGeom);
 private:
 
   unsigned int
@@ -150,7 +149,7 @@ private:
 
   QPointF _draggingPos;
 
-  std::unique_ptr<NodeDataModel> const &_dataModel;
+  NodeIndex _nodeIndex;
 
   mutable QFontMetrics _fontMetrics;
   mutable QFontMetrics _boldFontMetrics;

--- a/include/nodes/internal/NodeGraphicsObject.hpp
+++ b/include/nodes/internal/NodeGraphicsObject.hpp
@@ -3,8 +3,7 @@
 #include <QtCore/QUuid>
 #include <QtWidgets/QGraphicsObject>
 
-#include "Connection.hpp"
-
+#include "NodeIndex.hpp"
 #include "NodeGeometry.hpp"
 #include "NodeState.hpp"
 
@@ -14,7 +13,6 @@ namespace QtNodes
 {
 
 class FlowScene;
-class FlowItemEntry;
 
 /// Class reacts on GUI events, mouse clicks and
 /// forwards painting operation.
@@ -24,16 +22,31 @@ class NodeGraphicsObject : public QGraphicsObject
 
 public:
   NodeGraphicsObject(FlowScene &scene,
-                     Node& node);
-
+                     NodeIndex const& index);
+  
   virtual
   ~NodeGraphicsObject();
-
-  Node&
-  node();
-
-  Node const&
-  node() const;
+  
+  NodeIndex
+  index() const;
+  
+  FlowScene&
+  flowScene();
+  
+  FlowScene const&
+  flowScene() const;
+  
+  NodeGeometry&
+  geometry();
+  
+  NodeGeometry const&
+  geometry() const;
+  
+  NodeState&
+  nodeState();
+  
+  NodeState const&
+  nodeState() const;
 
   QRectF
   boundingRect() const override;
@@ -45,6 +58,14 @@ public:
   /// their corresponding end points.
   void
   moveConnections() const;
+
+  
+  void reactToPossibleConnection(PortType,
+                                 NodeDataType,
+                                 QPointF const& scenePoint);
+
+  void
+  resetReactionToConnection();
 
   enum { Type = UserType + 1 };
 
@@ -94,9 +115,13 @@ private:
 private:
 
   FlowScene & _scene;
-
-  Node& _node;
-
+  
+  NodeIndex _nodeIndex;
+  
+  NodeGeometry _geometry;
+  
+  NodeState _state;
+  
   bool _locked;
 
   // either nullptr or owned by parent QGraphicsItem

--- a/include/nodes/internal/NodeGraphicsObject.hpp
+++ b/include/nodes/internal/NodeGraphicsObject.hpp
@@ -3,6 +3,7 @@
 #include <QtCore/QUuid>
 #include <QtWidgets/QGraphicsObject>
 
+#include "Export.hpp"
 #include "NodeIndex.hpp"
 #include "NodeGeometry.hpp"
 #include "NodeState.hpp"
@@ -16,7 +17,7 @@ class FlowScene;
 
 /// Class reacts on GUI events, mouse clicks and
 /// forwards painting operation.
-class NodeGraphicsObject : public QGraphicsObject
+class NODE_EDITOR_PUBLIC NodeGraphicsObject : public QGraphicsObject
 {
   Q_OBJECT
 

--- a/include/nodes/internal/NodeGraphicsObject.hpp
+++ b/include/nodes/internal/NodeGraphicsObject.hpp
@@ -23,28 +23,28 @@ class NodeGraphicsObject : public QGraphicsObject
 public:
   NodeGraphicsObject(FlowScene &scene,
                      NodeIndex const& index);
-  
+
   virtual
   ~NodeGraphicsObject();
-  
+
   NodeIndex
   index() const;
-  
+
   FlowScene&
   flowScene();
-  
+
   FlowScene const&
   flowScene() const;
-  
+
   NodeGeometry&
   geometry();
-  
+
   NodeGeometry const&
   geometry() const;
-  
+
   NodeState&
   nodeState();
-  
+
   NodeState const&
   nodeState() const;
 
@@ -59,7 +59,7 @@ public:
   void
   moveConnections() const;
 
-  
+
   void reactToPossibleConnection(PortType,
                                  NodeDataType,
                                  QPointF const& scenePoint);
@@ -115,13 +115,13 @@ private:
 private:
 
   FlowScene & _scene;
-  
+
   NodeIndex _nodeIndex;
-  
+
   NodeGeometry _geometry;
-  
+
   NodeState _state;
-  
+
   bool _locked;
 
   // either nullptr or owned by parent QGraphicsItem

--- a/include/nodes/internal/NodeIndex.hpp
+++ b/include/nodes/internal/NodeIndex.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include <QUuid>
+#include <QtGlobal>
+
+namespace QtNodes {
+
+class FlowSceneModel;
+
+class NodeIndex {
+  friend FlowSceneModel;
+public:
+
+  /// Construct an invalid NodeIndex
+  NodeIndex() = default;
+
+private:
+  /// Regular constructor
+  NodeIndex(const QUuid& uuid, void* internalPtr, const FlowSceneModel* model) 
+    : _id {uuid}, _internalPointer{internalPtr}, _model{model} {
+      Q_ASSERT(!_id.isNull());
+      Q_ASSERT(_model != nullptr);
+    }
+
+public:
+
+  /// Get the internal pointer
+  void* internalPointer() const { return _internalPointer; }
+
+  /// Get the owning model
+  const FlowSceneModel* model() const { return _model; }
+
+  /// Get the id for the node
+  QUuid id() const { return _id; }
+  
+  /// Test if it's valid
+  bool isValid() const {
+    return !id().isNull() && model() != nullptr;
+  }
+
+
+private:
+
+  QUuid _id;
+  void* _internalPointer = nullptr;
+  const FlowSceneModel* _model = nullptr;
+};
+
+inline bool operator==(NodeIndex const& lhs, NodeIndex const& rhs) {
+  return lhs.model() == rhs.model() &&
+         lhs.id()    == rhs.id();
+}
+
+inline bool operator!=(NodeIndex const& lhs, NodeIndex const& rhs) {
+  return !(lhs == rhs);
+}
+
+} // namespace QtNodes
+

--- a/include/nodes/internal/NodeIndex.hpp
+++ b/include/nodes/internal/NodeIndex.hpp
@@ -6,11 +6,13 @@
 #include <QUuid>
 #include <QtGlobal>
 
-namespace QtNodes {
+namespace QtNodes
+{
 
 class FlowSceneModel;
 
-class NodeIndex {
+class NodeIndex
+{
   friend FlowSceneModel;
 public:
 
@@ -19,25 +21,33 @@ public:
 
 private:
   /// Regular constructor
-  NodeIndex(const QUuid& uuid, void* internalPtr, const FlowSceneModel* model) 
-    : _id {uuid}, _internalPointer{internalPtr}, _model{model} {
-      Q_ASSERT(!_id.isNull());
-      Q_ASSERT(_model != nullptr);
-    }
+  NodeIndex(const QUuid& uuid, void* internalPtr, const FlowSceneModel* model)
+    : _id {uuid}
+    , _internalPointer{internalPtr}
+    , _model{model}
+  {
+    Q_ASSERT(!_id.isNull());
+    Q_ASSERT(_model != nullptr);
+  }
 
 public:
 
   /// Get the internal pointer
-  void* internalPointer() const { return _internalPointer; }
+  void*
+  internalPointer() const { return _internalPointer; }
 
   /// Get the owning model
-  const FlowSceneModel* model() const { return _model; }
+  const FlowSceneModel*
+  model() const { return _model; }
 
   /// Get the id for the node
-  QUuid id() const { return _id; }
-  
+  QUuid
+  id() const { return _id; }
+
   /// Test if it's valid
-  bool isValid() const {
+  bool
+  isValid() const
+  {
     return !id().isNull() && model() != nullptr;
   }
 
@@ -45,16 +55,20 @@ public:
 private:
 
   QUuid _id;
-  void* _internalPointer = nullptr;
+  void* _internalPointer       = nullptr;
   const FlowSceneModel* _model = nullptr;
 };
 
-inline bool operator==(NodeIndex const& lhs, NodeIndex const& rhs) {
+inline bool
+operator==(NodeIndex const& lhs, NodeIndex const& rhs)
+{
   return lhs.model() == rhs.model() &&
          lhs.id()    == rhs.id();
 }
 
-inline bool operator!=(NodeIndex const& lhs, NodeIndex const& rhs) {
+inline bool
+operator!=(NodeIndex const& lhs, NodeIndex const& rhs)
+{
   return !(lhs == rhs);
 }
 

--- a/include/nodes/internal/NodePainterDelegate.hpp
+++ b/include/nodes/internal/NodePainterDelegate.hpp
@@ -2,12 +2,13 @@
 
 #include <QPainter>
 
-#include "NodeGeometry.hpp"
-#include "NodeDataModel.hpp"
 #include "Export.hpp"
 
 namespace QtNodes {
 
+class NodeGraphicsObject;
+class NodeIndex;
+  
 /// Class to allow for custom painting
 class NODE_EDITOR_PUBLIC NodePainterDelegate
 {
@@ -19,7 +20,7 @@ public:
 
   virtual void
   paint(QPainter* painter,
-        NodeGeometry const& geom,
-        NodeDataModel const * model) = 0;
+        NodeGeometry const& ngo,
+        NodeIndex const& index) = 0;
 };
 }

--- a/include/nodes/internal/NodePainterDelegate.hpp
+++ b/include/nodes/internal/NodePainterDelegate.hpp
@@ -4,11 +4,12 @@
 
 #include "Export.hpp"
 
-namespace QtNodes {
+namespace QtNodes
+{
 
 class NodeGraphicsObject;
 class NodeIndex;
-  
+
 /// Class to allow for custom painting
 class NODE_EDITOR_PUBLIC NodePainterDelegate
 {

--- a/include/nodes/internal/NodeState.hpp
+++ b/include/nodes/internal/NodeState.hpp
@@ -14,8 +14,8 @@
 namespace QtNodes
 {
 
-class Connection;
-class NodeDataModel;
+class NodeIndex;
+class ConnectionGraphicsObject;
 
 /// Contains vectors of connected input and output connections.
 /// Stores bool for reacting on hovering connections
@@ -30,33 +30,33 @@ public:
 
 public:
 
-  NodeState(std::unique_ptr<NodeDataModel> const &model);
+  NodeState(NodeIndex const& index);
 
 public:
 
-  using ConnectionPtrSet =
-          std::unordered_map<QUuid, Connection*>;
+  using ConnectionPtrVec =
+          std::vector<ConnectionGraphicsObject*>;
 
   /// Returns vector of connections ID.
   /// Some of them can be empty (null)
-  std::vector<ConnectionPtrSet> const&
+  std::vector<ConnectionPtrVec> const&
   getEntries(PortType) const;
 
-  std::vector<ConnectionPtrSet> &
+  std::vector<ConnectionPtrVec> &
   getEntries(PortType);
 
-  ConnectionPtrSet
+  ConnectionPtrVec
   connections(PortType portType, PortIndex portIndex) const;
 
   void
   setConnection(PortType portType,
                 PortIndex portIndex,
-                Connection& connection);
+                ConnectionGraphicsObject& connection);
 
   void
   eraseConnection(PortType portType,
                   PortIndex portIndex,
-                  QUuid id);
+                  ConnectionGraphicsObject& connection);
 
   ReactToConnectionState
   reaction() const;
@@ -85,8 +85,8 @@ public:
 
 private:
 
-  std::vector<ConnectionPtrSet> _inConnections;
-  std::vector<ConnectionPtrSet> _outConnections;
+  std::vector<ConnectionPtrVec> _inConnections;
+  std::vector<ConnectionPtrVec> _outConnections;
 
   ReactToConnectionState _reaction;
   PortType     _reactingPortType;

--- a/include/nodes/internal/NodeState.hpp
+++ b/include/nodes/internal/NodeState.hpp
@@ -35,7 +35,7 @@ public:
 public:
 
   using ConnectionPtrVec =
-          std::vector<ConnectionGraphicsObject*>;
+    std::vector<ConnectionGraphicsObject*>;
 
   /// Returns vector of connections ID.
   /// Some of them can be empty (null)
@@ -89,7 +89,7 @@ private:
   std::vector<ConnectionPtrVec> _outConnections;
 
   ReactToConnectionState _reaction;
-  PortType     _reactingPortType;
+  PortType _reactingPortType;
   NodeDataType _reactingDataType;
 
   bool _resizing;

--- a/include/nodes/internal/NodeStyle.hpp
+++ b/include/nodes/internal/NodeStyle.hpp
@@ -18,15 +18,19 @@ public:
 
 public:
 
-  static void setNodeStyle(QString jsonText);
+  static void
+  setNodeStyle(QString jsonText);
 
 private:
 
-  void loadJsonText(QString jsonText) override;
+  void
+  loadJsonText(QString jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void
+  loadJsonFile(QString fileName) override;
 
-  void loadJsonFromByteArray(QByteArray const &byteArray) override;
+  void
+  loadJsonFromByteArray(QByteArray const &byteArray) override;
 
 public:
 

--- a/include/nodes/internal/TypeConverter.hpp
+++ b/include/nodes/internal/TypeConverter.hpp
@@ -14,8 +14,4 @@ using SharedNodeData = std::shared_ptr<NodeData>;
 using TypeConverter =
   std::function<SharedNodeData(SharedNodeData)>;
 
-// data-type-in, data-type-out
-using TypeConverterId =
-  std::pair<NodeDataType, NodeDataType>;
-
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -64,27 +64,27 @@ save() const
 
   if (_inNode && _outNode)
   {
-    connectionJson["in_id"] = _inNode->id().toString();
+    connectionJson["in_id"]    = _inNode->id().toString();
     connectionJson["in_index"] = _inPortIndex;
 
-    connectionJson["out_id"] = _outNode->id().toString();
+    connectionJson["out_id"]    = _outNode->id().toString();
     connectionJson["out_index"] = _outPortIndex;
 
     if (_converter)
     {
       auto getTypeJson = [this](PortType type)
-      {
-        QJsonObject typeJson;
-        NodeDataType nodeType = this->dataType(type);
-        typeJson["id"] = nodeType.id;
-        typeJson["name"] = nodeType.name;
+                         {
+                           QJsonObject typeJson;
+                           NodeDataType nodeType = this->dataType(type);
+                           typeJson["id"]   = nodeType.id;
+                           typeJson["name"] = nodeType.name;
 
-        return typeJson;
-      };
+                           return typeJson;
+                         };
 
       QJsonObject converterTypeJson;
 
-      converterTypeJson["in"] = getTypeJson(PortType::In);
+      converterTypeJson["in"]  = getTypeJson(PortType::In);
       converterTypeJson["out"] = getTypeJson(PortType::Out);
 
       connectionJson["converter"] = converterTypeJson;
@@ -96,14 +96,15 @@ save() const
 
 ConnectionID
 Connection::
-id() const {
+id() const
+{
   ConnectionID ret;
   ret.lNodeID = getNode(PortType::Out)->id();
   ret.rNodeID = getNode(PortType::In)->id();
-  
+
   ret.lPortID = getPortIndex(PortType::Out);
   ret.rPortID = getPortIndex(PortType::In);
-  
+
   return ret;
 }
 
@@ -204,15 +205,15 @@ dataType(PortType portType) const
   if (_inNode && _outNode)
   {
     auto const & model = (portType == PortType::In) ?
-                        _inNode->nodeDataModel() :
-                        _outNode->nodeDataModel();
-    PortIndex index = (portType == PortType::In) ? 
+                         _inNode->nodeDataModel() :
+                         _outNode->nodeDataModel();
+    PortIndex index = (portType == PortType::In) ?
                       _inPortIndex :
                       _outPortIndex;
 
     return model->dataType(portType, index);
   }
-  else 
+  else
   {
     Node* validNode;
     PortIndex index = INVALID;

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -26,6 +26,7 @@ using QtNodes::FlowScene;
 using QtNodes::NodeDataType;
 using QtNodes::NodeIndex;
 using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 ConnectionGraphicsObject::
 ConnectionGraphicsObject(NodeIndex const& leftNode,

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -24,6 +24,7 @@ using QtNodes::Connection;
 using QtNodes::ConnectionID;
 using QtNodes::FlowScene;
 using QtNodes::NodeDataType;
+using QtNodes::NodeIndex;
 
 ConnectionGraphicsObject::
 ConnectionGraphicsObject(NodeIndex const& leftNode,
@@ -31,14 +32,14 @@ ConnectionGraphicsObject(NodeIndex const& leftNode,
                          NodeIndex const& rightNode,
                          PortIndex rightPortIndex,
                          FlowScene&       scene)
-  : _state(leftNode.isValid() ?
+  : _scene{scene}
+  , _state(leftNode.isValid() ?
            (rightNode.isValid() ?  PortType::None : PortType::In) :
            PortType::Out)
   , _leftNode{leftNode}
   , _rightNode{rightNode}
   , _leftPortIndex{leftPortIndex}
   , _rightPortIndex{rightPortIndex}
-  , _scene{scene}
 {
   _scene.addItem(this);
 

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -26,8 +26,14 @@ using QtNodes::FlowScene;
 using QtNodes::NodeDataType;
 
 ConnectionGraphicsObject::
-ConnectionGraphicsObject(const NodeIndex& leftNode, PortIndex leftPortIndex, const NodeIndex& rightNode, PortIndex rightPortIndex, FlowScene& scene)
-  : _state(leftNode.isValid() ? (rightNode.isValid() ? PortType::None : PortType::In) : PortType::Out)
+ConnectionGraphicsObject(NodeIndex const& leftNode,
+                         PortIndex leftPortIndex,
+                         NodeIndex const& rightNode,
+                         PortIndex rightPortIndex,
+                         FlowScene&       scene)
+  : _state(leftNode.isValid() ?
+           (rightNode.isValid() ?  PortType::None : PortType::In) :
+           PortType::Out)
   , _leftNode{leftNode}
   , _rightNode{rightNode}
   , _leftPortIndex{leftPortIndex}
@@ -47,14 +53,16 @@ ConnectionGraphicsObject(const NodeIndex& leftNode, PortIndex leftPortIndex, con
   setZValue(-1.0);
 
   // initialize the end points
-  if (leftNode.isValid()) {
+  if (leftNode.isValid())
+  {
     auto ngo = _scene.nodeGraphicsObject(leftNode);
     Q_ASSERT(ngo != nullptr);
 
     geometry().moveEndPoint(PortType::Out,  ngo->geometry().portScenePosition(leftPortIndex, PortType::Out, ngo->sceneTransform()));
 
   }
-  if (rightNode.isValid()) {
+  if (rightNode.isValid())
+  {
     auto ngo = _scene.nodeGraphicsObject(rightNode);
     Q_ASSERT(ngo != nullptr);
 
@@ -105,24 +113,26 @@ setGeometryChanged()
 
 ConnectionID
 ConnectionGraphicsObject::
-id() const {
+id() const
+{
   ConnectionID ret;
-  
+
   ret.lNodeID = _leftNode.id();
   ret.rNodeID = _rightNode.id();
   ret.lPortID = _leftPortIndex;
   ret.rPortID = _rightPortIndex;
-  
+
   return ret;
 }
 
 NodeDataType
-ConnectionGraphicsObject::dataType(PortType ty) const 
+ConnectionGraphicsObject::
+dataType(PortType ty) const
 {
   // get a valid node
   auto n = node(ty);
   Q_ASSERT(n.isValid());
-  
+
   return _scene.model()->nodePortDataType(n, portIndex(ty), ty);
 }
 
@@ -140,7 +150,7 @@ move()
       auto const &nodeGeom = nodeGraphics.geometry();
 
       QPointF scenePos =
-      nodeGeom.portScenePosition(portIndex(portType), 
+        nodeGeom.portScenePosition(portIndex(portType),
                                    portType,
                                    nodeGraphics.sceneTransform());
 
@@ -158,7 +168,9 @@ move()
 
 }
 
-void ConnectionGraphicsObject::lock(bool locked)
+void
+ConnectionGraphicsObject::
+lock(bool locked)
 {
   setFlag(QGraphicsItem::ItemIsMovable, !locked);
   setFlag(QGraphicsItem::ItemIsFocusable, !locked);
@@ -168,7 +180,7 @@ void ConnectionGraphicsObject::lock(bool locked)
 
 void
 ConnectionGraphicsObject::
-paint(QPainter* painter,
+paint(QPainter*                       painter,
       QStyleOptionGraphicsItem const* option,
       QWidget*)
 {
@@ -235,19 +247,22 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   auto node = locateNodeAt(event->scenePos(), _scene,
                            _scene.views()[0]->transform());
 
-  if (!node) {
-    
-    if (state().requiresPort()) {
+  if (!node)
+  {
+
+    if (state().requiresPort())
+    {
       Q_ASSERT(this == _scene._temporaryConn);
       // remove this from the scene
       delete _scene._temporaryConn;
       _scene._temporaryConn = nullptr;
     }
-    
+
     return;
   }
 
-  if (!state().requiresPort()) {
+  if (!state().requiresPort())
+  {
     return;
   }
 
@@ -278,9 +293,9 @@ hoverEnterEvent(QGraphicsSceneHoverEvent* event)
   geometry().setHovered(true);
 
   update();
-  
+
   flowScene().model()->connectionHovered(_leftNode, _leftPortIndex, _rightNode, _rightPortIndex, event->screenPos(), true);
-  
+
   event->accept();
 }
 

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -258,7 +258,7 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
       Q_ASSERT(this == _scene._temporaryConn);
       // remove this from the scene
       _scene._temporaryConn = nullptr;
-      delete this;
+      deleteLater();
     }
 
     return;
@@ -275,16 +275,14 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   {
     node->resetReactionToConnection();
     Q_ASSERT(this == _scene._temporaryConn);
-
-    delete _scene._temporaryConn;
     _scene._temporaryConn = nullptr;
+    deleteLater();
   }
   else if (state().requiresPort())
   {
     Q_ASSERT(this == _scene._temporaryConn);
-
-    delete _scene._temporaryConn;
     _scene._temporaryConn = nullptr;
+    deleteLater();
   }
 }
 

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -25,6 +25,7 @@ using QtNodes::ConnectionID;
 using QtNodes::FlowScene;
 using QtNodes::NodeDataType;
 using QtNodes::NodeIndex;
+using QtNodes::PortIndex;
 
 ConnectionGraphicsObject::
 ConnectionGraphicsObject(NodeIndex const& leftNode,

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -257,8 +257,8 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
     {
       Q_ASSERT(this == _scene._temporaryConn);
       // remove this from the scene
-      delete _scene._temporaryConn;
       _scene._temporaryConn = nullptr;
+      delete this;
     }
 
     return;

--- a/src/ConnectionPainter.cpp
+++ b/src/ConnectionPainter.cpp
@@ -222,10 +222,10 @@ drawNormalLine(QPainter * painter,
   {
     painter->setBrush(Qt::NoBrush);
 
-    QColor c = normalColorOut;
+    QColor cOut = normalColorOut;
     if (selected)
-      c = c.darker(200);
-    p.setColor(c);
+      cOut = cOut.darker(200);
+    p.setColor(cOut);
     painter->setPen(p);
 
     unsigned int const segments = 60;
@@ -237,11 +237,11 @@ drawNormalLine(QPainter * painter,
 
       if (i == segments / 2)
       {
-        QColor c = normalColorIn;
+        QColor cIn = normalColorIn;
         if (selected)
-          c = c.darker(200);
+          cIn = cIn.darker(200);
 
-        p.setColor(c);
+        p.setColor(cIn);
         painter->setPen(p);
       }
       painter->drawLine(cubic.pointAtPercent(ratioPrev),

--- a/src/ConnectionPainter.cpp
+++ b/src/ConnectionPainter.cpp
@@ -136,9 +136,9 @@ drawHoveredOrSelected(QPainter * painter,
   using QtNodes::ConnectionGeometry;
 
   ConnectionGeometry const& geom = cgo.geometry();
-  bool const hovered = geom.hovered();
+  bool const hovered             = geom.hovered();
 
-  
+
   bool const selected = cgo.isSelected();
 
   // drawn as a fat background
@@ -148,7 +148,7 @@ drawHoveredOrSelected(QPainter * painter,
 
     auto const &connectionStyle =
       QtNodes::StyleCollection::connectionStyle();
-    double const lineWidth     = connectionStyle.lineWidth();
+    double const lineWidth = connectionStyle.lineWidth();
 
     p.setWidth(2 * lineWidth);
     p.setColor(selected ?
@@ -183,9 +183,9 @@ drawNormalLine(QPainter * painter,
   auto const &connectionStyle =
     QtNodes::StyleCollection::connectionStyle();
 
-  QColor normalColorOut  = connectionStyle.normalColor();
-  QColor normalColorIn   = connectionStyle.normalColor();
-  QColor selectedColor = connectionStyle.selectedColor();
+  QColor normalColorOut = connectionStyle.normalColor();
+  QColor normalColorIn  = connectionStyle.normalColor();
+  QColor selectedColor  = connectionStyle.selectedColor();
 
   bool gradientColor = false;
 
@@ -194,13 +194,13 @@ drawNormalLine(QPainter * painter,
     using QtNodes::PortType;
 
     auto dataTypeOut = connection.dataType(PortType::Out);
-    auto dataTypeIn = connection.dataType(PortType::In);
+    auto dataTypeIn  = connection.dataType(PortType::In);
 
     gradientColor = (dataTypeOut.id != dataTypeIn.id);
 
-    normalColorOut  = connectionStyle.normalColor(dataTypeOut.id);
-    normalColorIn   = connectionStyle.normalColor(dataTypeIn.id);
-    selectedColor = normalColorOut.darker(200);
+    normalColorOut = connectionStyle.normalColor(dataTypeOut.id);
+    normalColorIn  = connectionStyle.normalColor(dataTypeIn.id);
+    selectedColor  = normalColorOut.darker(200);
   }
 
   // geometry
@@ -222,7 +222,7 @@ drawNormalLine(QPainter * painter,
   {
     painter->setBrush(Qt::NoBrush);
 
-    QColor c = normalColorOut; 
+    QColor c = normalColorOut;
     if (selected)
       c = c.darker(200);
     p.setColor(c);
@@ -233,11 +233,11 @@ drawNormalLine(QPainter * painter,
     for (unsigned int i = 0ul; i < segments; ++i)
     {
       double ratioPrev = double(i) / segments;
-      double ratio = double(i + 1) / segments;
+      double ratio     = double(i + 1) / segments;
 
       if (i == segments / 2)
       {
-        QColor c = normalColorIn; 
+        QColor c = normalColorIn;
         if (selected)
           c = c.darker(200);
 

--- a/src/ConnectionPainter.cpp
+++ b/src/ConnectionPainter.cpp
@@ -5,7 +5,6 @@
 #include "ConnectionGeometry.hpp"
 #include "ConnectionState.hpp"
 #include "ConnectionGraphicsObject.hpp"
-#include "Connection.hpp"
 
 #include "NodeData.hpp"
 
@@ -14,7 +13,7 @@
 
 using QtNodes::ConnectionPainter;
 using QtNodes::ConnectionGeometry;
-using QtNodes::Connection;
+using QtNodes::ConnectionGraphicsObject;
 
 
 static
@@ -62,12 +61,12 @@ getPainterStroke(ConnectionGeometry const& geom)
 static
 void
 debugDrawing(QPainter * painter,
-             Connection const & connection)
+             ConnectionGraphicsObject const & connection)
 {
   Q_UNUSED(painter);
   Q_UNUSED(connection);
   ConnectionGeometry const& geom =
-    connection.connectionGeometry();
+    connection.geometry();
 
   {
     QPointF const& source = geom.source();
@@ -100,12 +99,12 @@ debugDrawing(QPainter * painter,
 static
 void
 drawSketchLine(QPainter * painter,
-               Connection const & connection)
+               ConnectionGraphicsObject const & connection)
 {
   using QtNodes::ConnectionState;
 
   ConnectionState const& state =
-    connection.connectionState();
+    connection.state();
 
   if (state.requiresPort())
   {
@@ -121,7 +120,7 @@ drawSketchLine(QPainter * painter,
     painter->setBrush(Qt::NoBrush);
 
     using QtNodes::ConnectionGeometry;
-    ConnectionGeometry const& geom = connection.connectionGeometry();
+    ConnectionGeometry const& geom = connection.geometry();
 
     auto cubic = cubicPath(geom);
     // cubic spline
@@ -132,17 +131,15 @@ drawSketchLine(QPainter * painter,
 static
 void
 drawHoveredOrSelected(QPainter * painter,
-                      Connection const & connection)
+                      ConnectionGraphicsObject const & cgo)
 {
   using QtNodes::ConnectionGeometry;
 
-  ConnectionGeometry const& geom = connection.connectionGeometry();
+  ConnectionGeometry const& geom = cgo.geometry();
   bool const hovered = geom.hovered();
 
-  auto const& graphicsObject =
-    connection.getConnectionGraphicsObject();
-
-  bool const selected = graphicsObject.isSelected();
+  
+  bool const selected = cgo.isSelected();
 
   // drawn as a fat background
   if (hovered || selected)
@@ -171,12 +168,12 @@ drawHoveredOrSelected(QPainter * painter,
 static
 void
 drawNormalLine(QPainter * painter,
-               Connection const & connection)
+               ConnectionGraphicsObject const & connection)
 {
   using QtNodes::ConnectionState;
 
   ConnectionState const& state =
-    connection.connectionState();
+    connection.state();
 
   if (state.requiresPort())
     return;
@@ -208,7 +205,7 @@ drawNormalLine(QPainter * painter,
 
   // geometry
 
-  ConnectionGeometry const& geom = connection.connectionGeometry();
+  ConnectionGeometry const& geom = connection.geometry();
 
   double const lineWidth = connectionStyle.lineWidth();
 
@@ -217,8 +214,7 @@ drawNormalLine(QPainter * painter,
 
   p.setWidth(lineWidth);
 
-  auto const& graphicsObject = connection.getConnectionGraphicsObject();
-  bool const selected = graphicsObject.isSelected();
+  bool const selected = connection.isSelected();
 
 
   auto cubic = cubicPath(geom);
@@ -282,7 +278,7 @@ drawNormalLine(QPainter * painter,
 void
 ConnectionPainter::
 paint(QPainter* painter,
-      Connection const &connection)
+      ConnectionGraphicsObject const &connection)
 {
   drawHoveredOrSelected(painter, connection);
 
@@ -295,7 +291,7 @@ paint(QPainter* painter,
 #endif
 
   // draw end points
-  ConnectionGeometry const& geom = connection.connectionGeometry();
+  ConnectionGeometry const& geom = connection.geometry();
 
   QPointF const & source = geom.source();
   QPointF const & sink   = geom.sink();

--- a/src/ConnectionPainter.hpp
+++ b/src/ConnectionPainter.hpp
@@ -6,8 +6,7 @@ namespace QtNodes
 {
 
 class ConnectionGeometry;
-class ConnectionState;
-class Connection;
+class ConnectionGraphicsObject;
 
 class ConnectionPainter
 {
@@ -16,7 +15,7 @@ public:
   static
   void
   paint(QPainter* painter,
-        Connection const& connection);
+        ConnectionGraphicsObject const& connection);
 
   static
   QPainterPath

--- a/src/ConnectionState.cpp
+++ b/src/ConnectionState.cpp
@@ -5,10 +5,10 @@
 #include <QtCore/QPointF>
 
 #include "FlowScene.hpp"
-#include "Node.hpp"
+#include "NodeGraphicsObject.hpp"
 
 using QtNodes::ConnectionState;
-using QtNodes::Node;
+using QtNodes::NodeGraphicsObject;
 
 ConnectionState::
 ~ConnectionState()
@@ -19,7 +19,7 @@ ConnectionState::
 
 void
 ConnectionState::
-interactWithNode(Node* node)
+interactWithNode(NodeGraphicsObject* node)
 {
   if (node)
   {
@@ -34,7 +34,7 @@ interactWithNode(Node* node)
 
 void
 ConnectionState::
-setLastHoveredNode(Node* node)
+setLastHoveredNode(NodeGraphicsObject* node)
 {
   _lastHoveredNode = node;
 }

--- a/src/ConnectionStyle.cpp
+++ b/src/ConnectionStyle.cpp
@@ -14,7 +14,8 @@
 
 using QtNodes::ConnectionStyle;
 
-inline void initResources() { Q_INIT_RESOURCE(resources); }
+inline void
+initResources() { Q_INIT_RESOURCE(resources); }
 
 ConnectionStyle::
 ConnectionStyle()
@@ -47,10 +48,10 @@ setConnectionStyle(QString jsonText)
 
 #ifdef STYLE_DEBUG
   #define CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(v, variable) { \
-      if (v.type() == QJsonValue::Undefined || \
-          v.type() == QJsonValue::Null) \
-        qWarning() << "Undefined value for parameter:" << #variable; \
-  }
+    if (v.type() == QJsonValue::Undefined || \
+        v.type() == QJsonValue::Null) \
+      qWarning() << "Undefined value for parameter:" << #variable; \
+}
 #else
   #define CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
 #endif
@@ -63,7 +64,7 @@ setConnectionStyle(QString jsonText)
 #define CONNECTION_STYLE_READ_COLOR(values, variable)  { \
     auto valueRef = values[#variable]; \
     CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    if (CONNECTION_VALUE_EXISTS(valueRef)) {\
+    if (CONNECTION_VALUE_EXISTS(valueRef)) { \
       if (valueRef.isArray()) { \
         auto colorArray = valueRef.toArray(); \
         std::vector<int> rgb; rgb.reserve(3); \

--- a/src/DataFlowModel.cpp
+++ b/src/DataFlowModel.cpp
@@ -16,6 +16,7 @@ using QtNodes::NodeDataType;
 using QtNodes::PortIndex;
 using QtNodes::ConnectionPolicy;
 using QtNodes::Connection;
+using QtNodes::TypeConverter;
 
 DataFlowModel::
 DataFlowModel(std::shared_ptr<DataModelRegistry> registry)

--- a/src/DataFlowModel.cpp
+++ b/src/DataFlowModel.cpp
@@ -15,6 +15,7 @@ using QtNodes::NodePainterDelegate;
 using QtNodes::NodeDataType;
 using QtNodes::PortIndex;
 using QtNodes::ConnectionPolicy;
+using QtNodes::Connection;
 
 DataFlowModel::
 DataFlowModel(std::shared_ptr<DataModelRegistry> registry)

--- a/src/DataFlowModel.cpp
+++ b/src/DataFlowModel.cpp
@@ -1,0 +1,437 @@
+#include "DataFlowModel.hpp"
+#include "Node.hpp"
+#include "Connection.hpp"
+
+using QtNodes::DataFlowModel;
+using QtNodes::NodeIndex;
+using QtNodes::NodeValidationState;
+using QtNodes::DataModelRegistry;
+using QtNodes::TypeConverterId;
+using QtNodes::Node;
+using QtNodes::PortType;
+using QtNodes::ConnectionID;
+using QtNodes::NodeDataModel;
+using QtNodes::NodePainterDelegate;
+using QtNodes::NodeDataType;
+using QtNodes::PortIndex;
+using QtNodes::ConnectionPolicy;
+
+DataFlowModel::
+DataFlowModel(std::shared_ptr<DataModelRegistry> registry)
+  : _registry(std::move(registry))
+{
+}
+
+// FlowSceneModel read interface
+QStringList
+DataFlowModel::
+modelRegistry() const
+{
+  QStringList list;
+  for (const auto& item : _registry->registeredModelCreators())
+  {
+    list << item.first;
+  }
+  return list;
+}
+
+QString
+DataFlowModel::
+nodeTypeCatergory(QString const& name) const
+{
+  auto iter = _registry->registeredModelsCategoryAssociation().find(name);
+
+  if (iter != _registry->registeredModelsCategoryAssociation().end())
+  {
+    return iter->second;
+  }
+  return {};
+}
+
+bool
+DataFlowModel::
+getTypeConvertable(TypeConverterId const& id) const
+{
+  return static_cast<bool>(_registry->getTypeConverter(id.first, id.second));
+}
+
+
+
+QList<QUuid>
+DataFlowModel::
+nodeUUids() const
+{
+  QList<QUuid> ret;
+
+  // extract the keys
+  std::transform(_nodes.begin(),
+                 _nodes.end(),
+                 std::back_inserter(ret),
+                 [](const auto& pair) {
+                   return pair.first;
+                 });
+
+  return ret;
+}
+NodeIndex
+DataFlowModel::
+nodeIndex(const QUuid& ID) const
+{
+  auto iter = _nodes.find(ID);
+  if (iter == _nodes.end())
+    return {};
+
+  return createIndex(ID, iter->second.get());
+}
+QString
+DataFlowModel::
+nodeTypeIdentifier(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->name();
+}
+QString
+DataFlowModel::
+nodeCaption(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  if (!node->nodeDataModel()->captionVisible())
+    return {};
+
+  return node->nodeDataModel()->caption();
+}
+QPointF
+DataFlowModel::
+nodeLocation(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->position();
+}
+QWidget*
+DataFlowModel::
+nodeWidget(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->embeddedWidget();
+}
+bool
+DataFlowModel::
+nodeResizable(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->resizable();
+}
+NodeValidationState
+DataFlowModel::
+nodeValidationState(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->validationState();
+}
+
+
+QString
+DataFlowModel::
+nodeValidationMessage(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->validationMessage();
+}
+
+
+NodePainterDelegate*
+DataFlowModel::
+nodePainterDelegate(NodeIndex const& index) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->painterDelegate();
+}
+
+
+unsigned int
+DataFlowModel::
+nodePortCount(NodeIndex const& index, PortType portType) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->nPorts(portType);
+}
+
+
+QString
+DataFlowModel::
+nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->portCaption(portType, pIndex);
+}
+
+
+NodeDataType
+DataFlowModel::
+nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  return node->nodeDataModel()->dataType(portType, pIndex);
+}
+ConnectionPolicy
+DataFlowModel::
+nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  if (portType == PortType::In)
+  {
+    return ConnectionPolicy::One;
+  }
+  return node->nodeDataModel()->portOutConnectionPolicy(pIndex);
+}
+std::vector<std::pair<NodeIndex, PortIndex> >
+DataFlowModel::
+nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  std::vector<std::pair<NodeIndex, PortIndex> > ret;
+  // construct connections
+  for (const auto& conn : node->connections(portType, id))
+  {
+    ret.emplace_back(nodeIndex(conn->getNode(oppositePort(portType))->id()), conn->getPortIndex(oppositePort(portType)));
+  }
+  return ret;
+}
+
+// FlowSceneModel write interface
+bool
+
+DataFlowModel::
+removeConnection(NodeIndex const& leftNodeIdx,
+                 PortIndex leftPortID,
+                 NodeIndex const& rightNodeIdx,
+                 PortIndex rightPortID)
+{
+  Q_ASSERT(leftNodeIdx.isValid());
+  Q_ASSERT(rightNodeIdx.isValid());
+
+  auto* leftNode  = static_cast<Node*>(leftNodeIdx.internalPointer());
+  auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
+
+  ConnectionID connID;
+  connID.lNodeID = leftNodeIdx.id();
+  connID.rNodeID = rightNodeIdx.id();
+  connID.lPortID = leftPortID;
+  connID.rPortID = rightPortID;
+
+  _connections[connID]->propagateEmptyData();
+
+  // remove it from the nodes
+  auto& leftConns = leftNode->connections(PortType::Out, leftPortID);
+  auto iter       = std::find_if(leftConns.begin(), leftConns.end(), [&](Connection* conn){
+                                   return conn->id() == connID;
+                                 });
+  Q_ASSERT(iter != leftConns.end());
+  leftConns.erase(iter);
+
+  auto& rightConns = rightNode->connections(PortType::In, rightPortID);
+  iter = std::find_if(rightConns.begin(), rightConns.end(), [&](Connection* conn){
+                        return conn->id() == connID;
+                      });
+  Q_ASSERT(iter != rightConns.end());
+  rightConns.erase(iter);
+
+  // remove it from the map
+  _connections.erase(connID);
+
+  // tell the view
+  emit connectionRemoved(leftNodeIdx, leftPortID, rightNodeIdx, rightPortID);
+
+  return true;
+}
+
+
+bool
+
+DataFlowModel::
+addConnection(NodeIndex const& leftNodeIdx,
+              PortIndex leftPortID,
+              NodeIndex const& rightNodeIdx,
+              PortIndex rightPortID)
+{
+  Q_ASSERT(leftNodeIdx.isValid());
+  Q_ASSERT(rightNodeIdx.isValid());
+
+  auto* leftNode  = static_cast<Node*>(leftNodeIdx.internalPointer());
+  auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
+
+  // type conversions
+  TypeConverter conv = {};
+  auto ltype         = nodePortDataType(leftNodeIdx, leftPortID, PortType::Out);
+  auto rtype         = nodePortDataType(rightNodeIdx, rightPortID, PortType::In);
+  if (ltype.id != rtype.id)
+  {
+    conv = _registry->getTypeConverter(ltype, rtype);
+  }
+
+  addConnection(leftNode, leftPortID, rightNode, rightPortID, conv);
+
+  return true;
+}
+
+
+bool
+DataFlowModel::
+removeNode(NodeIndex const& index)
+{
+  Q_ASSERT(index.isValid());
+
+  // make sure there are no connections left
+#ifndef QT_NO_DEBUG
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::In); ++idx)
+  {
+    Q_ASSERT(node->connections(PortType::In, idx).empty());
+  }
+  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::Out); ++idx)
+  {
+    Q_ASSERT(node->connections(PortType::Out, idx).empty());
+  }
+#endif
+
+  // remove it from the map
+  _nodes.erase(index.id());
+
+  // tell the view
+  emit nodeRemoved(index.id());
+
+  return true;
+}
+QUuid
+DataFlowModel::
+addNode(const QString& typeID, QPointF const& location)
+{
+  auto nodeid = QUuid::createUuid();
+  addNode(typeID, location, nodeid);
+  return nodeid;
+}
+QUuid
+DataFlowModel::
+addNode(QString const& typeID, QPointF const& location, QUuid const& nodeid)
+{
+  // create the NodeDataModel
+  auto model = _registry->create(typeID);
+  if (!model)
+  {
+    return {};
+  }
+  return addNode(std::move(model), location, nodeid);
+}
+QUuid
+DataFlowModel::
+addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& nodeid)
+{
+
+  connect(model.get(), &NodeDataModel::dataUpdated, this, [this, nodeid](PortIndex){
+            emit nodeValidationUpdated(nodeIndex(nodeid));
+          });
+
+  // create a node
+  auto node = std::make_unique<Node>(std::move(model), nodeid);
+
+  node->setPosition(location);
+
+  // cache the pointer so the connection can be made
+  auto nodePtr = node.get();
+
+  // add it to the map
+  _nodes[nodeid] = std::move(node);
+
+  // connect to the geometry gets updated
+  connect(nodePtr, &Node::positionChanged, this, [this, nodeid](QPointF const&){
+            emit nodeMoved(nodeIndex(nodeid));
+          });
+
+  // tell the view
+  emit nodeAdded(nodeid);
+
+  return nodeid;
+}
+
+
+ConnectionID
+DataFlowModel::
+addConnection(Node* leftNode, PortIndex leftPortID, Node* rightNode, PortIndex rightPortID, TypeConverter conv)
+{
+
+  ConnectionID connID;
+  connID.lNodeID = leftNode->id();
+  connID.rNodeID = rightNode->id();
+  connID.lPortID = leftPortID;
+  connID.rPortID = rightPortID;
+
+  // create the connection
+  auto conn = std::make_shared<Connection>(*rightNode, rightPortID, *leftNode, leftPortID, conv);
+  _connections[connID] = conn;
+
+  // add it to the nodes
+  leftNode->connections(PortType::Out, leftPortID).push_back(conn.get());
+  rightNode->connections(PortType::In, rightPortID).push_back(conn.get());
+
+  // process data
+  conn->getNode(PortType::Out)->onDataUpdated(conn->getPortIndex(PortType::Out));
+
+  // tell the view the connection was added
+  emit connectionAdded(nodeIndex(leftNode->id()), leftPortID, nodeIndex(rightNode->id()), rightPortID);
+
+  return connID;
+}
+
+bool
+DataFlowModel::
+moveNode(NodeIndex const& index, QPointF newLocation)
+{
+  Q_ASSERT(index.isValid());
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+  node->setPosition(newLocation);
+
+  // no need to emit, it's done by the function already
+  return true;
+}

--- a/src/DataFlowModel.cpp
+++ b/src/DataFlowModel.cpp
@@ -39,7 +39,7 @@ modelRegistry() const
 
 QString
 DataFlowModel::
-nodeTypeCatergory(QString const& name) const
+nodeTypeCategory(QString const& name) const
 {
   auto iter = _registry->registeredModelsCategoryAssociation().find(name);
 

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -136,10 +136,11 @@ restoreNode(QJsonObject const& nodeJson)
 
   auto uid = QUuid(nodeJson["id"].toString());
  
-  _dataFlowModel->addNode(modelName, point, uid);
+  // set initial point to 0, 0, will be updated in Node::restore
+  _dataFlowModel->addNode(modelName, QPointF(0, 0), uid);
 
   auto& node = *_dataFlowModel->_nodes[uid];
-  node->restore(nodeJson);
+  node.restore(nodeJson);
   
   return node;
 }

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -18,42 +18,83 @@ using QtNodes::NodeDataType;
 using QtNodes::ConnectionPolicy;
 using QtNodes::PortIndex;
 
-class DataFlowScene::DataFlowModel : public FlowSceneModel {
+class DataFlowScene::DataFlowModel : public FlowSceneModel
+{
 public:
-  
+
   DataFlowModel(std::shared_ptr<DataModelRegistry> reg);
 
   // FlowSceneModel read interface
-  QStringList modelRegistry() const override;
-  QString nodeTypeCatergory(QString const& name) const override;
-  bool getTypeConvertable(TypeConverterId const& id ) const override;
-  QList<QUuid> nodeUUids() const override;
-  NodeIndex nodeIndex(const QUuid& ID) const override;
-  QString nodeTypeIdentifier(NodeIndex const& index) const override;
-  QString nodeCaption(NodeIndex const& index) const override;
-  QPointF nodeLocation(NodeIndex const& index) const override;
-  QWidget* nodeWidget(NodeIndex const& index) const override;
-  bool nodeResizable(NodeIndex const& index) const override;
-  NodeValidationState nodeValidationState(NodeIndex const& index) const override;
-  QString nodeValidationMessage(NodeIndex const& index) const override;
-  NodePainterDelegate* nodePainterDelegate(NodeIndex const& index) const override;
-  unsigned int nodePortCount(NodeIndex const& index, PortType portType) const override;
-  QString nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
-  NodeDataType nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
-  ConnectionPolicy nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
-  std::vector<std::pair<NodeIndex, PortIndex>> nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const override;
+  QStringList
+  modelRegistry() const override;
+
+  QString
+  nodeTypeCatergory(QString const& name) const override;
+
+  bool
+  getTypeConvertable(TypeConverterId const& id ) const override;
+
+  QList<QUuid>
+  nodeUUids() const override;
+
+  NodeIndex
+  nodeIndex(const QUuid& ID) const override;
+
+  QString
+  nodeTypeIdentifier(NodeIndex const& index) const override;
+
+  QString
+  nodeCaption(NodeIndex const& index) const override;
+
+  QPointF
+  nodeLocation(NodeIndex const& index) const override;
+
+  QWidget*
+  nodeWidget(NodeIndex const& index) const override;
+
+  bool
+  nodeResizable(NodeIndex const& index) const override;
+
+  NodeValidationState
+  nodeValidationState(NodeIndex const& index) const override;
+
+  QString
+  nodeValidationMessage(NodeIndex const& index) const override;
+
+  NodePainterDelegate*
+  nodePainterDelegate(NodeIndex const& index) const override;
+
+  unsigned int
+  nodePortCount(NodeIndex const& index, PortType portType) const override;
+
+  QString
+  nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  NodeDataType
+  nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  ConnectionPolicy
+  nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  std::vector<std::pair<NodeIndex, PortIndex> >
+  nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const override;
 
   // FlowSceneModel write interface
-  bool removeConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
-  bool addConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
-  bool removeNode(NodeIndex const& index) override;
-  QUuid addNode(QString const& typeID, QPointF const& location) override;
-  bool moveNode(NodeIndex const& index, QPointF newLocation) override;
+  bool
+  removeConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
+  bool
+  addConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
+  bool
+  removeNode(NodeIndex const& index) override;
+  QUuid
+  addNode(QString const& typeID, QPointF const& location) override;
+  bool
+  moveNode(NodeIndex const& index, QPointF newLocation) override;
 
   // convenience functions
-  QUuid addNode(QString const& typeID, QPointF const& location, QUuid const& uuid);
-  QUuid addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& uuid = QUuid::createUuid());
-  ConnectionID addConnection(Node* left, PortIndex leftIdx, Node* right, PortIndex rightIdx, TypeConverter converter);
+  QUuid
+  addNode(QString const& typeID, QPointF const& location, QUuid const& uuid);
+  QUuid
+  addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& uuid = QUuid::createUuid());
+  ConnectionID
+  addConnection(Node* left, PortIndex leftIdx, Node* right, PortIndex rightIdx, TypeConverter converter);
 
   using SharedConnection = std::shared_ptr<Connection>;
   using UniqueNode       = std::unique_ptr<Node>;
@@ -64,20 +105,25 @@ public:
 };
 
 
-DataFlowScene::DataFlowScene(std::shared_ptr<DataModelRegistry> registry, QObject* parent) 
-  : FlowScene(new DataFlowModel(std::move(registry)), parent) {
+DataFlowScene::
+DataFlowScene(std::shared_ptr<DataModelRegistry> registry, QObject* parent)
+  : FlowScene(new DataFlowModel(std::move(registry)), parent)
+{
   _dataFlowModel = static_cast<DataFlowModel*>(model());
 }
 
 std::shared_ptr<Connection>
 DataFlowScene::
 createConnection(Node& nodeIn,
-                  PortIndex portIndexIn,
-                  Node& nodeOut,
-                  PortIndex portIndexOut,
-                  TypeConverter const& converter) {
-  
-  auto connid = _dataFlowModel->addConnection(&nodeOut, portIndexOut, &nodeIn, portIndexIn, converter);
+                 PortIndex portIndexIn,
+                 Node& nodeOut,
+                 PortIndex portIndexOut,
+                 TypeConverter const& converter)
+{
+  auto connid =
+    _dataFlowModel->addConnection(&nodeOut, portIndexOut,
+                                  &nodeIn, portIndexIn,
+                                  converter);
 
   return _dataFlowModel->_connections[connid];
 }
@@ -96,15 +142,17 @@ restoreConnection(QJsonObject const &connectionJson)
   ConnectionID connId;
   connId.lNodeID = nodeOutId;
   connId.rNodeID = nodeInId;
-  
+
   connId.lPortID = portIndexOut;
   connId.rPortID = portIndexIn;
-  
-  if (!_dataFlowModel->addConnection(_dataFlowModel->nodeIndex(nodeOutId), connId.lPortID, _dataFlowModel->nodeIndex(nodeInId), connId.rPortID)) 
+
+  if (!_dataFlowModel->addConnection(_dataFlowModel->nodeIndex(nodeOutId),
+                                     connId.lPortID,
+                                     _dataFlowModel->nodeIndex(nodeInId),
+                                     connId.rPortID))
     return nullptr;
 
   return _dataFlowModel->_connections[connId];
-  
 }
 
 void
@@ -135,17 +183,17 @@ restoreNode(QJsonObject const& nodeJson)
   QString modelName = nodeJson["model"].toObject()["name"].toString();
 
   auto uid = QUuid(nodeJson["id"].toString());
- 
+
   // set initial point to 0, 0, will be updated in Node::restore
   _dataFlowModel->addNode(modelName, QPointF(0, 0), uid);
 
   auto& node = *_dataFlowModel->_nodes[uid];
   node.restore(nodeJson);
-  
+
   return node;
 }
 
-void 
+void
 DataFlowScene::
 removeNode(Node& node)
 {
@@ -168,9 +216,10 @@ setRegistry(std::shared_ptr<DataModelRegistry> registry)
 
 void
 DataFlowScene::
-iterateOverNodes(std::function<void(Node*)> const& visitor) 
+iterateOverNodes(std::function<void(Node*)> const& visitor)
 {
-  for (auto const& node : _dataFlowModel->_nodes) {
+  for (auto const& node : _dataFlowModel->_nodes)
+  {
     visitor(node.second.get());
   }
 }
@@ -179,7 +228,8 @@ void
 DataFlowScene::
 iterateOverNodeData(std::function<void(NodeDataModel*)> const& visitor)
 {
-  for (auto const& node : _dataFlowModel->_nodes) {
+  for (auto const& node : _dataFlowModel->_nodes)
+  {
     visitor(node.second->nodeDataModel());
   }
 }
@@ -260,7 +310,7 @@ iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& vis
 
 QPointF
 DataFlowScene::
-getNodePosition(Node const& node) const 
+getNodePosition(Node const& node) const
 {
   return _dataFlowModel->nodeLocation(_dataFlowModel->nodeIndex(node.id()));
 }
@@ -280,9 +330,9 @@ nodes() const
   return _dataFlowModel->_nodes;
 }
 
-std::unordered_map<ConnectionID, std::shared_ptr<Connection>> const &
+std::unordered_map<ConnectionID, std::shared_ptr<Connection> > const &
 DataFlowScene::
-connections() const 
+connections() const
 {
   return _dataFlowModel->_connections;
 }
@@ -295,16 +345,17 @@ selectedNodes() const
   std::vector<Node*> ret;
   ret.reserve(ids.size());
 
-  std::transform(ids.begin(), ids.end(), std::back_inserter(ret), [this](NodeIndex const& id) {
-    return _dataFlowModel->_nodes.find(id.id())->second.get();
-  });
+  std::transform(ids.begin(), ids.end(), std::back_inserter(ret),
+                 [this](NodeIndex const& id)
+                 { return _dataFlowModel->_nodes.find(id.id())->second.get(); });
 
   return ret;
 }
 
 void
 DataFlowScene::
-clearScene() {
+clearScene()
+{
   // delete all the nodes
   while(!_dataFlowModel->_nodes.empty()) {
     removeNode(*_dataFlowModel->_nodes.begin()->second);
@@ -420,155 +471,243 @@ loadFromMemory(const QByteArray& data)
   }
 }
 
-DataFlowScene::DataFlowModel::DataFlowModel(std::shared_ptr<DataModelRegistry> registry) 
-  : _registry(std::move(registry)) {
+DataFlowScene::DataFlowModel::
+DataFlowModel(std::shared_ptr<DataModelRegistry> registry)
+  : _registry(std::move(registry))
+{
 }
 
 // FlowSceneModel read interface
-QStringList DataFlowScene::DataFlowModel::modelRegistry() const {
+QStringList
+DataFlowScene::DataFlowModel::
+modelRegistry() const
+{
   QStringList list;
-  for (const auto& item : _registry->registeredModelCreators()) {
+  for (const auto& item : _registry->registeredModelCreators())
+  {
     list << item.first;
   }
   return list;
 }
-QString DataFlowScene::DataFlowModel::nodeTypeCatergory(QString const& name) const {
+
+QString
+DataFlowScene::DataFlowModel::
+nodeTypeCatergory(QString const& name) const
+{
   auto iter = _registry->registeredModelsCategoryAssociation().find(name);
-  
-  if (iter != _registry->registeredModelsCategoryAssociation().end()) {
+
+  if (iter != _registry->registeredModelsCategoryAssociation().end())
+  {
     return iter->second;
   }
   return {};
 }
-bool DataFlowScene::DataFlowModel::getTypeConvertable(TypeConverterId const& id) const {
+
+bool
+DataFlowScene::DataFlowModel::
+getTypeConvertable(TypeConverterId const& id) const
+{
   return static_cast<bool>(_registry->getTypeConverter(id.first, id.second));
 }
-QList<QUuid> DataFlowScene::DataFlowModel::nodeUUids() const {
+
+
+
+QList<QUuid>
+DataFlowScene::
+DataFlowModel::
+nodeUUids() const
+{
   QList<QUuid> ret;
 
   // extract the keys
-  std::transform(_nodes.begin(), _nodes.end(), std::back_inserter(ret), [](const auto& pair) {
-    return pair.first;
-  });
+  std::transform(_nodes.begin(),
+                 _nodes.end(),
+                 std::back_inserter(ret),
+                 [](const auto& pair) {
+                   return pair.first;
+                 });
 
   return ret;
 }
-NodeIndex DataFlowScene::DataFlowModel::nodeIndex(const QUuid& ID) const {
+NodeIndex
+DataFlowScene::DataFlowModel::
+nodeIndex(const QUuid& ID) const
+{
   auto iter = _nodes.find(ID);
-  if (iter == _nodes.end()) return {};
-  
+  if (iter == _nodes.end())
+    return {};
+
   return createIndex(ID, iter->second.get());
 }
-QString DataFlowScene::DataFlowModel::nodeTypeIdentifier(NodeIndex const& index) const {
+QString
+DataFlowScene::DataFlowModel::
+nodeTypeIdentifier(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->name();
 }
-QString DataFlowScene::DataFlowModel::nodeCaption(NodeIndex const& index) const {
+QString
+DataFlowScene::DataFlowModel::
+nodeCaption(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
-  if (!node->nodeDataModel()->captionVisible()) return {};
-  
+
+  if (!node->nodeDataModel()->captionVisible())
+    return {};
+
   return node->nodeDataModel()->caption();
 }
-QPointF DataFlowScene::DataFlowModel::nodeLocation(NodeIndex const& index) const {
+QPointF
+DataFlowScene::DataFlowModel::
+nodeLocation(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->position();
 }
-QWidget* DataFlowScene::DataFlowModel::nodeWidget(NodeIndex const& index) const {
+QWidget*
+DataFlowScene::DataFlowModel::
+nodeWidget(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->embeddedWidget();
 }
-bool DataFlowScene::DataFlowModel::nodeResizable(NodeIndex const& index) const {
+bool
+DataFlowScene::DataFlowModel::
+nodeResizable(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->resizable();
 }
-NodeValidationState DataFlowScene::DataFlowModel::nodeValidationState(NodeIndex const& index) const {
+NodeValidationState
+DataFlowScene::DataFlowModel::
+nodeValidationState(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->validationState();
 }
-QString DataFlowScene::DataFlowModel::nodeValidationMessage(NodeIndex const& index) const {
+
+
+QString
+DataFlowScene::DataFlowModel::
+nodeValidationMessage(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->validationMessage();
 }
-NodePainterDelegate* DataFlowScene::DataFlowModel::nodePainterDelegate(NodeIndex const& index) const {
+
+
+NodePainterDelegate*
+DataFlowScene::DataFlowModel::
+nodePainterDelegate(NodeIndex const& index) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->painterDelegate();
 }
-unsigned int DataFlowScene::DataFlowModel::nodePortCount(NodeIndex const& index, PortType portType) const {
+
+
+unsigned int
+DataFlowScene::DataFlowModel::
+nodePortCount(NodeIndex const& index, PortType portType) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->nPorts(portType);
 }
-QString DataFlowScene::DataFlowModel::nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const {
+
+
+QString
+DataFlowScene::DataFlowModel::
+nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->portCaption(portType, pIndex);
 }
-NodeDataType DataFlowScene::DataFlowModel::nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const {
+
+
+NodeDataType
+DataFlowScene::DataFlowModel::
+nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   return node->nodeDataModel()->dataType(portType, pIndex);
 }
-ConnectionPolicy DataFlowScene::DataFlowModel::nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const {
+ConnectionPolicy
+DataFlowScene::DataFlowModel::
+nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
-  if (portType == PortType::In) {
+
+  if (portType == PortType::In)
+  {
     return ConnectionPolicy::One;
   }
   return node->nodeDataModel()->portOutConnectionPolicy(pIndex);
 }
-std::vector<std::pair<NodeIndex, PortIndex>> DataFlowScene::DataFlowModel::nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const {
+std::vector<std::pair<NodeIndex, PortIndex> >
+DataFlowScene::DataFlowModel::
+nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
-  
-  std::vector<std::pair<NodeIndex, PortIndex>> ret;
+
+  std::vector<std::pair<NodeIndex, PortIndex> > ret;
   // construct connections
-  for (const auto& conn : node->connections(portType, id)) {
+  for (const auto& conn : node->connections(portType, id))
+  {
     ret.emplace_back(nodeIndex(conn->getNode(oppositePort(portType))->id()), conn->getPortIndex(oppositePort(portType)));
   }
   return ret;
 }
 
 // FlowSceneModel write interface
-bool DataFlowScene::DataFlowModel::removeConnection(NodeIndex const& leftNodeIdx, PortIndex leftPortID, NodeIndex const& rightNodeIdx, PortIndex rightPortID) {
+bool
+DataFlowScene::
+DataFlowModel::
+removeConnection(NodeIndex const& leftNodeIdx,
+                 PortIndex leftPortID,
+                 NodeIndex const& rightNodeIdx,
+                 PortIndex rightPortID)
+{
   Q_ASSERT(leftNodeIdx.isValid());
   Q_ASSERT(rightNodeIdx.isValid());
-  
-  auto* leftNode = static_cast<Node*>(leftNodeIdx.internalPointer());
+
+  auto* leftNode  = static_cast<Node*>(leftNodeIdx.internalPointer());
   auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
-  
+
   ConnectionID connID;
   connID.lNodeID = leftNodeIdx.id();
   connID.rNodeID = rightNodeIdx.id();
@@ -576,38 +715,52 @@ bool DataFlowScene::DataFlowModel::removeConnection(NodeIndex const& leftNodeIdx
   connID.rPortID = rightPortID;
 
   _connections[connID]->propagateEmptyData();
-  
+
   // remove it from the nodes
   auto& leftConns = leftNode->connections(PortType::Out, leftPortID);
-  auto iter = std::find_if(leftConns.begin(), leftConns.end(), [&](Connection* conn){ return conn->id() == connID; });
+  auto iter       = std::find_if(leftConns.begin(), leftConns.end(), [&](Connection* conn){
+                                   return conn->id() == connID;
+                                 });
   Q_ASSERT(iter != leftConns.end());
   leftConns.erase(iter);
-  
+
   auto& rightConns = rightNode->connections(PortType::In, rightPortID);
-  iter = std::find_if(rightConns.begin(), rightConns.end(), [&](Connection* conn){ return conn->id() == connID; });
+  iter = std::find_if(rightConns.begin(), rightConns.end(), [&](Connection* conn){
+                        return conn->id() == connID;
+                      });
   Q_ASSERT(iter != rightConns.end());
   rightConns.erase(iter);
-  
+
   // remove it from the map
   _connections.erase(connID);
 
   // tell the view
   emit connectionRemoved(leftNodeIdx, leftPortID, rightNodeIdx, rightPortID);
-  
+
   return true;
 }
-bool DataFlowScene::DataFlowModel::addConnection(NodeIndex const& leftNodeIdx, PortIndex leftPortID, NodeIndex const& rightNodeIdx, PortIndex rightPortID) {
+
+
+bool
+DataFlowScene::
+DataFlowModel::
+addConnection(NodeIndex const& leftNodeIdx,
+              PortIndex leftPortID,
+              NodeIndex const& rightNodeIdx,
+              PortIndex rightPortID)
+{
   Q_ASSERT(leftNodeIdx.isValid());
   Q_ASSERT(rightNodeIdx.isValid());
-  
-  auto* leftNode = static_cast<Node*>(leftNodeIdx.internalPointer());
+
+  auto* leftNode  = static_cast<Node*>(leftNodeIdx.internalPointer());
   auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
 
   // type conversions
   TypeConverter conv = {};
-  auto ltype = nodePortDataType(leftNodeIdx, leftPortID, PortType::Out);
-  auto rtype = nodePortDataType(rightNodeIdx, rightPortID, PortType::In);
-  if (ltype.id != rtype.id) {
+  auto ltype         = nodePortDataType(leftNodeIdx, leftPortID, PortType::Out);
+  auto rtype         = nodePortDataType(rightNodeIdx, rightPortID, PortType::In);
+  if (ltype.id != rtype.id)
+  {
     conv = _registry->getTypeConverter(ltype, rtype);
   }
 
@@ -615,66 +768,93 @@ bool DataFlowScene::DataFlowModel::addConnection(NodeIndex const& leftNodeIdx, P
 
   return true;
 }
-bool DataFlowScene::DataFlowModel::removeNode(NodeIndex const& index) {
+
+
+bool
+DataFlowScene::DataFlowModel::
+removeNode(NodeIndex const& index)
+{
   Q_ASSERT(index.isValid());
-  
-  auto* node = static_cast<Node*>(index.internalPointer());
-  
+
   // make sure there are no connections left
 #ifndef QT_NO_DEBUG
-  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::In); ++idx) {
+
+  auto* node = static_cast<Node*>(index.internalPointer());
+
+  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::In); ++idx)
+  {
     Q_ASSERT(node->connections(PortType::In, idx).empty());
   }
-  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::Out); ++idx) {
+  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::Out); ++idx)
+  {
     Q_ASSERT(node->connections(PortType::Out, idx).empty());
   }
 #endif
 
   // remove it from the map
   _nodes.erase(index.id());
-  
+
   // tell the view
   emit nodeRemoved(index.id());
 
   return true;
 }
-QUuid DataFlowScene::DataFlowModel::addNode(const QString& typeID, QPointF const& location) {
+QUuid
+DataFlowScene::DataFlowModel::
+addNode(const QString& typeID, QPointF const& location)
+{
   auto nodeid = QUuid::createUuid();
   addNode(typeID, location, nodeid);
   return nodeid;
 }
-QUuid DataFlowScene::DataFlowModel::addNode(QString const& typeID, QPointF const& location, QUuid const& nodeid) {
+QUuid
+DataFlowScene::DataFlowModel::
+addNode(QString const& typeID, QPointF const& location, QUuid const& nodeid)
+{
   // create the NodeDataModel
   auto model = _registry->create(typeID);
-  if (!model) {
+  if (!model)
+  {
     return {};
   }
   return addNode(std::move(model), location, nodeid);
 }
-QUuid DataFlowScene::DataFlowModel::addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& nodeid) {
+QUuid
+DataFlowScene::DataFlowModel::
+addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& nodeid)
+{
 
-  connect(model.get(), &NodeDataModel::dataUpdated, this, [this, nodeid](PortIndex){ emit nodeValidationUpdated(nodeIndex(nodeid)); });
+  connect(model.get(), &NodeDataModel::dataUpdated, this, [this, nodeid](PortIndex){
+            emit nodeValidationUpdated(nodeIndex(nodeid));
+          });
 
   // create a node
   auto node = std::make_unique<Node>(std::move(model), nodeid);
 
   node->setPosition(location);
-  
+
   // cache the pointer so the connection can be made
   auto nodePtr = node.get();
-  
+
   // add it to the map
   _nodes[nodeid] = std::move(node);
-  
+
   // connect to the geometry gets updated
-  connect(nodePtr, &Node::positionChanged, this, [this, nodeid](QPointF const&){ emit nodeMoved(nodeIndex(nodeid)); });
-  
+  connect(nodePtr, &Node::positionChanged, this, [this, nodeid](QPointF const&){
+            emit nodeMoved(nodeIndex(nodeid));
+          });
+
   // tell the view
   emit nodeAdded(nodeid);
 
   return nodeid;
 }
-ConnectionID DataFlowScene::DataFlowModel::addConnection(Node* leftNode, PortIndex leftPortID, Node* rightNode, PortIndex rightPortID, TypeConverter conv) {
+
+
+ConnectionID
+DataFlowScene::DataFlowModel::
+addConnection(Node* leftNode, PortIndex leftPortID, Node* rightNode, PortIndex rightPortID, TypeConverter conv)
+{
 
   ConnectionID connID;
   connID.lNodeID = leftNode->id();
@@ -685,26 +865,29 @@ ConnectionID DataFlowScene::DataFlowModel::addConnection(Node* leftNode, PortInd
   // create the connection
   auto conn = std::make_shared<Connection>(*rightNode, rightPortID, *leftNode, leftPortID, conv);
   _connections[connID] = conn;
-  
+
   // add it to the nodes
   leftNode->connections(PortType::Out, leftPortID).push_back(conn.get());
   rightNode->connections(PortType::In, rightPortID).push_back(conn.get());
 
   // process data
   conn->getNode(PortType::Out)->onDataUpdated(conn->getPortIndex(PortType::Out));
-  
+
   // tell the view the connection was added
   emit connectionAdded(nodeIndex(leftNode->id()), leftPortID, nodeIndex(rightNode->id()), rightPortID);
 
   return connID;
 }
 
-bool DataFlowScene::DataFlowModel::moveNode(NodeIndex const& index, QPointF newLocation) {
+bool
+DataFlowScene::DataFlowModel::
+moveNode(NodeIndex const& index, QPointF newLocation)
+{
   Q_ASSERT(index.isValid());
-  
+
   auto* node = static_cast<Node*>(index.internalPointer());
   node->setPosition(newLocation);
-  
+
   // no need to emit, it's done by the function already
   return true;
 }

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -76,6 +76,8 @@ deleteConnection(Connection& connection)
     connection.getPortIndex(PortType::Out),
     _dataFlowModel->nodeIndex(connection.getNode(PortType::In)->id()),
     connection.getPortIndex(PortType::Out));
+  
+  Q_UNUSED(deleted);
   Q_ASSERT(deleted);
 }
 

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -17,6 +17,8 @@ using QtNodes::NodePainterDelegate;
 using QtNodes::NodeDataType;
 using QtNodes::ConnectionPolicy;
 using QtNodes::PortIndex;
+using QtNodes::TypeConverterId;
+using QtNodes::TypeCOnverter;
 
 class DataFlowScene::DataFlowModel : public FlowSceneModel
 {

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -15,6 +15,7 @@ using QtNodes::PortIndex;
 using QtNodes::TypeConverter;
 using QtNodes::ConnectionID;
 using QtNodes::DataFlowModel;
+using QtNodes::NodeDataModel;
 
 DataFlowScene::
 DataFlowScene(std::shared_ptr<DataModelRegistry> registry, QObject* parent)

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -621,7 +621,7 @@ bool DataFlowScene::DataFlowModel::removeNode(NodeIndex const& index) {
   auto* node = static_cast<Node*>(index.internalPointer());
   
   // make sure there are no connections left
-#ifndef NDEBUG
+#ifndef QT_NO_DEBUG
   for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::In); ++idx) {
     Q_ASSERT(node->connections(PortType::In, idx).empty());
   }

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -1,6 +1,7 @@
 #include "DataFlowScene.hpp"
 #include "Connection.hpp"
 #include "Node.hpp"
+#include "DataFlowModel.hpp"
 
 #include <QFileDialog>
 #include <QJsonArray>
@@ -10,102 +11,10 @@ using QtNodes::DataFlowScene;
 using QtNodes::DataModelRegistry;
 using QtNodes::Connection;
 using QtNodes::Node;
-using QtNodes::ConnectionID;
-using QtNodes::NodeIndex;
-using QtNodes::NodeValidationState;
-using QtNodes::NodePainterDelegate;
-using QtNodes::NodeDataType;
-using QtNodes::ConnectionPolicy;
 using QtNodes::PortIndex;
-using QtNodes::TypeConverterId;
-using QtNodes::TypeCOnverter;
-
-class DataFlowScene::DataFlowModel : public FlowSceneModel
-{
-public:
-
-  DataFlowModel(std::shared_ptr<DataModelRegistry> reg);
-
-  // FlowSceneModel read interface
-  QStringList
-  modelRegistry() const override;
-
-  QString
-  nodeTypeCatergory(QString const& name) const override;
-
-  bool
-  getTypeConvertable(TypeConverterId const& id ) const override;
-
-  QList<QUuid>
-  nodeUUids() const override;
-
-  NodeIndex
-  nodeIndex(const QUuid& ID) const override;
-
-  QString
-  nodeTypeIdentifier(NodeIndex const& index) const override;
-
-  QString
-  nodeCaption(NodeIndex const& index) const override;
-
-  QPointF
-  nodeLocation(NodeIndex const& index) const override;
-
-  QWidget*
-  nodeWidget(NodeIndex const& index) const override;
-
-  bool
-  nodeResizable(NodeIndex const& index) const override;
-
-  NodeValidationState
-  nodeValidationState(NodeIndex const& index) const override;
-
-  QString
-  nodeValidationMessage(NodeIndex const& index) const override;
-
-  NodePainterDelegate*
-  nodePainterDelegate(NodeIndex const& index) const override;
-
-  unsigned int
-  nodePortCount(NodeIndex const& index, PortType portType) const override;
-
-  QString
-  nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
-  NodeDataType
-  nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
-  ConnectionPolicy
-  nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
-  std::vector<std::pair<NodeIndex, PortIndex> >
-  nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const override;
-
-  // FlowSceneModel write interface
-  bool
-  removeConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
-  bool
-  addConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
-  bool
-  removeNode(NodeIndex const& index) override;
-  QUuid
-  addNode(QString const& typeID, QPointF const& location) override;
-  bool
-  moveNode(NodeIndex const& index, QPointF newLocation) override;
-
-  // convenience functions
-  QUuid
-  addNode(QString const& typeID, QPointF const& location, QUuid const& uuid);
-  QUuid
-  addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& uuid = QUuid::createUuid());
-  ConnectionID
-  addConnection(Node* left, PortIndex leftIdx, Node* right, PortIndex rightIdx, TypeConverter converter);
-
-  using SharedConnection = std::shared_ptr<Connection>;
-  using UniqueNode       = std::unique_ptr<Node>;
-
-  std::unordered_map<ConnectionID, SharedConnection> _connections;
-  std::unordered_map<QUuid, UniqueNode>              _nodes;
-  std::shared_ptr<DataModelRegistry>                 _registry;
-};
-
+using QtNodes::TypeConverter;
+using QtNodes::ConnectionID;
+using QtNodes::DataFlowModel;
 
 DataFlowScene::
 DataFlowScene(std::shared_ptr<DataModelRegistry> registry, QObject* parent)
@@ -127,7 +36,7 @@ createConnection(Node& nodeIn,
                                   &nodeIn, portIndexIn,
                                   converter);
 
-  return _dataFlowModel->_connections[connid];
+  return _dataFlowModel->connections()[connid];
 }
 
 std::shared_ptr<Connection>
@@ -154,7 +63,7 @@ restoreConnection(QJsonObject const &connectionJson)
                                      connId.rPortID))
     return nullptr;
 
-  return _dataFlowModel->_connections[connId];
+  return _dataFlowModel->connections()[connId];
 }
 
 void
@@ -175,7 +84,7 @@ createNode(std::unique_ptr<NodeDataModel> && dataModel)
 {
   auto uid = _dataFlowModel->addNode(std::move(dataModel), {0.0, 0.0});
 
-  return *_dataFlowModel->_nodes[uid];
+  return *_dataFlowModel->nodes()[uid];
 }
 
 Node&
@@ -189,7 +98,7 @@ restoreNode(QJsonObject const& nodeJson)
   // set initial point to 0, 0, will be updated in Node::restore
   _dataFlowModel->addNode(modelName, QPointF(0, 0), uid);
 
-  auto& node = *_dataFlowModel->_nodes[uid];
+  auto& node = *_dataFlowModel->nodes()[uid];
   node.restore(nodeJson);
 
   return node;
@@ -206,21 +115,21 @@ DataModelRegistry&
 DataFlowScene::
 registry() const
 {
-  return *_dataFlowModel->_registry;
+  return _dataFlowModel->registry();
 }
 
 void
 DataFlowScene::
 setRegistry(std::shared_ptr<DataModelRegistry> registry)
 {
-  _dataFlowModel->_registry = registry;
+  _dataFlowModel->setRegistry(registry);
 }
 
 void
 DataFlowScene::
 iterateOverNodes(std::function<void(Node*)> const& visitor)
 {
-  for (auto const& node : _dataFlowModel->_nodes)
+  for (auto const& node : _dataFlowModel->nodes())
   {
     visitor(node.second.get());
   }
@@ -230,7 +139,7 @@ void
 DataFlowScene::
 iterateOverNodeData(std::function<void(NodeDataModel*)> const& visitor)
 {
-  for (auto const& node : _dataFlowModel->_nodes)
+  for (auto const& node : _dataFlowModel->nodes())
   {
     visitor(node.second->nodeDataModel());
   }
@@ -259,7 +168,7 @@ iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& vis
     };
 
   //Iterate over "leaf" nodes
-  for (auto const &_node : _dataFlowModel->_nodes)
+  for (auto const &_node : _dataFlowModel->nodes())
   {
     auto const &node = _node.second;
     auto model       = node->nodeDataModel();
@@ -291,9 +200,9 @@ iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& vis
     };
 
   //Iterate over dependent nodes
-  while (_dataFlowModel->_nodes.size() != visitedNodesSet.size())
+  while (_dataFlowModel->nodes().size() != visitedNodesSet.size())
   {
-    for (auto const &_node : _dataFlowModel->_nodes)
+    for (auto const &_node : _dataFlowModel->nodes())
     {
       auto const &node = _node.second;
       if (visitedNodesSet.find(node->id()) != visitedNodesSet.end())
@@ -329,14 +238,14 @@ std::unordered_map<QUuid, std::unique_ptr<Node> > const &
 DataFlowScene::
 nodes() const
 {
-  return _dataFlowModel->_nodes;
+  return _dataFlowModel->nodes();
 }
 
 std::unordered_map<ConnectionID, std::shared_ptr<Connection> > const &
 DataFlowScene::
 connections() const
 {
-  return _dataFlowModel->_connections;
+  return _dataFlowModel->connections();
 }
 
 std::vector<Node*>
@@ -349,7 +258,7 @@ selectedNodes() const
 
   std::transform(ids.begin(), ids.end(), std::back_inserter(ret),
                  [this](NodeIndex const& id)
-                 { return _dataFlowModel->_nodes.find(id.id())->second.get(); });
+                 { return _dataFlowModel->nodes().find(id.id())->second.get(); });
 
   return ret;
 }
@@ -359,8 +268,8 @@ DataFlowScene::
 clearScene()
 {
   // delete all the nodes
-  while(!_dataFlowModel->_nodes.empty()) {
-    removeNode(*_dataFlowModel->_nodes.begin()->second);
+  while(!_dataFlowModel->nodes().empty()) {
+    removeNode(*_dataFlowModel->nodes().begin()->second);
   }
 }
 
@@ -424,7 +333,7 @@ saveToMemory() const
 
   QJsonArray nodesJsonArray;
 
-  for (auto const & pair : _dataFlowModel->_nodes)
+  for (auto const & pair : _dataFlowModel->nodes())
   {
     auto const &node = pair.second;
 
@@ -434,7 +343,7 @@ saveToMemory() const
   sceneJson["nodes"] = nodesJsonArray;
 
   QJsonArray connectionJsonArray;
-  for (auto const & pair : _dataFlowModel->_connections)
+  for (auto const & pair : _dataFlowModel->connections())
   {
     auto const &connection = pair.second;
 
@@ -471,425 +380,4 @@ loadFromMemory(const QByteArray& data)
   {
     restoreConnection(connectionJsonArray[i].toObject());
   }
-}
-
-DataFlowScene::DataFlowModel::
-DataFlowModel(std::shared_ptr<DataModelRegistry> registry)
-  : _registry(std::move(registry))
-{
-}
-
-// FlowSceneModel read interface
-QStringList
-DataFlowScene::DataFlowModel::
-modelRegistry() const
-{
-  QStringList list;
-  for (const auto& item : _registry->registeredModelCreators())
-  {
-    list << item.first;
-  }
-  return list;
-}
-
-QString
-DataFlowScene::DataFlowModel::
-nodeTypeCatergory(QString const& name) const
-{
-  auto iter = _registry->registeredModelsCategoryAssociation().find(name);
-
-  if (iter != _registry->registeredModelsCategoryAssociation().end())
-  {
-    return iter->second;
-  }
-  return {};
-}
-
-bool
-DataFlowScene::DataFlowModel::
-getTypeConvertable(TypeConverterId const& id) const
-{
-  return static_cast<bool>(_registry->getTypeConverter(id.first, id.second));
-}
-
-
-
-QList<QUuid>
-DataFlowScene::
-DataFlowModel::
-nodeUUids() const
-{
-  QList<QUuid> ret;
-
-  // extract the keys
-  std::transform(_nodes.begin(),
-                 _nodes.end(),
-                 std::back_inserter(ret),
-                 [](const auto& pair) {
-                   return pair.first;
-                 });
-
-  return ret;
-}
-NodeIndex
-DataFlowScene::DataFlowModel::
-nodeIndex(const QUuid& ID) const
-{
-  auto iter = _nodes.find(ID);
-  if (iter == _nodes.end())
-    return {};
-
-  return createIndex(ID, iter->second.get());
-}
-QString
-DataFlowScene::DataFlowModel::
-nodeTypeIdentifier(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->name();
-}
-QString
-DataFlowScene::DataFlowModel::
-nodeCaption(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  if (!node->nodeDataModel()->captionVisible())
-    return {};
-
-  return node->nodeDataModel()->caption();
-}
-QPointF
-DataFlowScene::DataFlowModel::
-nodeLocation(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->position();
-}
-QWidget*
-DataFlowScene::DataFlowModel::
-nodeWidget(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->embeddedWidget();
-}
-bool
-DataFlowScene::DataFlowModel::
-nodeResizable(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->resizable();
-}
-NodeValidationState
-DataFlowScene::DataFlowModel::
-nodeValidationState(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->validationState();
-}
-
-
-QString
-DataFlowScene::DataFlowModel::
-nodeValidationMessage(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->validationMessage();
-}
-
-
-NodePainterDelegate*
-DataFlowScene::DataFlowModel::
-nodePainterDelegate(NodeIndex const& index) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->painterDelegate();
-}
-
-
-unsigned int
-DataFlowScene::DataFlowModel::
-nodePortCount(NodeIndex const& index, PortType portType) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->nPorts(portType);
-}
-
-
-QString
-DataFlowScene::DataFlowModel::
-nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->portCaption(portType, pIndex);
-}
-
-
-NodeDataType
-DataFlowScene::DataFlowModel::
-nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  return node->nodeDataModel()->dataType(portType, pIndex);
-}
-ConnectionPolicy
-DataFlowScene::DataFlowModel::
-nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  if (portType == PortType::In)
-  {
-    return ConnectionPolicy::One;
-  }
-  return node->nodeDataModel()->portOutConnectionPolicy(pIndex);
-}
-std::vector<std::pair<NodeIndex, PortIndex> >
-DataFlowScene::DataFlowModel::
-nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  std::vector<std::pair<NodeIndex, PortIndex> > ret;
-  // construct connections
-  for (const auto& conn : node->connections(portType, id))
-  {
-    ret.emplace_back(nodeIndex(conn->getNode(oppositePort(portType))->id()), conn->getPortIndex(oppositePort(portType)));
-  }
-  return ret;
-}
-
-// FlowSceneModel write interface
-bool
-DataFlowScene::
-DataFlowModel::
-removeConnection(NodeIndex const& leftNodeIdx,
-                 PortIndex leftPortID,
-                 NodeIndex const& rightNodeIdx,
-                 PortIndex rightPortID)
-{
-  Q_ASSERT(leftNodeIdx.isValid());
-  Q_ASSERT(rightNodeIdx.isValid());
-
-  auto* leftNode  = static_cast<Node*>(leftNodeIdx.internalPointer());
-  auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
-
-  ConnectionID connID;
-  connID.lNodeID = leftNodeIdx.id();
-  connID.rNodeID = rightNodeIdx.id();
-  connID.lPortID = leftPortID;
-  connID.rPortID = rightPortID;
-
-  _connections[connID]->propagateEmptyData();
-
-  // remove it from the nodes
-  auto& leftConns = leftNode->connections(PortType::Out, leftPortID);
-  auto iter       = std::find_if(leftConns.begin(), leftConns.end(), [&](Connection* conn){
-                                   return conn->id() == connID;
-                                 });
-  Q_ASSERT(iter != leftConns.end());
-  leftConns.erase(iter);
-
-  auto& rightConns = rightNode->connections(PortType::In, rightPortID);
-  iter = std::find_if(rightConns.begin(), rightConns.end(), [&](Connection* conn){
-                        return conn->id() == connID;
-                      });
-  Q_ASSERT(iter != rightConns.end());
-  rightConns.erase(iter);
-
-  // remove it from the map
-  _connections.erase(connID);
-
-  // tell the view
-  emit connectionRemoved(leftNodeIdx, leftPortID, rightNodeIdx, rightPortID);
-
-  return true;
-}
-
-
-bool
-DataFlowScene::
-DataFlowModel::
-addConnection(NodeIndex const& leftNodeIdx,
-              PortIndex leftPortID,
-              NodeIndex const& rightNodeIdx,
-              PortIndex rightPortID)
-{
-  Q_ASSERT(leftNodeIdx.isValid());
-  Q_ASSERT(rightNodeIdx.isValid());
-
-  auto* leftNode  = static_cast<Node*>(leftNodeIdx.internalPointer());
-  auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
-
-  // type conversions
-  TypeConverter conv = {};
-  auto ltype         = nodePortDataType(leftNodeIdx, leftPortID, PortType::Out);
-  auto rtype         = nodePortDataType(rightNodeIdx, rightPortID, PortType::In);
-  if (ltype.id != rtype.id)
-  {
-    conv = _registry->getTypeConverter(ltype, rtype);
-  }
-
-  addConnection(leftNode, leftPortID, rightNode, rightPortID, conv);
-
-  return true;
-}
-
-
-bool
-DataFlowScene::DataFlowModel::
-removeNode(NodeIndex const& index)
-{
-  Q_ASSERT(index.isValid());
-
-  // make sure there are no connections left
-#ifndef QT_NO_DEBUG
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-
-  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::In); ++idx)
-  {
-    Q_ASSERT(node->connections(PortType::In, idx).empty());
-  }
-  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::Out); ++idx)
-  {
-    Q_ASSERT(node->connections(PortType::Out, idx).empty());
-  }
-#endif
-
-  // remove it from the map
-  _nodes.erase(index.id());
-
-  // tell the view
-  emit nodeRemoved(index.id());
-
-  return true;
-}
-QUuid
-DataFlowScene::DataFlowModel::
-addNode(const QString& typeID, QPointF const& location)
-{
-  auto nodeid = QUuid::createUuid();
-  addNode(typeID, location, nodeid);
-  return nodeid;
-}
-QUuid
-DataFlowScene::DataFlowModel::
-addNode(QString const& typeID, QPointF const& location, QUuid const& nodeid)
-{
-  // create the NodeDataModel
-  auto model = _registry->create(typeID);
-  if (!model)
-  {
-    return {};
-  }
-  return addNode(std::move(model), location, nodeid);
-}
-QUuid
-DataFlowScene::DataFlowModel::
-addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& nodeid)
-{
-
-  connect(model.get(), &NodeDataModel::dataUpdated, this, [this, nodeid](PortIndex){
-            emit nodeValidationUpdated(nodeIndex(nodeid));
-          });
-
-  // create a node
-  auto node = std::make_unique<Node>(std::move(model), nodeid);
-
-  node->setPosition(location);
-
-  // cache the pointer so the connection can be made
-  auto nodePtr = node.get();
-
-  // add it to the map
-  _nodes[nodeid] = std::move(node);
-
-  // connect to the geometry gets updated
-  connect(nodePtr, &Node::positionChanged, this, [this, nodeid](QPointF const&){
-            emit nodeMoved(nodeIndex(nodeid));
-          });
-
-  // tell the view
-  emit nodeAdded(nodeid);
-
-  return nodeid;
-}
-
-
-ConnectionID
-DataFlowScene::DataFlowModel::
-addConnection(Node* leftNode, PortIndex leftPortID, Node* rightNode, PortIndex rightPortID, TypeConverter conv)
-{
-
-  ConnectionID connID;
-  connID.lNodeID = leftNode->id();
-  connID.rNodeID = rightNode->id();
-  connID.lPortID = leftPortID;
-  connID.rPortID = rightPortID;
-
-  // create the connection
-  auto conn = std::make_shared<Connection>(*rightNode, rightPortID, *leftNode, leftPortID, conv);
-  _connections[connID] = conn;
-
-  // add it to the nodes
-  leftNode->connections(PortType::Out, leftPortID).push_back(conn.get());
-  rightNode->connections(PortType::In, rightPortID).push_back(conn.get());
-
-  // process data
-  conn->getNode(PortType::Out)->onDataUpdated(conn->getPortIndex(PortType::Out));
-
-  // tell the view the connection was added
-  emit connectionAdded(nodeIndex(leftNode->id()), leftPortID, nodeIndex(rightNode->id()), rightPortID);
-
-  return connID;
-}
-
-bool
-DataFlowScene::DataFlowModel::
-moveNode(NodeIndex const& index, QPointF newLocation)
-{
-  Q_ASSERT(index.isValid());
-
-  auto* node = static_cast<Node*>(index.internalPointer());
-  node->setPosition(newLocation);
-
-  // no need to emit, it's done by the function already
-  return true;
 }

--- a/src/DataFlowScene.cpp
+++ b/src/DataFlowScene.cpp
@@ -1,0 +1,709 @@
+#include "DataFlowScene.hpp"
+#include "Connection.hpp"
+#include "Node.hpp"
+
+#include <QFileDialog>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+using QtNodes::DataFlowScene;
+using QtNodes::DataModelRegistry;
+using QtNodes::Connection;
+using QtNodes::Node;
+using QtNodes::ConnectionID;
+using QtNodes::NodeIndex;
+using QtNodes::NodeValidationState;
+using QtNodes::NodePainterDelegate;
+using QtNodes::NodeDataType;
+using QtNodes::ConnectionPolicy;
+using QtNodes::PortIndex;
+
+class DataFlowScene::DataFlowModel : public FlowSceneModel {
+public:
+  
+  DataFlowModel(std::shared_ptr<DataModelRegistry> reg);
+
+  // FlowSceneModel read interface
+  QStringList modelRegistry() const override;
+  QString nodeTypeCatergory(QString const& name) const override;
+  bool getTypeConvertable(TypeConverterId const& id ) const override;
+  QList<QUuid> nodeUUids() const override;
+  NodeIndex nodeIndex(const QUuid& ID) const override;
+  QString nodeTypeIdentifier(NodeIndex const& index) const override;
+  QString nodeCaption(NodeIndex const& index) const override;
+  QPointF nodeLocation(NodeIndex const& index) const override;
+  QWidget* nodeWidget(NodeIndex const& index) const override;
+  bool nodeResizable(NodeIndex const& index) const override;
+  NodeValidationState nodeValidationState(NodeIndex const& index) const override;
+  QString nodeValidationMessage(NodeIndex const& index) const override;
+  NodePainterDelegate* nodePainterDelegate(NodeIndex const& index) const override;
+  unsigned int nodePortCount(NodeIndex const& index, PortType portType) const override;
+  QString nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  NodeDataType nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  ConnectionPolicy nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const override;
+  std::vector<std::pair<NodeIndex, PortIndex>> nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const override;
+
+  // FlowSceneModel write interface
+  bool removeConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
+  bool addConnection(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID) override;
+  bool removeNode(NodeIndex const& index) override;
+  QUuid addNode(QString const& typeID, QPointF const& location) override;
+  bool moveNode(NodeIndex const& index, QPointF newLocation) override;
+
+  // convenience functions
+  QUuid addNode(QString const& typeID, QPointF const& location, QUuid const& uuid);
+  QUuid addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& uuid = QUuid::createUuid());
+  ConnectionID addConnection(Node* left, PortIndex leftIdx, Node* right, PortIndex rightIdx, TypeConverter converter);
+
+  using SharedConnection = std::shared_ptr<Connection>;
+  using UniqueNode       = std::unique_ptr<Node>;
+
+  std::unordered_map<ConnectionID, SharedConnection> _connections;
+  std::unordered_map<QUuid, UniqueNode>              _nodes;
+  std::shared_ptr<DataModelRegistry>                 _registry;
+};
+
+
+DataFlowScene::DataFlowScene(std::shared_ptr<DataModelRegistry> registry, QObject* parent) 
+  : FlowScene(new DataFlowModel(std::move(registry)), parent) {
+  _dataFlowModel = static_cast<DataFlowModel*>(model());
+}
+
+std::shared_ptr<Connection>
+DataFlowScene::
+createConnection(Node& nodeIn,
+                  PortIndex portIndexIn,
+                  Node& nodeOut,
+                  PortIndex portIndexOut,
+                  TypeConverter const& converter) {
+  
+  auto connid = _dataFlowModel->addConnection(&nodeOut, portIndexOut, &nodeIn, portIndexIn, converter);
+
+  return _dataFlowModel->_connections[connid];
+}
+
+std::shared_ptr<Connection>
+DataFlowScene::
+restoreConnection(QJsonObject const &connectionJson)
+{
+  QUuid nodeInId  = QUuid(connectionJson["in_id"].toString());
+  QUuid nodeOutId = QUuid(connectionJson["out_id"].toString());
+
+  PortIndex portIndexIn  = connectionJson["in_index"].toInt();
+  PortIndex portIndexOut = connectionJson["out_index"].toInt();
+
+
+  ConnectionID connId;
+  connId.lNodeID = nodeOutId;
+  connId.rNodeID = nodeInId;
+  
+  connId.lPortID = portIndexOut;
+  connId.rPortID = portIndexIn;
+  
+  if (!_dataFlowModel->addConnection(_dataFlowModel->nodeIndex(nodeOutId), connId.lPortID, _dataFlowModel->nodeIndex(nodeInId), connId.rPortID)) 
+    return nullptr;
+
+  return _dataFlowModel->_connections[connId];
+  
+}
+
+void
+DataFlowScene::
+deleteConnection(Connection& connection)
+{
+  auto deleted = _dataFlowModel->removeConnection(
+    _dataFlowModel->nodeIndex(connection.getNode(PortType::Out)->id()),
+    connection.getPortIndex(PortType::Out),
+    _dataFlowModel->nodeIndex(connection.getNode(PortType::In)->id()),
+    connection.getPortIndex(PortType::Out));
+  Q_ASSERT(deleted);
+}
+
+Node&
+DataFlowScene::
+createNode(std::unique_ptr<NodeDataModel> && dataModel)
+{
+  auto uid = _dataFlowModel->addNode(std::move(dataModel), {0.0, 0.0});
+
+  return *_dataFlowModel->_nodes[uid];
+}
+
+Node&
+DataFlowScene::
+restoreNode(QJsonObject const& nodeJson)
+{
+  QString modelName = nodeJson["model"].toObject()["name"].toString();
+
+  auto uid = QUuid(nodeJson["id"].toString());
+ 
+  _dataFlowModel->addNode(modelName, point, uid);
+
+  auto& node = *_dataFlowModel->_nodes[uid];
+  node->restore(nodeJson);
+  
+  return node;
+}
+
+void 
+DataFlowScene::
+removeNode(Node& node)
+{
+  model()->removeNodeWithConnections(model()->nodeIndex(node.id()));
+}
+
+DataModelRegistry&
+DataFlowScene::
+registry() const
+{
+  return *_dataFlowModel->_registry;
+}
+
+void
+DataFlowScene::
+setRegistry(std::shared_ptr<DataModelRegistry> registry)
+{
+  _dataFlowModel->_registry = registry;
+}
+
+void
+DataFlowScene::
+iterateOverNodes(std::function<void(Node*)> const& visitor) 
+{
+  for (auto const& node : _dataFlowModel->_nodes) {
+    visitor(node.second.get());
+  }
+}
+
+void
+DataFlowScene::
+iterateOverNodeData(std::function<void(NodeDataModel*)> const& visitor)
+{
+  for (auto const& node : _dataFlowModel->_nodes) {
+    visitor(node.second->nodeDataModel());
+  }
+}
+
+void
+DataFlowScene::
+iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const& visitor)
+{
+  std::set<QUuid> visitedNodesSet;
+
+  //A leaf node is a node with no input ports, or all possible input ports empty
+  auto isNodeLeaf =
+    [](Node const &node, NodeDataModel const &model)
+    {
+      for (unsigned int i = 0; i < model.nPorts(PortType::In); ++i)
+      {
+        auto connections = node.connections(PortType::In, i);
+        if (!connections.empty())
+        {
+          return false;
+        }
+      }
+
+      return true;
+    };
+
+  //Iterate over "leaf" nodes
+  for (auto const &_node : _dataFlowModel->_nodes)
+  {
+    auto const &node = _node.second;
+    auto model       = node->nodeDataModel();
+
+    if (isNodeLeaf(*node, *model))
+    {
+      visitor(model);
+      visitedNodesSet.insert(node->id());
+    }
+  }
+
+  auto areNodeInputsVisitedBefore =
+    [&](Node const &node, NodeDataModel const &model)
+    {
+      for (size_t i = 0; i < model.nPorts(PortType::In); ++i)
+      {
+        auto connections = node.connections(PortType::In, i);
+
+        for (auto& conn : connections)
+        {
+          if (visitedNodesSet.find(conn->getNode(PortType::Out)->id()) == visitedNodesSet.end())
+          {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    };
+
+  //Iterate over dependent nodes
+  while (_dataFlowModel->_nodes.size() != visitedNodesSet.size())
+  {
+    for (auto const &_node : _dataFlowModel->_nodes)
+    {
+      auto const &node = _node.second;
+      if (visitedNodesSet.find(node->id()) != visitedNodesSet.end())
+        continue;
+
+      auto model = node->nodeDataModel();
+
+      if (areNodeInputsVisitedBefore(*node, *model))
+      {
+        visitor(model);
+        visitedNodesSet.insert(node->id());
+      }
+    }
+  }
+}
+
+QPointF
+DataFlowScene::
+getNodePosition(Node const& node) const 
+{
+  return _dataFlowModel->nodeLocation(_dataFlowModel->nodeIndex(node.id()));
+}
+
+void
+DataFlowScene::
+setNodePosition(Node& node, QPointF const& pos) const
+{
+  _dataFlowModel->moveNode(_dataFlowModel->nodeIndex(node.id()), pos);
+}
+
+
+std::unordered_map<QUuid, std::unique_ptr<Node> > const &
+DataFlowScene::
+nodes() const
+{
+  return _dataFlowModel->_nodes;
+}
+
+std::unordered_map<ConnectionID, std::shared_ptr<Connection>> const &
+DataFlowScene::
+connections() const 
+{
+  return _dataFlowModel->_connections;
+}
+
+std::vector<Node*>
+DataFlowScene::
+selectedNodes() const
+{
+  auto ids = FlowScene::selectedNodes();
+  std::vector<Node*> ret;
+  ret.reserve(ids.size());
+
+  std::transform(ids.begin(), ids.end(), std::back_inserter(ret), [this](NodeIndex const& id) {
+    return _dataFlowModel->_nodes.find(id.id())->second.get();
+  });
+
+  return ret;
+}
+
+void
+DataFlowScene::
+clearScene() {
+  // delete all the nodes
+  while(!_dataFlowModel->_nodes.empty()) {
+    removeNode(*_dataFlowModel->_nodes.begin()->second);
+  }
+}
+
+void
+DataFlowScene::
+save() const
+{
+  QString fileName =
+    QFileDialog::getSaveFileName(nullptr,
+                                 tr("Open Flow Scene"),
+                                 QDir::homePath(),
+                                 tr("Flow Scene Files (*.flow)"));
+
+  if (!fileName.isEmpty())
+  {
+    if (!fileName.endsWith("flow", Qt::CaseInsensitive))
+      fileName += ".flow";
+
+    QFile file(fileName);
+    if (file.open(QIODevice::WriteOnly))
+    {
+      file.write(saveToMemory());
+    }
+  }
+}
+
+
+void
+DataFlowScene::
+load()
+{
+  clearScene();
+
+  //-------------
+
+  QString fileName =
+    QFileDialog::getOpenFileName(nullptr,
+                                 tr("Open Flow Scene"),
+                                 QDir::homePath(),
+                                 tr("Flow Scene Files (*.flow)"));
+
+  if (!QFileInfo::exists(fileName))
+    return;
+
+  QFile file(fileName);
+
+  if (!file.open(QIODevice::ReadOnly))
+    return;
+
+  QByteArray wholeFile = file.readAll();
+
+  loadFromMemory(wholeFile);
+}
+
+
+QByteArray
+DataFlowScene::
+saveToMemory() const
+{
+  QJsonObject sceneJson;
+
+  QJsonArray nodesJsonArray;
+
+  for (auto const & pair : _dataFlowModel->_nodes)
+  {
+    auto const &node = pair.second;
+
+    nodesJsonArray.append(node->save());
+  }
+
+  sceneJson["nodes"] = nodesJsonArray;
+
+  QJsonArray connectionJsonArray;
+  for (auto const & pair : _dataFlowModel->_connections)
+  {
+    auto const &connection = pair.second;
+
+    QJsonObject connectionJson = connection->save();
+
+    if (!connectionJson.isEmpty())
+      connectionJsonArray.append(connectionJson);
+  }
+
+  sceneJson["connections"] = connectionJsonArray;
+
+  QJsonDocument document(sceneJson);
+
+  return document.toJson();
+}
+
+
+void
+DataFlowScene::
+loadFromMemory(const QByteArray& data)
+{
+  QJsonObject const jsonDocument = QJsonDocument::fromJson(data).object();
+
+  QJsonArray nodesJsonArray = jsonDocument["nodes"].toArray();
+
+  for (int i = 0; i < nodesJsonArray.size(); ++i)
+  {
+    restoreNode(nodesJsonArray[i].toObject());
+  }
+
+  QJsonArray connectionJsonArray = jsonDocument["connections"].toArray();
+
+  for (int i = 0; i < connectionJsonArray.size(); ++i)
+  {
+    restoreConnection(connectionJsonArray[i].toObject());
+  }
+}
+
+DataFlowScene::DataFlowModel::DataFlowModel(std::shared_ptr<DataModelRegistry> registry) 
+  : _registry(std::move(registry)) {
+}
+
+// FlowSceneModel read interface
+QStringList DataFlowScene::DataFlowModel::modelRegistry() const {
+  QStringList list;
+  for (const auto& item : _registry->registeredModelCreators()) {
+    list << item.first;
+  }
+  return list;
+}
+QString DataFlowScene::DataFlowModel::nodeTypeCatergory(QString const& name) const {
+  auto iter = _registry->registeredModelsCategoryAssociation().find(name);
+  
+  if (iter != _registry->registeredModelsCategoryAssociation().end()) {
+    return iter->second;
+  }
+  return {};
+}
+bool DataFlowScene::DataFlowModel::getTypeConvertable(TypeConverterId const& id) const {
+  return static_cast<bool>(_registry->getTypeConverter(id.first, id.second));
+}
+QList<QUuid> DataFlowScene::DataFlowModel::nodeUUids() const {
+  QList<QUuid> ret;
+
+  // extract the keys
+  std::transform(_nodes.begin(), _nodes.end(), std::back_inserter(ret), [](const auto& pair) {
+    return pair.first;
+  });
+
+  return ret;
+}
+NodeIndex DataFlowScene::DataFlowModel::nodeIndex(const QUuid& ID) const {
+  auto iter = _nodes.find(ID);
+  if (iter == _nodes.end()) return {};
+  
+  return createIndex(ID, iter->second.get());
+}
+QString DataFlowScene::DataFlowModel::nodeTypeIdentifier(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->name();
+}
+QString DataFlowScene::DataFlowModel::nodeCaption(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  if (!node->nodeDataModel()->captionVisible()) return {};
+  
+  return node->nodeDataModel()->caption();
+}
+QPointF DataFlowScene::DataFlowModel::nodeLocation(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->position();
+}
+QWidget* DataFlowScene::DataFlowModel::nodeWidget(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->embeddedWidget();
+}
+bool DataFlowScene::DataFlowModel::nodeResizable(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->resizable();
+}
+NodeValidationState DataFlowScene::DataFlowModel::nodeValidationState(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->validationState();
+}
+QString DataFlowScene::DataFlowModel::nodeValidationMessage(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->validationMessage();
+}
+NodePainterDelegate* DataFlowScene::DataFlowModel::nodePainterDelegate(NodeIndex const& index) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->painterDelegate();
+}
+unsigned int DataFlowScene::DataFlowModel::nodePortCount(NodeIndex const& index, PortType portType) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->nPorts(portType);
+}
+QString DataFlowScene::DataFlowModel::nodePortCaption(NodeIndex const& index, PortIndex pIndex, PortType portType) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->portCaption(portType, pIndex);
+}
+NodeDataType DataFlowScene::DataFlowModel::nodePortDataType(NodeIndex const& index, PortIndex pIndex, PortType portType) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  return node->nodeDataModel()->dataType(portType, pIndex);
+}
+ConnectionPolicy DataFlowScene::DataFlowModel::nodePortConnectionPolicy(NodeIndex const& index, PortIndex pIndex, PortType portType) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  if (portType == PortType::In) {
+    return ConnectionPolicy::One;
+  }
+  return node->nodeDataModel()->portOutConnectionPolicy(pIndex);
+}
+std::vector<std::pair<NodeIndex, PortIndex>> DataFlowScene::DataFlowModel::nodePortConnections(NodeIndex const& index, PortIndex id, PortType portType) const {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  std::vector<std::pair<NodeIndex, PortIndex>> ret;
+  // construct connections
+  for (const auto& conn : node->connections(portType, id)) {
+    ret.emplace_back(nodeIndex(conn->getNode(oppositePort(portType))->id()), conn->getPortIndex(oppositePort(portType)));
+  }
+  return ret;
+}
+
+// FlowSceneModel write interface
+bool DataFlowScene::DataFlowModel::removeConnection(NodeIndex const& leftNodeIdx, PortIndex leftPortID, NodeIndex const& rightNodeIdx, PortIndex rightPortID) {
+  Q_ASSERT(leftNodeIdx.isValid());
+  Q_ASSERT(rightNodeIdx.isValid());
+  
+  auto* leftNode = static_cast<Node*>(leftNodeIdx.internalPointer());
+  auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
+  
+  ConnectionID connID;
+  connID.lNodeID = leftNodeIdx.id();
+  connID.rNodeID = rightNodeIdx.id();
+  connID.lPortID = leftPortID;
+  connID.rPortID = rightPortID;
+
+  _connections[connID]->propagateEmptyData();
+  
+  // remove it from the nodes
+  auto& leftConns = leftNode->connections(PortType::Out, leftPortID);
+  auto iter = std::find_if(leftConns.begin(), leftConns.end(), [&](Connection* conn){ return conn->id() == connID; });
+  Q_ASSERT(iter != leftConns.end());
+  leftConns.erase(iter);
+  
+  auto& rightConns = rightNode->connections(PortType::In, rightPortID);
+  iter = std::find_if(rightConns.begin(), rightConns.end(), [&](Connection* conn){ return conn->id() == connID; });
+  Q_ASSERT(iter != rightConns.end());
+  rightConns.erase(iter);
+  
+  // remove it from the map
+  _connections.erase(connID);
+
+  // tell the view
+  emit connectionRemoved(leftNodeIdx, leftPortID, rightNodeIdx, rightPortID);
+  
+  return true;
+}
+bool DataFlowScene::DataFlowModel::addConnection(NodeIndex const& leftNodeIdx, PortIndex leftPortID, NodeIndex const& rightNodeIdx, PortIndex rightPortID) {
+  Q_ASSERT(leftNodeIdx.isValid());
+  Q_ASSERT(rightNodeIdx.isValid());
+  
+  auto* leftNode = static_cast<Node*>(leftNodeIdx.internalPointer());
+  auto* rightNode = static_cast<Node*>(rightNodeIdx.internalPointer());
+
+  // type conversions
+  TypeConverter conv = {};
+  auto ltype = nodePortDataType(leftNodeIdx, leftPortID, PortType::Out);
+  auto rtype = nodePortDataType(rightNodeIdx, rightPortID, PortType::In);
+  if (ltype.id != rtype.id) {
+    conv = _registry->getTypeConverter(ltype, rtype);
+  }
+
+  addConnection(leftNode, leftPortID, rightNode, rightPortID, conv);
+
+  return true;
+}
+bool DataFlowScene::DataFlowModel::removeNode(NodeIndex const& index) {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  
+  // make sure there are no connections left
+#ifndef NDEBUG
+  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::In); ++idx) {
+    Q_ASSERT(node->connections(PortType::In, idx).empty());
+  }
+  for (auto idx = 0u; idx < node->nodeDataModel()->nPorts(PortType::Out); ++idx) {
+    Q_ASSERT(node->connections(PortType::Out, idx).empty());
+  }
+#endif
+
+  // remove it from the map
+  _nodes.erase(index.id());
+  
+  // tell the view
+  emit nodeRemoved(index.id());
+
+  return true;
+}
+QUuid DataFlowScene::DataFlowModel::addNode(const QString& typeID, QPointF const& location) {
+  auto nodeid = QUuid::createUuid();
+  addNode(typeID, location, nodeid);
+  return nodeid;
+}
+QUuid DataFlowScene::DataFlowModel::addNode(QString const& typeID, QPointF const& location, QUuid const& nodeid) {
+  // create the NodeDataModel
+  auto model = _registry->create(typeID);
+  if (!model) {
+    return {};
+  }
+  return addNode(std::move(model), location, nodeid);
+}
+QUuid DataFlowScene::DataFlowModel::addNode(std::unique_ptr<NodeDataModel>&& model, QPointF const& location, QUuid const& nodeid) {
+
+  connect(model.get(), &NodeDataModel::dataUpdated, this, [this, nodeid](PortIndex){ emit nodeValidationUpdated(nodeIndex(nodeid)); });
+
+  // create a node
+  auto node = std::make_unique<Node>(std::move(model), nodeid);
+
+  node->setPosition(location);
+  
+  // cache the pointer so the connection can be made
+  auto nodePtr = node.get();
+  
+  // add it to the map
+  _nodes[nodeid] = std::move(node);
+  
+  // connect to the geometry gets updated
+  connect(nodePtr, &Node::positionChanged, this, [this, nodeid](QPointF const&){ emit nodeMoved(nodeIndex(nodeid)); });
+  
+  // tell the view
+  emit nodeAdded(nodeid);
+
+  return nodeid;
+}
+ConnectionID DataFlowScene::DataFlowModel::addConnection(Node* leftNode, PortIndex leftPortID, Node* rightNode, PortIndex rightPortID, TypeConverter conv) {
+
+  ConnectionID connID;
+  connID.lNodeID = leftNode->id();
+  connID.rNodeID = rightNode->id();
+  connID.lPortID = leftPortID;
+  connID.rPortID = rightPortID;
+
+  // create the connection
+  auto conn = std::make_shared<Connection>(*rightNode, rightPortID, *leftNode, leftPortID, conv);
+  _connections[connID] = conn;
+  
+  // add it to the nodes
+  leftNode->connections(PortType::Out, leftPortID).push_back(conn.get());
+  rightNode->connections(PortType::In, rightPortID).push_back(conn.get());
+
+  // process data
+  conn->getNode(PortType::Out)->onDataUpdated(conn->getPortIndex(PortType::Out));
+  
+  // tell the view the connection was added
+  emit connectionAdded(nodeIndex(leftNode->id()), leftPortID, nodeIndex(rightNode->id()), rightPortID);
+
+  return connID;
+}
+
+bool DataFlowScene::DataFlowModel::moveNode(NodeIndex const& index, QPointF newLocation) {
+  Q_ASSERT(index.isValid());
+  
+  auto* node = static_cast<Node*>(index.internalPointer());
+  node->setPosition(newLocation);
+  
+  // no need to emit, it's done by the function already
+  return true;
+}

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -2,6 +2,7 @@
 #include "NodeIndex.hpp"
 #include "ConnectionGraphicsObject.hpp"
 #include "NodeGraphicsObject.hpp"
+#include "FlowSceneModel.hpp"
 
 #include <algorithm>
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -1,405 +1,84 @@
 #include "FlowScene.hpp"
-
-#include <stdexcept>
-#include <utility>
-
-#include <QtWidgets/QGraphicsSceneMoveEvent>
-#include <QtWidgets/QFileDialog>
-#include <QtCore/QByteArray>
-#include <QtCore/QBuffer>
-#include <QtCore/QDataStream>
-#include <QtCore/QFile>
-
-#include <QtCore/QJsonDocument>
-#include <QtCore/QJsonObject>
-#include <QtCore/QJsonArray>
-
-#include <QDebug>
-
-#include "Node.hpp"
-#include "NodeGraphicsObject.hpp"
-
-#include "NodeGraphicsObject.hpp"
+#include "NodeIndex.hpp"
 #include "ConnectionGraphicsObject.hpp"
+#include "NodeGraphicsObject.hpp"
 
-#include "Connection.hpp"
-
-#include "FlowView.hpp"
-#include "DataModelRegistry.hpp"
+#include <algorithm>
 
 using QtNodes::FlowScene;
-using QtNodes::Node;
 using QtNodes::NodeGraphicsObject;
-using QtNodes::Connection;
-using QtNodes::DataModelRegistry;
-using QtNodes::NodeDataModel;
-using QtNodes::PortType;
-using QtNodes::PortIndex;
-using QtNodes::TypeConverter;
-
+using QtNodes::NodeIndex;
 
 FlowScene::
-FlowScene(std::shared_ptr<DataModelRegistry> registry,
-          QObject * parent)
-  : QGraphicsScene(parent)
-  , _registry(std::move(registry))
+FlowScene(FlowSceneModel* model,
+          QObject * parent) 
+  : QGraphicsScene(parent),
+    _model(model)
 {
-  setItemIndexMethod(QGraphicsScene::NoIndex);
-}
+  Q_ASSERT(model != nullptr);
 
-FlowScene::
-FlowScene(QObject * parent)
-  : FlowScene(std::make_shared<DataModelRegistry>(),
-              parent)
-{}
+  connect(model, &FlowSceneModel::nodeRemoved, this, &FlowScene::nodeRemoved);
+  connect(model, &FlowSceneModel::nodeAdded, this, &FlowScene::nodeAdded);
+  connect(model, &FlowSceneModel::nodePortUpdated, this, &FlowScene::nodePortUpdated);
+  connect(model, &FlowSceneModel::nodeValidationUpdated, this, &FlowScene::nodeValidationUpdated);
+  connect(model, &FlowSceneModel::connectionRemoved, this, &FlowScene::connectionRemoved);
+  connect(model, &FlowSceneModel::connectionAdded, this, &FlowScene::connectionAdded);
+  connect(model, &FlowSceneModel::nodeMoved, this, &FlowScene::nodeMoved);
 
-
-FlowScene::
-~FlowScene()
-{
-  clearScene();
-}
-
-
-//------------------------------------------------------------------------------
-
-std::shared_ptr<Connection>
-FlowScene::
-createConnection(PortType connectedPort,
-                 Node& node,
-                 PortIndex portIndex)
-{
-  auto connection = std::make_shared<Connection>(connectedPort, node, portIndex);
-
-  auto cgo = detail::make_unique<ConnectionGraphicsObject>(*this, *connection);
-
-  // after this function connection points are set to node port
-  connection->setGraphicsObject(std::move(cgo));
-
-  _connections[connection->id()] = connection;
-
-  connectionCreated(*connection);
-  return connection;
-}
-
-
-std::shared_ptr<Connection>
-FlowScene::
-createConnection(Node& nodeIn,
-                 PortIndex portIndexIn,
-                 Node& nodeOut,
-                 PortIndex portIndexOut,
-                 TypeConverter const &converter)
-{
-  auto connection =
-    std::make_shared<Connection>(nodeIn,
-                                 portIndexIn,
-                                 nodeOut,
-                                 portIndexOut,
-                                 converter);
-
-  auto cgo = detail::make_unique<ConnectionGraphicsObject>(*this, *connection);
-
-  nodeIn.nodeState().setConnection(PortType::In, portIndexIn, *connection);
-  nodeOut.nodeState().setConnection(PortType::Out, portIndexOut, *connection);
-
-  // after this function connection points are set to node port
-  connection->setGraphicsObject(std::move(cgo));
-
-  // trigger data propagation
-  nodeOut.onDataUpdated(portIndexOut);
-
-  _connections[connection->id()] = connection;
-
-  connectionCreated(*connection);
-
-  return connection;
-}
-
-
-std::shared_ptr<Connection>
-FlowScene::
-restoreConnection(QJsonObject const &connectionJson)
-{
-  QUuid nodeInId  = QUuid(connectionJson["in_id"].toString());
-  QUuid nodeOutId = QUuid(connectionJson["out_id"].toString());
-
-  PortIndex portIndexIn  = connectionJson["in_index"].toInt();
-  PortIndex portIndexOut = connectionJson["out_index"].toInt();
-
-  auto nodeIn  = _nodes[nodeInId].get();
-  auto nodeOut = _nodes[nodeOutId].get();
-
-  auto getConverter = [&]()
-  {
-    QJsonValue converterVal = connectionJson["converter"];
-
-    if (!converterVal.isUndefined())
-    {
-      QJsonObject converterJson = converterVal.toObject();
-
-      NodeDataType inType { converterJson["in"].toObject()["id"].toString(),
-                            converterJson["in"].toObject()["name"].toString() };
-
-      NodeDataType outType { converterJson["out"].toObject()["id"].toString(),
-                             converterJson["out"].toObject()["name"].toString() };
-
-      auto converter  =
-        registry().getTypeConverter(outType, inType);
-
-      if (converter)
-        return converter;
-    }
-
-    return TypeConverter{};
-  };
-
-  std::shared_ptr<Connection> connection =
-    createConnection(*nodeIn, portIndexIn,
-                     *nodeOut, portIndexOut,
-                     getConverter());
-
-  return connection;
-}
-
-
-void
-FlowScene::
-deleteConnection(Connection& connection)
-{
-  connectionDeleted(connection);
-  connection.removeFromNodes();
-  _connections.erase(connection.id());
-}
-
-
-Node&
-FlowScene::
-createNode(std::unique_ptr<NodeDataModel> && dataModel)
-{
-  auto node = detail::make_unique<Node>(std::move(dataModel));
-  auto ngo  = detail::make_unique<NodeGraphicsObject>(*this, *node);
-
-  node->setGraphicsObject(std::move(ngo));
-
-  auto nodePtr = node.get();
-  _nodes[node->id()] = std::move(node);
-
-  nodeCreated(*nodePtr);
-  return *nodePtr;
-}
-
-
-Node&
-FlowScene::
-restoreNode(QJsonObject const& nodeJson)
-{
-  QString modelName = nodeJson["model"].toObject()["name"].toString();
-
-  auto dataModel = registry().create(modelName);
-
-  if (!dataModel)
-    throw std::logic_error(std::string("No registered model with name ") +
-                           modelName.toLocal8Bit().data());
-
-  auto node = detail::make_unique<Node>(std::move(dataModel));
-  auto ngo  = detail::make_unique<NodeGraphicsObject>(*this, *node);
-  node->setGraphicsObject(std::move(ngo));
-
-  node->restore(nodeJson);
-
-  auto nodePtr = node.get();
-  _nodes[node->id()] = std::move(node);
-
-  nodeCreated(*nodePtr);
-  return *nodePtr;
-}
-
-
-void
-FlowScene::
-removeNode(Node& node)
-{
-  // call signal
-  nodeDeleted(node);
-
-  for(auto portType: {PortType::In,PortType::Out})
-  {
-    auto nodeState = node.nodeState();
-    auto const & nodeEntries = nodeState.getEntries(portType);
-
-    for (auto &connections : nodeEntries)
-    {
-      for (auto const &pair : connections)
-        deleteConnection(*pair.second);
-    }
+  // emit node added on all the existing nodes
+  for (const auto& n : model->nodeUUids()) {
+    nodeAdded(n);
   }
-
-  _nodes.erase(node.id());
-}
-
-
-DataModelRegistry&
-FlowScene::
-registry() const
-{
-  return *_registry;
-}
-
-
-void
-FlowScene::
-setRegistry(std::shared_ptr<DataModelRegistry> registry)
-{
-  _registry = std::move(registry);
-}
-
-
-void
-FlowScene::
-iterateOverNodes(std::function<void(Node*)> const & visitor)
-{
-  for (const auto& _node : _nodes)
-  {
-    visitor(_node.second.get());
-  }
-}
-
-
-void
-FlowScene::
-iterateOverNodeData(std::function<void(NodeDataModel*)> const & visitor)
-{
-  for (const auto& _node : _nodes)
-  {
-    visitor(_node.second->nodeDataModel());
-  }
-}
-
-
-void
-FlowScene::
-iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const & visitor)
-{
-  std::set<QUuid> visitedNodesSet;
-
-  //A leaf node is a node with no input ports, or all possible input ports empty
-  auto isNodeLeaf =
-    [](Node const &node, NodeDataModel const &model)
-    {
-      for (unsigned int i = 0; i < model.nPorts(PortType::In); ++i)
-      {
-        auto connections = node.nodeState().connections(PortType::In, i);
-        if (!connections.empty())
-        {
-          return false;
-        }
-      }
-
-      return true;
-    };
-
-  //Iterate over "leaf" nodes
-  for (auto const &_node : _nodes)
-  {
-    auto const &node = _node.second;
-    auto model       = node->nodeDataModel();
-
-    if (isNodeLeaf(*node, *model))
-    {
-      visitor(model);
-      visitedNodesSet.insert(node->id());
-    }
-  }
-
-  auto areNodeInputsVisitedBefore =
-    [&](Node const &node, NodeDataModel const &model)
-    {
-      for (size_t i = 0; i < model.nPorts(PortType::In); ++i)
-      {
-        auto connections = node.nodeState().connections(PortType::In, i);
-
-        for (auto& conn : connections)
-        {
-          if (visitedNodesSet.find(conn.second->getNode(PortType::Out)->id()) == visitedNodesSet.end())
-          {
-            return false;
-          }
-        }
-      }
-
-      return true;
-    };
-
-  //Iterate over dependent nodes
-  while (_nodes.size() != visitedNodesSet.size())
-  {
-    for (auto const &_node : _nodes)
-    {
-      auto const &node = _node.second;
-      if (visitedNodesSet.find(node->id()) != visitedNodesSet.end())
-        continue;
-
-      auto model = node->nodeDataModel();
-
-      if (areNodeInputsVisitedBefore(*node, *model))
-      {
-        visitor(model);
-        visitedNodesSet.insert(node->id());
+  
+  // add connections
+  for (const auto& n : model->nodeUUids()) {
+    auto id = model->nodeIndex(n);
+    Q_ASSERT(id.isValid());
+    
+    // query the number of ports   
+    auto numPorts = model->nodePortCount(id, PortType::Out);
+    
+    // go through them and add the connections
+    for (auto portID = 0u; portID < numPorts; ++portID) {
+      // go through connections
+      auto connections = model->nodePortConnections(id, portID, PortType::Out);
+      
+      // validate the sanity of the model--make sure if it is marked as one connection per port then there is no more than one connection
+      Q_ASSERT(model->nodePortConnectionPolicy(id, portID, PortType::Out) == ConnectionPolicy::Many || connections.size() <= 1);
+      
+      for (const auto& conn : connections) {
+        connectionAdded(id, portID, conn.first, conn.second);
       }
     }
   }
+  
+  // for some reason these end up in the wrong spot, fix that
+  for (const auto& n : model->nodeUUids()) {
+    auto ngo = nodeGraphicsObject(model->nodeIndex(n));
+    ngo->geometry().recalculateSize();
+    ngo->moveConnections();
+  }
 }
 
+FlowScene::~FlowScene() = default;
 
-QPointF
+NodeGraphicsObject*
 FlowScene::
-getNodePosition(const Node& node) const
+nodeGraphicsObject(const NodeIndex& index)
 {
-  return node.nodeGraphicsObject().pos();
+  auto iter = _nodeGraphicsObjects.find(index.id());
+  if (iter == _nodeGraphicsObjects.end()) {
+    return nullptr;
+  }
+  return iter->second;
 }
 
-
-void
+std::vector<NodeIndex>
 FlowScene::
-setNodePosition(Node& node, const QPointF& pos) const
-{
-  node.nodeGraphicsObject().setPos(pos);
-  node.nodeGraphicsObject().moveConnections();
-}
-
-
-QSizeF
-FlowScene::
-getNodeSize(const Node& node) const
-{
-  return QSizeF(node.nodeGeometry().width(), node.nodeGeometry().height());
-}
-
-
-std::unordered_map<QUuid, std::unique_ptr<Node> > const &
-FlowScene::
-nodes() const
-{
-  return _nodes;
-}
-
-
-std::unordered_map<QUuid, std::shared_ptr<Connection> > const &
-FlowScene::
-connections() const
-{
-  return _connections;
-}
-
-
-std::vector<Node*>
-FlowScene::
-selectedNodes() const
-{
+selectedNodes() const {
   QList<QGraphicsItem*> graphicsItems = selectedItems();
 
-  std::vector<Node*> ret;
+  std::vector<NodeIndex> ret;
   ret.reserve(graphicsItems.size());
 
   for (QGraphicsItem* item : graphicsItems)
@@ -408,151 +87,246 @@ selectedNodes() const
 
     if (ngo != nullptr)
     {
-      ret.push_back(&ngo->node());
+      ret.push_back(ngo->index());
     }
   }
 
   return ret;
+
 }
 
+// model slots
 
-//------------------------------------------------------------------------------
+void 
+FlowScene::
+nodeRemoved(const QUuid& id)
+{
+  Q_ASSERT(!id.isNull());
+
+  auto ngo = _nodeGraphicsObjects[id];
+#ifndef NDEBUG
+  // make sure there are no connections left
+  for (const auto& connPtrSet : ngo->nodeState().getEntries(PortType::In)) {
+    Q_ASSERT(connPtrSet.size() == 0);
+  }
+  for (const auto& connPtrSet : ngo->nodeState().getEntries(PortType::Out)) {
+    Q_ASSERT(connPtrSet.size() == 0);
+  }
+#endif
+
+  // just delete it
+  delete ngo;
+  auto erased = _nodeGraphicsObjects.erase(id);
+  Q_ASSERT(erased == 1);
+}
 
 void
 FlowScene::
-clearScene()
+nodeAdded(const QUuid& newID)
 {
-  //Manual node cleanup. Simply clearing the holding datastructures doesn't work, the code crashes when
-  // there are both nodes and connections in the scene. (The data propagation internal logic tries to propagate
-  // data through already freed connections.)
-  std::vector<Node*> nodesToDelete;
-  for (auto& node : _nodes)
-  {
-    nodesToDelete.push_back(node.second.get());
-  }
+  Q_ASSERT(!newID.isNull());
 
-  for (auto& node : nodesToDelete)
-  {
-    removeNode(*node);
-  }
+  // make sure the ID doens't exist already
+  Q_ASSERT(_nodeGraphicsObjects.find(newID) == _nodeGraphicsObjects.end());
+
+  auto index = model()->nodeIndex(newID);
+  Q_ASSERT(index.isValid());
+
+  auto ngo = new NodeGraphicsObject(*this, index);
+  Q_ASSERT(ngo->scene() == this);
+
+  _nodeGraphicsObjects[index.id()] = ngo;
+
+  nodeMoved(index);
 }
-
-
 void
 FlowScene::
-save() const
+nodePortUpdated(NodeIndex const& id)
 {
-  QString fileName =
-    QFileDialog::getSaveFileName(nullptr,
-                                 tr("Open Flow Scene"),
-                                 QDir::homePath(),
-                                 tr("Flow Scene Files (*.flow)"));
+  Q_ASSERT(!id.id().isNull());
 
-  if (!fileName.isEmpty())
-  {
-    if (!fileName.endsWith("flow", Qt::CaseInsensitive))
-      fileName += ".flow";
+  auto thisNodeNGO = nodeGraphicsObject(id);
+  Q_ASSERT(thisNodeNGO != Q_NULLPTR);
 
-    QFile file(fileName);
-    if (file.open(QIODevice::WriteOnly))
-    {
-      file.write(saveToMemory());
+  // remove all the connections
+  for (auto ty : {PortType::In, PortType::Out}) {
+    for (auto i = 0ull; i < thisNodeNGO->nodeState().getEntries(ty).size(); ++i) {
+
+      while (!thisNodeNGO->nodeState().getEntries(ty)[i].empty()) {
+        
+        auto conn = thisNodeNGO->nodeState().getEntries(ty)[i][0];
+        // remove it from the nodes
+        auto& otherNgo = *nodeGraphicsObject(conn->node(oppositePort(ty)));
+        otherNgo.nodeState().eraseConnection(oppositePort(ty), conn->portIndex(oppositePort(ty)), *conn);
+
+        auto& thisNgo = *nodeGraphicsObject(conn->node(ty));
+        thisNgo.nodeState().eraseConnection(ty, conn->portIndex(ty), *conn);
+
+        // remove the ConnectionGraphicsObject
+        delete conn;
+        auto erased = _connGraphicsObjects.erase(conn->id());
+        Q_ASSERT(erased == 1);
+      }
+    }
+  }
+ 
+  // recreate the NGO
+  
+  // just delete it
+  delete thisNodeNGO;
+  auto erased = _nodeGraphicsObjects.erase(id.id());
+  Q_ASSERT(erased == 1);
+ 
+  // create it
+  auto ngo = new NodeGraphicsObject(*this, id);
+  Q_ASSERT(ngo->scene() == this);
+
+  _nodeGraphicsObjects[id.id()] = ngo;
+
+  nodeMoved(id);
+  
+  // add the connections back
+  for (auto ty : { PortType::In, PortType::Out }) {
+            
+    // query the number of ports   
+    auto numPorts = model()->nodePortCount(id, ty);
+    
+    for (auto portID = 0u; portID < numPorts; ++portID) {
+
+      // go through connections
+      auto connections = model()->nodePortConnections(id, portID, ty);
+#ifndef NDEBUG
+      for (auto conn : connections) {
+        auto remoteConns = model()->nodePortConnections(conn.first, conn.second, oppositePort(ty));
+
+        // if you fail here, your connections aren't self-consistent
+        Q_ASSERT(std::any_of(remoteConns.begin(), remoteConns.end(), [&](std::pair<NodeIndex, PortIndex> this_conn){
+          return this_conn.first == id && (size_t)this_conn.second == portID;
+        }));
+      }
+#endif
+      
+      // validate the sanity of the model--make sure if it is marked as one connection per port then there is no more than one connection
+      Q_ASSERT(model()->nodePortConnectionPolicy(id, portID, ty) == ConnectionPolicy::Many || connections.size() <= 1);
+      
+      for (const auto& conn : connections) {
+        
+        if (ty == PortType::Out) {
+          connectionAdded(id, portID, conn.first, conn.second);
+        } else {
+          connectionAdded(conn.first, conn.second, id, portID);
+        }
+      }
     }
   }
 }
+void
+FlowScene::
+nodeValidationUpdated(NodeIndex const& id)
+{
+  // repaint
+  auto ngo = nodeGraphicsObject(id);
+  ngo->setGeometryChanged();
+  ngo->geometry().recalculateSize();
+  ngo->moveConnections();
+  ngo->update();
+  
+}
+void
+FlowScene::
+connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID)
+{
+  // check the model's sanity
+#ifndef NDEBUG
+  for (const auto& conn : model()->nodePortConnections(leftNode, leftPortID, PortType::Out)) {
+    // if you fail here, then you're emitting connectionRemoved on a connection that is in the model
+    Q_ASSERT (conn.first != rightNode || conn.second != rightPortID);
+  }
+  for (const auto& conn : model()->nodePortConnections(rightNode, rightPortID, PortType::In)) {
+    // if you fail here, then you're emitting connectionRemoved on a connection that is in the model
+    Q_ASSERT (conn.first != leftNode || conn.second != leftPortID);
+  }
+#endif
 
+  // create a connection ID
+  ConnectionID id;
+  id.lNodeID = leftNode.id();
+  id.rNodeID = rightNode.id();
+  id.lPortID = leftPortID;
+  id.rPortID = rightPortID;
+  
+  // cgo
+  auto& cgo = *_connGraphicsObjects[id];
+  
+  // remove it from the nodes
+  auto& lngo = *nodeGraphicsObject(leftNode);
+  lngo.nodeState().eraseConnection(PortType::Out, leftPortID, cgo);
+  
+  auto& rngo = *nodeGraphicsObject(rightNode);
+  rngo.nodeState().eraseConnection(PortType::In, rightPortID, cgo);
+  
+  // remove the ConnectionGraphicsObject
+  delete &cgo;
+  _connGraphicsObjects.erase(id);
+}
+void
+FlowScene::
+connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID)
+{
+  // check the model's sanity
+#ifndef NDEBUG
+  Q_ASSERT(leftPortID >= 0);
+  Q_ASSERT(rightPortID >= 0);
+  // if you fail here, then you're emitting connectionAdded on a portID that doesn't exist
+  Q_ASSERT((size_t)leftPortID < model()->nodePortCount(leftNode, PortType::Out));
+  Q_ASSERT((size_t)rightPortID < model()->nodePortCount(rightNode, PortType::In));
+
+  bool checkedOut = false;
+  for (const auto& conn : model()->nodePortConnections(leftNode, leftPortID, PortType::Out)) {
+    if (conn.first == rightNode && conn.second == rightPortID) {
+      checkedOut = true;
+      break;
+    }
+  }
+  // if you fail here, then you're emitting connectionAdded on a connection that isn't in the model
+  Q_ASSERT(checkedOut);
+  checkedOut = false;
+  for (const auto& conn : model()->nodePortConnections(rightNode, rightPortID, PortType::In)) {
+    if (conn.first == leftNode && conn.second == leftPortID) {
+      checkedOut = true;
+      break;
+    }
+  }
+  // if you fail here, then you're emitting connectionAdded on a connection that isn't in the model
+  Q_ASSERT(checkedOut);
+#endif
+  
+  // create the cgo
+  auto cgo = new ConnectionGraphicsObject(leftNode, leftPortID, rightNode, rightPortID, *this);
+  
+  // add it to the nodes
+  auto lngo = nodeGraphicsObject(leftNode);
+  lngo->nodeState().setConnection(PortType::Out, leftPortID, *cgo);
+  
+  auto rngo = nodeGraphicsObject(rightNode);
+  rngo->nodeState().setConnection(PortType::In, rightPortID, *cgo);
+  
+  // add the cgo to the map
+  _connGraphicsObjects[cgo->id()] = cgo;
+  
+}
 
 void
 FlowScene::
-load()
-{
-  clearScene();
-
-  //-------------
-
-  QString fileName =
-    QFileDialog::getOpenFileName(nullptr,
-                                 tr("Open Flow Scene"),
-                                 QDir::homePath(),
-                                 tr("Flow Scene Files (*.flow)"));
-
-  if (!QFileInfo::exists(fileName))
-    return;
-
-  QFile file(fileName);
-
-  if (!file.open(QIODevice::ReadOnly))
-    return;
-
-  QByteArray wholeFile = file.readAll();
-
-  loadFromMemory(wholeFile);
+nodeMoved(NodeIndex const& index) {
+  _nodeGraphicsObjects[index.id()]->setPos(model()->nodeLocation(index));
 }
-
-
-QByteArray
-FlowScene::
-saveToMemory() const
-{
-  QJsonObject sceneJson;
-
-  QJsonArray nodesJsonArray;
-
-  for (auto const & pair : _nodes)
-  {
-    auto const &node = pair.second;
-
-    nodesJsonArray.append(node->save());
-  }
-
-  sceneJson["nodes"] = nodesJsonArray;
-
-  QJsonArray connectionJsonArray;
-  for (auto const & pair : _connections)
-  {
-    auto const &connection = pair.second;
-
-    QJsonObject connectionJson = connection->save();
-
-    if (!connectionJson.isEmpty())
-      connectionJsonArray.append(connectionJson);
-  }
-
-  sceneJson["connections"] = connectionJsonArray;
-
-  QJsonDocument document(sceneJson);
-
-  return document.toJson();
-}
-
-
-void
-FlowScene::
-loadFromMemory(const QByteArray& data)
-{
-  QJsonObject const jsonDocument = QJsonDocument::fromJson(data).object();
-
-  QJsonArray nodesJsonArray = jsonDocument["nodes"].toArray();
-
-  for (QJsonValueRef node : nodesJsonArray)
-  {
-    restoreNode(node.toObject());
-  }
-
-  QJsonArray connectionJsonArray = jsonDocument["connections"].toArray();
-
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    restoreConnection(connection.toObject());
-  }
-}
-
 
 //------------------------------------------------------------------------------
 namespace QtNodes
 {
 
-Node*
+NodeGraphicsObject*
 locateNodeAt(QPointF scenePoint, FlowScene &scene,
              QTransform const & viewTransform)
 {
@@ -574,16 +348,14 @@ locateNodeAt(QPointF scenePoint, FlowScene &scene,
       return (dynamic_cast<NodeGraphicsObject*>(item) != nullptr);
     });
 
-  Node* resultNode = nullptr;
-
   if (!filteredItems.empty())
   {
     QGraphicsItem* graphicsItem = filteredItems.front();
     auto ngo = dynamic_cast<NodeGraphicsObject*>(graphicsItem);
 
-    resultNode = &ngo->node();
+    return ngo;
   }
 
-  return resultNode;
+  return nullptr;
 }
 }

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -10,6 +10,7 @@ using QtNodes::FlowScene;
 using QtNodes::NodeGraphicsObject;
 using QtNodes::NodeIndex;
 using QtNodes::FlowSceneModel;
+using QtNodes::PortIndex;
 
 FlowScene::
 FlowScene(FlowSceneModel* model,
@@ -128,6 +129,7 @@ nodeRemoved(const QUuid& id)
   // just delete it
   delete ngo;
   auto erased = _nodeGraphicsObjects.erase(id);
+  Q_UNUSED(erased);
   Q_ASSERT(erased == 1);
 }
 
@@ -178,6 +180,7 @@ nodePortUpdated(NodeIndex const& id)
         // remove the ConnectionGraphicsObject
         delete conn;
         auto erased = _connGraphicsObjects.erase(conn->id());
+        Q_UNUSED(erased);
         Q_ASSERT(erased == 1);
       }
     }
@@ -188,6 +191,7 @@ nodePortUpdated(NodeIndex const& id)
   // just delete it
   delete thisNodeNGO;
   auto erased = _nodeGraphicsObjects.erase(id.id());
+  Q_UNUSED(erased);
   Q_ASSERT(erased == 1);
 
   // create it

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -104,7 +104,7 @@ nodeRemoved(const QUuid& id)
   Q_ASSERT(!id.isNull());
 
   auto ngo = _nodeGraphicsObjects[id];
-#ifndef NDEBUG
+#ifndef QT_NO_DEBUG
   // make sure there are no connections left
   for (const auto& connPtrSet : ngo->nodeState().getEntries(PortType::In)) {
     Q_ASSERT(connPtrSet.size() == 0);
@@ -195,7 +195,7 @@ nodePortUpdated(NodeIndex const& id)
 
       // go through connections
       auto connections = model()->nodePortConnections(id, portID, ty);
-#ifndef NDEBUG
+#ifndef QT_NO_DEBUG
       for (auto conn : connections) {
         auto remoteConns = model()->nodePortConnections(conn.first, conn.second, oppositePort(ty));
 
@@ -237,7 +237,7 @@ FlowScene::
 connectionRemoved(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID)
 {
   // check the model's sanity
-#ifndef NDEBUG
+#ifndef QT_NO_DEBUG
   for (const auto& conn : model()->nodePortConnections(leftNode, leftPortID, PortType::Out)) {
     // if you fail here, then you're emitting connectionRemoved on a connection that is in the model
     Q_ASSERT (conn.first != rightNode || conn.second != rightPortID);
@@ -274,7 +274,7 @@ FlowScene::
 connectionAdded(NodeIndex const& leftNode, PortIndex leftPortID, NodeIndex const& rightNode, PortIndex rightPortID)
 {
   // check the model's sanity
-#ifndef NDEBUG
+#ifndef QT_NO_DEBUG
   Q_ASSERT(leftPortID >= 0);
   Q_ASSERT(rightPortID >= 0);
   // if you fail here, then you're emitting connectionAdded on a portID that doesn't exist

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -9,6 +9,7 @@
 using QtNodes::FlowScene;
 using QtNodes::NodeGraphicsObject;
 using QtNodes::NodeIndex;
+using QtNodes::FlowSceneModel;
 
 FlowScene::
 FlowScene(FlowSceneModel* model,

--- a/src/FlowSceneModel.cpp
+++ b/src/FlowSceneModel.cpp
@@ -1,46 +1,60 @@
 #include "FlowSceneModel.hpp"
 #include "NodeIndex.hpp"
 
-namespace QtNodes {
-
-FlowSceneModel::FlowSceneModel()
+namespace QtNodes
 {
-}
 
-bool FlowSceneModel::removeNodeWithConnections(NodeIndex const& index) {
-  
+
+bool
+FlowSceneModel::
+removeNodeWithConnections(NodeIndex const& index)
+{
+
   // delete the conenctions that node has first
-  auto deleteConnections = [&](PortType ty) -> bool {
-    for (PortIndex portID = 0; (size_t)portID < nodePortCount(index, ty); ++portID) {
-      auto inputConnections = nodePortConnections(index, portID, ty);
-      for (const auto& conn : inputConnections) {
-        // try to remove it
-        bool success;
-        if (ty == PortType::In) {
-          success = removeConnection(conn.first, conn.second, index, portID);
-        } else {
-          success = removeConnection(index, portID, conn.first, conn.second);
-        }
+  auto deleteConnections =
+    [&](PortType ty) -> bool
+    {
+      for (PortIndex portID = 0; (size_t)portID < nodePortCount(index, ty); ++portID)
+      {
+        auto inputConnections = nodePortConnections(index, portID, ty);
+        for (const auto& conn : inputConnections)
+        {
+          // try to remove it
+          bool success;
+          if (ty == PortType::In)
+          {
+            success = removeConnection(conn.first, conn.second, index, portID);
+          }
+          else {
+            success = removeConnection(index, portID, conn.first, conn.second);
+          }
 
-        // failed, abort the node deletion
-        if (!success) {
-          return false;
+          // failed, abort the node deletion
+          if (!success)
+          {
+            return false;
+          }
         }
       }
-    }
-    return true;
-  };
+      return true;
+    };
+
   bool success = deleteConnections(PortType::In);
-  if (!success) return false;
-  
+
+  if (!success)
+    return false;
+
   success = deleteConnections(PortType::Out);
-  if (!success) return false;
-  
+  if (!success)
+    return false;
+
   // if we get here, then try to remove the node itsself
   return removeNode(index);
 }
 
-NodeIndex FlowSceneModel::createIndex(const QUuid& id, void* internalPointer) const
+NodeIndex
+FlowSceneModel::
+createIndex(const QUuid& id, void* internalPointer) const
 {
   return NodeIndex(id, internalPointer, this);
 }

--- a/src/FlowSceneModel.cpp
+++ b/src/FlowSceneModel.cpp
@@ -1,0 +1,49 @@
+#include "FlowSceneModel.hpp"
+#include "NodeIndex.hpp"
+
+namespace QtNodes {
+
+FlowSceneModel::FlowSceneModel()
+{
+}
+
+bool FlowSceneModel::removeNodeWithConnections(NodeIndex const& index) {
+  
+  // delete the conenctions that node has first
+  auto deleteConnections = [&](PortType ty) -> bool {
+    for (PortIndex portID = 0; (size_t)portID < nodePortCount(index, ty); ++portID) {
+      auto inputConnections = nodePortConnections(index, portID, ty);
+      for (const auto& conn : inputConnections) {
+        // try to remove it
+        bool success;
+        if (ty == PortType::In) {
+          success = removeConnection(conn.first, conn.second, index, portID);
+        } else {
+          success = removeConnection(index, portID, conn.first, conn.second);
+        }
+
+        // failed, abort the node deletion
+        if (!success) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+  bool success = deleteConnections(PortType::In);
+  if (!success) return false;
+  
+  success = deleteConnections(PortType::Out);
+  if (!success) return false;
+  
+  // if we get here, then try to remove the node itsself
+  return removeNode(index);
+}
+
+NodeIndex FlowSceneModel::createIndex(const QUuid& id, void* internalPointer) const
+{
+  return NodeIndex(id, internalPointer, this);
+}
+
+} // namespace QtNodes
+

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -132,21 +132,34 @@ contextMenuEvent(QContextMenuEvent *event)
 
   modelMenu.addAction(treeViewAction);
 
-  QMap<QString, QTreeWidgetItem*> topLevelItems;
-  for (auto const &cat : _scene->registry().categories())
+  QMap<QString, QTreeWidgetItem*> catergoryItems;
+  for (auto const &modelName : _scene->model()->modelRegistry())
   {
-    auto item = new QTreeWidgetItem(treeView);
-    item->setText(0, cat);
-    item->setData(0, Qt::UserRole, skipText);
-    topLevelItems[cat] = item;
-  }
+    // get the catergory
+    auto category = _scene->model()->nodeTypeCatergory(modelName);
+    
+    // see if it's already in the map
+    auto iter = catergoryItems.find(category);
+    
+    // add it if it doesn't exist
+    if (iter == catergoryItems.end()) {
+          
+      auto item = new QTreeWidgetItem(treeView);
+      item->setText(0, category);
+      item->setData(0, Qt::UserRole, skipText);
+          
+      iter = catergoryItems.insert(category, item); 
+    }
 
-  for (auto const &assoc : _scene->registry().registeredModelsCategoryAssociation())
-  {
-    auto parent = topLevelItems[assoc.second];
+    // this is the catergory item
+    auto parent = iter.value();
+    
+    // add the item
+    
+
     auto item   = new QTreeWidgetItem(parent);
-    item->setText(0, assoc.first);
-    item->setData(0, Qt::UserRole, assoc.first);
+    item->setText(0, modelName);
+    item->setData(0, Qt::UserRole, modelName);
   }
 
   treeView->expandAll();
@@ -160,21 +173,17 @@ contextMenuEvent(QContextMenuEvent *event)
       return;
     }
 
-    auto type = _scene->registry().create(modelName);
+    QPoint pos = event->pos();
 
-    if (type)
-    {
-      auto& node = _scene->createNode(std::move(type));
+    QPointF posView = this->mapToScene(pos);
 
-      QPoint pos = event->pos();
-
-      QPointF posView = this->mapToScene(pos);
-
-      node.nodeGraphicsObject().setPos(posView);
-    }
-    else
-    {
-      qDebug() << "Model not found";
+    // try to create the node
+    auto uuid = _scene->model()->addNode(modelName, posView);
+    
+    // if the node creation failed, then don't add it
+    if (!uuid.isNull()) {
+        // move it to the cursor location
+        _scene->model()->moveNode(_scene->model()->nodeIndex(uuid), posView);
     }
 
     modelMenu.close();
@@ -183,7 +192,7 @@ contextMenuEvent(QContextMenuEvent *event)
   //Setup filtering
   connect(txtBox, &QLineEdit::textChanged, [&](const QString &text)
   {
-    for (auto& topLvlItem : topLevelItems)
+    for (auto& topLvlItem : catergoryItems)
     {
       for (int i = 0; i < topLvlItem->childCount(); ++i)
       {
@@ -259,8 +268,12 @@ deleteSelectedNodes()
   // deletes some connections as well)
   for (QGraphicsItem * item : _scene->selectedItems())
   {
-    if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
-      _scene->deleteConnection(c->connection());
+    if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item)) {
+      
+      // does't matter if it works or doesn't, at least we tried
+      scene()->model()->removeConnection(c->node(PortType::Out), c->portIndex(PortType::Out), c->node(PortType::In), c->portIndex(PortType::In));
+      
+    }
   }
 
   // Delete the nodes; this will delete many of the connections.
@@ -269,8 +282,11 @@ deleteSelectedNodes()
   // when a selected connection is deleted by deleting the node.
   for (QGraphicsItem * item : _scene->selectedItems())
   {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
-      _scene->removeNode(n->node());
+    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item)) {
+      auto index = n->index();
+      
+      scene()->model()->removeNodeWithConnections(index);
+    }
   }
 }
 
@@ -330,7 +346,7 @@ mouseMoveEvent(QMouseEvent *event)
   if (scene()->mouseGrabberItem() == nullptr && event->buttons() == Qt::LeftButton)
   {
     // Make sure shift is not being pressed
-    if ((event->modifiers() & Qt::ShiftModifier) == 0)
+      if ((event->modifiers() & Qt::ShiftModifier) == 0)
     {
       QPointF difference = _clickPos - mapToScene(event->pos());
       setSceneRect(sceneRect().translated(difference.x(), difference.y()));

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -133,27 +133,27 @@ contextMenuEvent(QContextMenuEvent *event)
 
   modelMenu.addAction(treeViewAction);
 
-  QMap<QString, QTreeWidgetItem*> catergoryItems;
+  QMap<QString, QTreeWidgetItem*> categoryItems;
   for (auto const &modelName : _scene->model()->modelRegistry())
   {
-    // get the catergory
-    auto category = _scene->model()->nodeTypeCatergory(modelName);
+    // get the category
+    auto category = _scene->model()->nodeTypeCategory(modelName);
 
     // see if it's already in the map
-    auto iter = catergoryItems.find(category);
+    auto iter = categoryItems.find(category);
 
     // add it if it doesn't exist
-    if (iter == catergoryItems.end())
+    if (iter == categoryItems.end())
     {
 
       auto item = new QTreeWidgetItem(treeView);
       item->setText(0, category);
       item->setData(0, Qt::UserRole, skipText);
 
-      iter = catergoryItems.insert(category, item);
+      iter = categoryItems.insert(category, item);
     }
 
-    // this is the catergory item
+    // this is the category item
     auto parent = iter.value();
 
     // add the item
@@ -195,7 +195,7 @@ contextMenuEvent(QContextMenuEvent *event)
   //Setup filtering
   connect(txtBox, &QLineEdit::textChanged, [&](const QString &text)
           {
-            for (auto& topLvlItem : catergoryItems)
+            for (auto& topLvlItem : categoryItems)
             {
               for (int i = 0; i < topLvlItem->childCount(); ++i)
               {

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -78,7 +78,8 @@ deleteSelectionAction() const
 
 
 void
-FlowView::setScene(FlowScene *scene)
+FlowView::
+setScene(FlowScene *scene)
 {
   _scene = scene;
   QGraphicsView::setScene(_scene);
@@ -137,27 +138,28 @@ contextMenuEvent(QContextMenuEvent *event)
   {
     // get the catergory
     auto category = _scene->model()->nodeTypeCatergory(modelName);
-    
+
     // see if it's already in the map
     auto iter = catergoryItems.find(category);
-    
+
     // add it if it doesn't exist
-    if (iter == catergoryItems.end()) {
-          
+    if (iter == catergoryItems.end())
+    {
+
       auto item = new QTreeWidgetItem(treeView);
       item->setText(0, category);
       item->setData(0, Qt::UserRole, skipText);
-          
-      iter = catergoryItems.insert(category, item); 
+
+      iter = catergoryItems.insert(category, item);
     }
 
     // this is the catergory item
     auto parent = iter.value();
-    
-    // add the item
-    
 
-    auto item   = new QTreeWidgetItem(parent);
+    // add the item
+
+
+    auto item = new QTreeWidgetItem(parent);
     item->setText(0, modelName);
     item->setData(0, Qt::UserRole, modelName);
   }
@@ -165,44 +167,45 @@ contextMenuEvent(QContextMenuEvent *event)
   treeView->expandAll();
 
   connect(treeView, &QTreeWidget::itemClicked, [&](QTreeWidgetItem *item, int)
-  {
-    QString modelName = item->data(0, Qt::UserRole).toString();
+          {
+            QString modelName = item->data(0, Qt::UserRole).toString();
 
-    if (modelName == skipText)
-    {
-      return;
-    }
+            if (modelName == skipText)
+            {
+              return;
+            }
 
-    QPoint pos = event->pos();
+            QPoint pos = event->pos();
 
-    QPointF posView = this->mapToScene(pos);
+            QPointF posView = this->mapToScene(pos);
 
-    // try to create the node
-    auto uuid = _scene->model()->addNode(modelName, posView);
-    
-    // if the node creation failed, then don't add it
-    if (!uuid.isNull()) {
-        // move it to the cursor location
-        _scene->model()->moveNode(_scene->model()->nodeIndex(uuid), posView);
-    }
+            // try to create the node
+            auto uuid = _scene->model()->addNode(modelName, posView);
 
-    modelMenu.close();
-  });
+            // if the node creation failed, then don't add it
+            if (!uuid.isNull())
+            {
+              // move it to the cursor location
+              _scene->model()->moveNode(_scene->model()->nodeIndex(uuid), posView);
+            }
+
+            modelMenu.close();
+          });
 
   //Setup filtering
   connect(txtBox, &QLineEdit::textChanged, [&](const QString &text)
-  {
-    for (auto& topLvlItem : catergoryItems)
-    {
-      for (int i = 0; i < topLvlItem->childCount(); ++i)
-      {
-        auto child = topLvlItem->child(i);
-        auto modelName = child->data(0, Qt::UserRole).toString();
-        const bool match = (modelName.contains(text, Qt::CaseInsensitive));
-        child->setHidden(!match);
-      }
-    }
-  });
+          {
+            for (auto& topLvlItem : catergoryItems)
+            {
+              for (int i = 0; i < topLvlItem->childCount(); ++i)
+              {
+                auto child       = topLvlItem->child(i);
+                auto modelName   = child->data(0, Qt::UserRole).toString();
+                const bool match = (modelName.contains(text, Qt::CaseInsensitive));
+                child->setHidden(!match);
+              }
+            }
+          });
 
   // make sure the text box gets focus so the user doesn't have to click on it
   txtBox->setFocus();
@@ -268,11 +271,12 @@ deleteSelectedNodes()
   // deletes some connections as well)
   for (QGraphicsItem * item : _scene->selectedItems())
   {
-    if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item)) {
-      
+    if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
+    {
+
       // does't matter if it works or doesn't, at least we tried
       scene()->model()->removeConnection(c->node(PortType::Out), c->portIndex(PortType::Out), c->node(PortType::In), c->portIndex(PortType::In));
-      
+
     }
   }
 
@@ -282,9 +286,10 @@ deleteSelectedNodes()
   // when a selected connection is deleted by deleting the node.
   for (QGraphicsItem * item : _scene->selectedItems())
   {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item)) {
+    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
+    {
       auto index = n->index();
-      
+
       scene()->model()->removeNodeWithConnections(index);
     }
   }
@@ -346,7 +351,7 @@ mouseMoveEvent(QMouseEvent *event)
   if (scene()->mouseGrabberItem() == nullptr && event->buttons() == Qt::LeftButton)
   {
     // Make sure shift is not being pressed
-      if ((event->modifiers() & Qt::ShiftModifier) == 0)
+    if ((event->modifiers() & Qt::ShiftModifier) == 0)
     {
       QPointF difference = _clickPos - mapToScene(event->pos());
       setSceneRect(sceneRect().translated(difference.x(), difference.y()));
@@ -364,9 +369,9 @@ drawBackground(QPainter* painter, const QRectF& r)
   auto drawGrid =
     [&](double gridStep)
     {
-      QRect   windowRect = rect();
-      QPointF tl = mapToScene(windowRect.topLeft());
-      QPointF br = mapToScene(windowRect.bottomRight());
+      QRect windowRect = rect();
+      QPointF tl       = mapToScene(windowRect.topLeft());
+      QPointF br       = mapToScene(windowRect.bottomRight());
 
       double left   = std::floor(tl.x() / gridStep - 0.5);
       double right  = std::floor(br.x() / gridStep + 1.0);

--- a/src/FlowViewStyle.cpp
+++ b/src/FlowViewStyle.cpp
@@ -12,7 +12,8 @@
 
 using QtNodes::FlowViewStyle;
 
-inline void initResources() { Q_INIT_RESOURCE(resources); }
+inline void
+initResources() { Q_INIT_RESOURCE(resources); }
 
 FlowViewStyle::
 FlowViewStyle()
@@ -45,10 +46,10 @@ setStyle(QString jsonText)
 
 #ifdef STYLE_DEBUG
   #define FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(v, variable) { \
-      if (v.type() == QJsonValue::Undefined || \
-          v.type() == QJsonValue::Null) \
-        qWarning() << "Undefined value for parameter:" << #variable; \
-  }
+    if (v.type() == QJsonValue::Undefined || \
+        v.type() == QJsonValue::Null) \
+      qWarning() << "Undefined value for parameter:" << #variable; \
+}
 #else
   #define FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
 #endif

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -17,6 +17,8 @@
 using QtNodes::Node;
 using QtNodes::NodeDataModel;
 using QtNodes::Connection;
+using QtNodes::PortType;
+using QtNodes::PortIndex;
 
 Node::
 Node(std::unique_ptr<NodeDataModel> && dataModel, QUuid const& id)

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -20,9 +20,8 @@ using QtNodes::Connection;
 
 Node::
 Node(std::unique_ptr<NodeDataModel> && dataModel, QUuid const& id)
-  : _uid(id),
-    _nodeDataModel(std::move(dataModel))
-  
+  : _uid(id)
+  ,_nodeDataModel(std::move(dataModel))
 {
   // propagate data: model => node
   connect(_nodeDataModel.get(), &NodeDataModel::dataUpdated,
@@ -47,8 +46,8 @@ save() const
   nodeJson["model"] = _nodeDataModel->save();
 
   QJsonObject obj;
-  obj["x"] = _pos.x();
-  obj["y"] = _pos.y();
+  obj["x"]             = _pos.x();
+  obj["y"]             = _pos.y();
   nodeJson["position"] = obj;
 
   return nodeJson;
@@ -61,8 +60,8 @@ restore(QJsonObject const& json)
 {
 
   QJsonObject positionJson = json["position"].toObject();
-  QPointF     point(positionJson["x"].toDouble(),
-                    positionJson["y"].toDouble());
+  QPointF point(positionJson["x"].toDouble(),
+                positionJson["y"].toDouble());
   setPosition(point);
 
   _nodeDataModel->restore(json["model"].toObject());
@@ -92,7 +91,8 @@ position() const
 
 void
 Node::
-setPosition(QPointF const& newPos) {
+setPosition(QPointF const& newPos)
+{
   _pos = newPos;
 
   emit positionChanged(newPos);
@@ -132,7 +132,7 @@ Node::
 onDataUpdated(PortIndex index)
 {
   auto nodeData = _nodeDataModel->outData(index);
-  auto& conns =
+  auto& conns   =
     connections(PortType::Out, index);
 
   for (auto const & c : conns)

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -19,6 +19,7 @@ using QtNodes::NodeDataModel;
 using QtNodes::Connection;
 using QtNodes::PortType;
 using QtNodes::PortIndex;
+using QtNodes::NodeData;
 
 Node::
 Node(std::unique_ptr<NodeDataModel> && dataModel, QUuid const& id)

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -14,7 +14,9 @@
 #include "ConnectionState.hpp"
 #include "Connection.hpp"
 
-namespace QtNodes {
+using QtNodes::Node;
+using QtNodes::NodeDataModel;
+using QtNodes::Connection;
 
 Node::
 Node(std::unique_ptr<NodeDataModel> && dataModel, QUuid const& id)

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -65,7 +65,7 @@ canConnect(PortIndex &portIndex, bool& converted) const
   auto connectionDataType =
     _connection->dataType(oppositePort(requiredPort));
 
-  auto const   modelTarget           = _node.model();
+  auto const modelTarget             = _node.model();
   NodeDataType candidateNodeDataType = modelTarget->nodePortDataType(_node, portIndex, requiredPort);
 
   // if the types don't match, try a conversion
@@ -78,7 +78,7 @@ canConnect(PortIndex &portIndex, bool& converted) const
     }
     else if (requiredPort == PortType::Out)
     {
-      return modelTarget->getTypeConvertable({candidateNodeDataType , connectionDataType});
+      return modelTarget->getTypeConvertable({candidateNodeDataType, connectionDataType});
     }
     Q_UNREACHABLE();
   }
@@ -103,15 +103,16 @@ tryConnect() const
     return false;
   }
 
-  auto requiredPort = connectionRequiredPort();
+  auto requiredPort  = connectionRequiredPort();
   auto connectedPort = oppositePort(requiredPort);
 
   auto outNodePortIndex = _connection->portIndex(connectedPort);
-  auto outNode = _connection->node(connectedPort);
+  auto outNode          = _connection->node(connectedPort);
 
   auto model = _connection->flowScene().model();
 
-  if (requiredPort == PortType::In) {
+  if (requiredPort == PortType::In)
+  {
     return model->addConnection(outNode, outNodePortIndex, _node, portIndex);
   }
   return model->addConnection(_node, portIndex, outNode, outNodePortIndex);
@@ -147,7 +148,7 @@ nodePortScenePosition(PortType portType, PortIndex portIndex) const
 {
 
   NodeGraphicsObject const& ngo = *_connection->flowScene().nodeGraphicsObject(_node);
-  
+
   NodeGeometry const &geom = ngo.geometry();
 
   QPointF p = geom.portScenePosition(portIndex, portType);
@@ -162,7 +163,7 @@ nodePortIndexUnderScenePoint(PortType portType,
                              QPointF const & scenePoint) const
 {
   NodeGraphicsObject const& ngo = *_connection->flowScene().nodeGraphicsObject(_node);
-  NodeGeometry const &nodeGeom = ngo.geometry();
+  NodeGeometry const &nodeGeom  = ngo.geometry();
 
   QTransform sceneTransform =
     ngo.sceneTransform();
@@ -182,7 +183,8 @@ nodePortIsEmpty(PortType portType, PortIndex portIndex) const
 
   auto const & entries = nodeState.getEntries(portType);
 
-  if (entries[portIndex].empty()) return true;
+  if (entries[portIndex].empty())
+    return true;
 
   const auto outPolicy = _node.model()->nodePortConnectionPolicy(_node, portIndex, portType);
   return outPolicy == ConnectionPolicy::Many;

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -13,6 +13,7 @@ using QtNodes::FlowScene;
 using QtNodes::NodeDataModel;
 using QtNodes::TypeConverter;
 using QtNodes::NodeIndex;
+using QtNodes::ConnectionGraphicsObject;
 
 NodeConnectionInteraction::
 NodeConnectionInteraction(NodeIndex const& node,

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -12,7 +12,7 @@ using QtNodes::PortIndex;
 using QtNodes::FlowScene;
 using QtNodes::NodeDataModel;
 using QtNodes::TypeConverter;
-
+using QtNodes::NodeIndex;
 
 NodeConnectionInteraction::
 NodeConnectionInteraction(NodeIndex const& node,

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -20,7 +20,8 @@ public:
   /// 2) Connection's vacant end is above the node port
   /// 3) Node port is vacant
   /// 4) Connection type equals node port type, or there is a registered type conversion that can translate between the two
-  bool canConnect(PortIndex & portIndex, bool& converted) const;
+  bool
+  canConnect(PortIndex & portIndex, bool& converted) const;
 
   /// 1)   Check conditions from 'canConnect'
   /// 1.5) If the connection is possible but a type conversion is needed, add a converter node to the scene, and connect it properly
@@ -28,21 +29,26 @@ public:
   /// 3)   Assign Connection to empty port in NodeState
   /// 4)   Adjust Connection geometry
   /// 5)   Poke model to initiate data transfer
-  bool tryConnect() const;
+  bool
+  tryConnect() const;
 
 private:
 
-  PortType connectionRequiredPort() const;
+  PortType
+  connectionRequiredPort() const;
 
   QPointF connectionEndScenePosition(PortType) const;
 
-  QPointF nodePortScenePosition(PortType portType,
-                                PortIndex portIndex) const;
+  QPointF
+  nodePortScenePosition(PortType portType,
+                        PortIndex portIndex) const;
 
-  PortIndex nodePortIndexUnderScenePoint(PortType portType,
-                                         QPointF const &p) const;
+  PortIndex
+  nodePortIndexUnderScenePoint(PortType portType,
+                               QPointF const &p) const;
 
-  bool nodePortIsEmpty(PortType portType, PortIndex portIndex) const;
+  bool
+  nodePortIsEmpty(PortType portType, PortIndex portIndex) const;
 
 private:
 

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -6,27 +6,21 @@
 namespace QtNodes
 {
 
-class DataModelRegistry;
-class FlowScene;
-class NodeDataModel;
-
 /// Class performs various operations on the Node and Connection pair.
 /// An instance should be created on the stack and destroyed when
 /// the operation is completed
 class NodeConnectionInteraction
 {
 public:
-  NodeConnectionInteraction(Node& node,
-                            Connection& connection,
-                            FlowScene& scene);
+  NodeConnectionInteraction(NodeIndex const& node,
+                            ConnectionGraphicsObject& connection);
 
   /// Can connect when following conditions are met:
   /// 1) Connection 'requires' a port
   /// 2) Connection's vacant end is above the node port
   /// 3) Node port is vacant
   /// 4) Connection type equals node port type, or there is a registered type conversion that can translate between the two
-  bool canConnect(PortIndex & portIndex, 
-                  TypeConverter & converter) const;
+  bool canConnect(PortIndex & portIndex, bool& converted) const;
 
   /// 1)   Check conditions from 'canConnect'
   /// 1.5) If the connection is possible but a type conversion is needed, add a converter node to the scene, and connect it properly
@@ -35,13 +29,6 @@ public:
   /// 4)   Adjust Connection geometry
   /// 5)   Poke model to initiate data transfer
   bool tryConnect() const;
-
-
-  /// 1) Node and Connection should be already connected
-  /// 2) If so, clear Connection entry in the NodeState
-  /// 3) Propagate invalid data to IN node
-  /// 4) Set Connection end to 'requiring a port'
-  bool disconnect(PortType portToDisconnect) const;
 
 private:
 
@@ -59,10 +46,8 @@ private:
 
 private:
 
-  Node* _node;
+  NodeIndex _node;
 
-  Connection* _connection;
-
-  FlowScene* _scene;
+  ConnectionGraphicsObject* _connection;
 };
 }

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -12,7 +12,8 @@
 
 #include <QWidget>
 
-namespace QtNodes {
+namespace QtNodes
+{
 
 NodeGeometry::
 NodeGeometry(const NodeIndex& index)
@@ -72,7 +73,7 @@ recalculateSize() const
 
   {
     unsigned int maxNumOfEntries = std::max(_nSinks, _nSources);
-    unsigned int step = _entryHeight + _spacing;
+    unsigned int step            = _entryHeight + _spacing;
     _height = step * maxNumOfEntries;
   }
 
@@ -194,8 +195,8 @@ checkHitScenePoint(PortType portType,
   {
     auto pp = portScenePosition(i, portType, sceneTransform);
 
-    QPointF p = pp - scenePoint;
-    auto    distance = std::sqrt(QPointF::dotProduct(p, p));
+    QPointF p     = pp - scenePoint;
+    auto distance = std::sqrt(QPointF::dotProduct(p, p));
 
     if (distance < tolerance)
     {
@@ -285,16 +286,16 @@ validationWidth() const
 
 QPointF
 NodeGeometry::
-calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, const NodeGraphicsObject& targetNode, 
-                                      PortIndex sourcePortIndex, PortType sourcePort, const NodeGraphicsObject& sourceNode, 
+calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, const NodeGraphicsObject& targetNode,
+                                      PortIndex sourcePortIndex, PortType sourcePort, const NodeGraphicsObject& sourceNode,
                                       const NodeGeometry& newNodeGeom)
 {
-  //Calculating the nodes position in the scene. It'll be positioned half way between the two ports that it "connects". 
+  //Calculating the nodes position in the scene. It'll be positioned half way between the two ports that it "connects".
   //The first line calculates the halfway point between the ports (node position + port position on the node for both nodes averaged).
   //The second line offsets this coordinate with the size of the new node, so that the new nodes center falls on the originally
   //calculated coordinate, instead of it's upper left corner.
-  auto converterNodePos = (sourceNode.pos() + sourceNode.geometry().portScenePosition(sourcePortIndex, sourcePort) 
-    + targetNode.pos() + targetNode.geometry().portScenePosition(targetPortIndex, targetPort)) / 2.0f;
+  auto converterNodePos = (sourceNode.pos() + sourceNode.geometry().portScenePosition(sourcePortIndex, sourcePort)
+                           + targetNode.pos() + targetNode.geometry().portScenePosition(targetPortIndex, targetPort)) / 2.0f;
   converterNodePos.setX(converterNodePos.x() - newNodeGeom.width() / 2.0f);
   converterNodePos.setY(converterNodePos.y() - newNodeGeom.height() / 2.0f);
   return converterNodePos;

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -67,13 +67,14 @@ NodeGraphicsObject(FlowScene &scene,
 
   // connect to the move signals
   auto onMoveSlot = [this] {
-    // ask the model to move it
-    if (!flowScene().model()->moveNode(index(), pos())) {
-      // set the location back
-      setPos(flowScene().model()->nodeLocation(index()));
-      moveConnections();
-    }
-  };
+                      // ask the model to move it
+                      if (!flowScene().model()->moveNode(index(), pos()))
+                      {
+                        // set the location back
+                        setPos(flowScene().model()->nodeLocation(index()));
+                        moveConnections();
+                      }
+                    };
   connect(this, &QGraphicsObject::xChanged, this, onMoveSlot);
   connect(this, &QGraphicsObject::yChanged, this, onMoveSlot);
 
@@ -81,8 +82,10 @@ NodeGraphicsObject(FlowScene &scene,
 
 
 NodeGraphicsObject::
-~NodeGraphicsObject() {
-  if (_proxyWidget) {
+~NodeGraphicsObject()
+{
+  if (_proxyWidget)
+  {
     delete _proxyWidget->widget();
   }
   _scene.removeItem(this);
@@ -104,32 +107,37 @@ flowScene()
 
 FlowScene const&
 NodeGraphicsObject::
-flowScene() const {
+flowScene() const
+{
   return _scene;
 }
 
 NodeGeometry&
 NodeGraphicsObject::
-geometry() {
+geometry()
+{
   return _geometry;
 }
 
 NodeGeometry const&
 NodeGraphicsObject::
-geometry() const {
+geometry() const
+{
   return _geometry;
 }
 
 
 NodeState&
 NodeGraphicsObject::
-nodeState() {
+nodeState()
+{
   return _state;
 }
 
 NodeState const&
 NodeGraphicsObject::
-nodeState() const {
+nodeState() const
+{
   return _state;
 }
 
@@ -181,14 +189,15 @@ moveConnections() const
   for(PortType portType: {PortType::In, PortType::Out})
   {
     auto const & connectionEntries =
-        nodeState().getEntries(portType);
+      nodeState().getEntries(portType);
 
     for (auto const & connections : connectionEntries)
     {
       for (auto & con : connections)
         con->move();
     }
-  };
+  }
+  ;
 }
 
 
@@ -209,8 +218,8 @@ reactToPossibleConnection(PortType reactingPortType,
   update();
 
   _state.setReaction(NodeState::REACTING,
-                         reactingPortType,
-                         reactingDataType);
+                     reactingPortType,
+                     reactingDataType);
 }
 
 
@@ -222,7 +231,9 @@ resetReactionToConnection()
   update();
 }
 
-void NodeGraphicsObject::lock(bool locked)
+void
+NodeGraphicsObject::
+lock(bool locked)
 {
   _locked = locked;
   setFlag(QGraphicsItem::ItemIsMovable, !locked);
@@ -260,7 +271,8 @@ void
 NodeGraphicsObject::
 mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
-  if(_locked) return;
+  if(_locked)
+    return;
 
   // deselect all other items after this one is selected
   if (!isSelected() &&
@@ -273,16 +285,16 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
   {
     // TODO do not pass sceneTransform
     int portIndex = geometry().checkHitScenePoint(portToCheck,
-                                                    event->scenePos(),
-                                                    sceneTransform());
+                                                  event->scenePos(),
+                                                  sceneTransform());
     if (portIndex != INVALID)
     {
       std::vector<ConnectionGraphicsObject*> connections =
         nodeState().connections(portToCheck, portIndex);
 
       // start dragging existing connection
-      if (!connections.empty() && 
-        flowScene().model()->nodePortConnectionPolicy(index(), portIndex, portToCheck) == ConnectionPolicy::One)
+      if (!connections.empty() &&
+          flowScene().model()->nodePortConnectionPolicy(index(), portIndex, portToCheck) == ConnectionPolicy::One)
       {
         Q_ASSERT(connections.size() == 1);
 
@@ -290,29 +302,33 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
 
         // remove it
         flowScene().model()->removeConnection(
-          con->node(PortType::Out), 
-          con->portIndex(PortType::Out), 
-          con->node(PortType::In), 
+          con->node(PortType::Out),
+          con->portIndex(PortType::Out),
+          con->node(PortType::In),
           con->portIndex(PortType::In));
 
         // start connecting anew, except start with the port that this connection was already connected to
         Q_ASSERT(_scene._temporaryConn == nullptr);
-        if (portToCheck == PortType::In) {
+        if (portToCheck == PortType::In)
+        {
           _scene._temporaryConn = new ConnectionGraphicsObject(con->node(PortType::Out), con->portIndex(PortType::Out), NodeIndex{}, -1, _scene);
           _scene._temporaryConn->geometry().setEndPoint(PortType::In, event->scenePos());
-        } else {
+        }
+        else {
           _scene._temporaryConn = new ConnectionGraphicsObject(NodeIndex{}, -1, con->node(PortType::In), con->portIndex(PortType::In), _scene);
           _scene._temporaryConn->geometry().setEndPoint(PortType::Out, event->scenePos());
         }
-         _scene._temporaryConn->grabMouse();
+        _scene._temporaryConn->grabMouse();
       }
       else // initialize new Connection
       {
-        if (portToCheck == PortType::In) {
+        if (portToCheck == PortType::In)
+        {
           Q_ASSERT(_scene._temporaryConn == nullptr);
           _scene._temporaryConn = new ConnectionGraphicsObject(NodeIndex{}, -1, _nodeIndex, portIndex, _scene);
           _scene._temporaryConn->geometry().setEndPoint(PortType::Out, event->scenePos());
-        } else {
+        }
+        else {
           Q_ASSERT(_scene._temporaryConn == nullptr);
           _scene._temporaryConn = new ConnectionGraphicsObject(_nodeIndex, portIndex, NodeIndex{}, -1, _scene);
           _scene._temporaryConn->geometry().setEndPoint(PortType::In, event->scenePos());
@@ -323,10 +339,10 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
     }
   }
 
-  auto pos     = event->pos();
+  auto pos = event->pos();
 
   if (flowScene().model()->nodeResizable(index()) &&
-    geometry().resizeRect().contains(QPoint(pos.x(), pos.y())))
+      geometry().resizeRect().contains(QPoint(pos.x(), pos.y())))
   {
     nodeState().setResizing(true);
   }
@@ -433,10 +449,10 @@ void
 NodeGraphicsObject::
 hoverMoveEvent(QGraphicsSceneHoverEvent * event)
 {
-  auto pos    = event->pos();
+  auto pos = event->pos();
 
   if (flowScene().model()->nodeResizable(index()) &&
-    geometry().resizeRect().contains(QPoint(pos.x(), pos.y())))
+      geometry().resizeRect().contains(QPoint(pos.x(), pos.y())))
   {
     setCursor(QCursor(Qt::SizeFDiagCursor));
   }
@@ -463,6 +479,6 @@ NodeGraphicsObject::
 contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
 {
   QGraphicsItem::contextMenuEvent(event);
-  
+
   flowScene().model()->nodeContextMenu(index(), event->screenPos());
 }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -12,8 +12,8 @@
 #include "FlowScene.hpp"
 #include "NodePainter.hpp"
 
-#include "Node.hpp"
-#include "NodeDataModel.hpp"
+#include "NodeIndex.hpp"
+#include "FlowSceneModel.hpp"
 #include "NodeConnectionInteraction.hpp"
 
 #include "StyleCollection.hpp"
@@ -21,12 +21,18 @@
 using QtNodes::NodeGraphicsObject;
 using QtNodes::Node;
 using QtNodes::FlowScene;
+using QtNodes::NodeIndex;
+using QtNodes::NodeGeometry;
+using QtNodes::NodeState;
+using QtNodes::ConnectionPolicy;
 
 NodeGraphicsObject::
 NodeGraphicsObject(FlowScene &scene,
-                   Node& node)
+                   NodeIndex const& node)
   : _scene(scene)
-  , _node(node)
+  , _nodeIndex(node)
+  , _geometry(node)
+  , _state(node)
   , _locked(false)
   , _proxyWidget(nullptr)
 {
@@ -40,7 +46,7 @@ NodeGraphicsObject(FlowScene &scene,
 
   setCacheMode( QGraphicsItem::DeviceCoordinateCache );
 
-  auto const &nodeStyle = node.nodeDataModel()->nodeStyle();
+  auto const &nodeStyle = flowScene().model()->nodeStyle(index());
 
   {
     auto effect = new QGraphicsDropShadowEffect;
@@ -59,9 +65,14 @@ NodeGraphicsObject(FlowScene &scene,
 
   embedQWidget();
 
-  // connect to the move signals to emit the move signals in FlowScene
+  // connect to the move signals
   auto onMoveSlot = [this] {
-    _scene.nodeMoved(_node, pos());
+    // ask the model to move it
+    if (!flowScene().model()->moveNode(index(), pos())) {
+      // set the location back
+      setPos(flowScene().model()->nodeLocation(index()));
+      moveConnections();
+    }
   };
   connect(this, &QGraphicsObject::xChanged, this, onMoveSlot);
   connect(this, &QGraphicsObject::yChanged, this, onMoveSlot);
@@ -70,34 +81,64 @@ NodeGraphicsObject(FlowScene &scene,
 
 
 NodeGraphicsObject::
-~NodeGraphicsObject()
-{
+~NodeGraphicsObject() {
+  if (_proxyWidget) {
+    delete _proxyWidget->widget();
+  }
   _scene.removeItem(this);
 }
-
-
-Node&
+NodeIndex
 NodeGraphicsObject::
-node()
+index() const
 {
-  return _node;
+  return _nodeIndex;
 }
 
 
-Node const&
+FlowScene&
 NodeGraphicsObject::
-node() const
+flowScene()
 {
-  return _node;
+  return _scene;
+}
+
+FlowScene const&
+NodeGraphicsObject::
+flowScene() const {
+  return _scene;
+}
+
+NodeGeometry&
+NodeGraphicsObject::
+geometry() {
+  return _geometry;
+}
+
+NodeGeometry const&
+NodeGraphicsObject::
+geometry() const {
+  return _geometry;
+}
+
+
+NodeState&
+NodeGraphicsObject::
+nodeState() {
+  return _state;
+}
+
+NodeState const&
+NodeGraphicsObject::
+nodeState() const {
+  return _state;
 }
 
 void
 NodeGraphicsObject::
 embedQWidget()
 {
-  NodeGeometry & geom = _node.nodeGeometry();
 
-  if (auto w = _node.nodeDataModel()->embeddedWidget())
+  if (auto w = flowScene().model()->nodeWidget(index()))
   {
     _proxyWidget = new QGraphicsProxyWidget(this);
 
@@ -105,9 +146,9 @@ embedQWidget()
 
     _proxyWidget->setPreferredWidth(5);
 
-    geom.recalculateSize();
+    geometry().recalculateSize();
 
-    _proxyWidget->setPos(geom.widgetPosition());
+    _proxyWidget->setPos(geometry().widgetPosition());
 
     update();
 
@@ -121,7 +162,7 @@ QRectF
 NodeGraphicsObject::
 boundingRect() const
 {
-  return _node.nodeGeometry().boundingRect();
+  return geometry().boundingRect();
 }
 
 
@@ -137,19 +178,48 @@ void
 NodeGraphicsObject::
 moveConnections() const
 {
-  NodeState const & nodeState = _node.nodeState();
-
   for(PortType portType: {PortType::In, PortType::Out})
   {
     auto const & connectionEntries =
-        nodeState.getEntries(portType);
+        nodeState().getEntries(portType);
 
     for (auto const & connections : connectionEntries)
     {
       for (auto & con : connections)
-        con.second->getConnectionGraphicsObject().move();
+        con->move();
     }
   };
+}
+
+
+
+void
+NodeGraphicsObject::
+reactToPossibleConnection(PortType reactingPortType,
+
+                          NodeDataType reactingDataType,
+                          QPointF const &scenePoint)
+{
+  QTransform const t = sceneTransform();
+
+  QPointF p = t.inverted().map(scenePoint);
+
+  geometry().setDraggingPosition(p);
+
+  update();
+
+  _state.setReaction(NodeState::REACTING,
+                         reactingPortType,
+                         reactingDataType);
+}
+
+
+void
+NodeGraphicsObject::
+resetReactionToConnection()
+{
+  _state.setReaction(NodeState::NOT_REACTING);
+  update();
 }
 
 void NodeGraphicsObject::lock(bool locked)
@@ -169,7 +239,7 @@ paint(QPainter * painter,
 {
   painter->setClipRect(option->exposedRect);
 
-  NodePainter::paint(painter, _node, _scene);
+  NodePainter::paint(painter, *this);
 }
 
 
@@ -201,63 +271,64 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
 
   for(PortType portToCheck: {PortType::In, PortType::Out})
   {
-    NodeGeometry & nodeGeometry = _node.nodeGeometry();
-
     // TODO do not pass sceneTransform
-    int portIndex = nodeGeometry.checkHitScenePoint(portToCheck,
+    int portIndex = geometry().checkHitScenePoint(portToCheck,
                                                     event->scenePos(),
                                                     sceneTransform());
     if (portIndex != INVALID)
     {
-      NodeState const & nodeState = _node.nodeState();
-
-      std::unordered_map<QUuid, Connection*> connections =
-          nodeState.connections(portToCheck, portIndex);
+      std::vector<ConnectionGraphicsObject*> connections =
+        nodeState().connections(portToCheck, portIndex);
 
       // start dragging existing connection
-      if (!connections.empty() && portToCheck == PortType::In)
+      if (!connections.empty() && 
+        flowScene().model()->nodePortConnectionPolicy(index(), portIndex, portToCheck) == ConnectionPolicy::One)
       {
-        auto con = connections.begin()->second;
+        Q_ASSERT(connections.size() == 1);
 
-        NodeConnectionInteraction interaction(_node, *con, _scene);
+        auto con = *connections.begin();
 
-        interaction.disconnect(portToCheck);
+        // remove it
+        flowScene().model()->removeConnection(
+          con->node(PortType::Out), 
+          con->portIndex(PortType::Out), 
+          con->node(PortType::In), 
+          con->portIndex(PortType::In));
+
+        // start connecting anew, except start with the port that this connection was already connected to
+        Q_ASSERT(_scene._temporaryConn == nullptr);
+        if (portToCheck == PortType::In) {
+          _scene._temporaryConn = new ConnectionGraphicsObject(con->node(PortType::Out), con->portIndex(PortType::Out), NodeIndex{}, -1, _scene);
+          _scene._temporaryConn->geometry().setEndPoint(PortType::In, event->scenePos());
+        } else {
+          _scene._temporaryConn = new ConnectionGraphicsObject(NodeIndex{}, -1, con->node(PortType::In), con->portIndex(PortType::In), _scene);
+          _scene._temporaryConn->geometry().setEndPoint(PortType::Out, event->scenePos());
+        }
+         _scene._temporaryConn->grabMouse();
       }
       else // initialize new Connection
       {
-        if (portToCheck == PortType::Out)
-        {
-          const auto outPolicy = _node.nodeDataModel()->portOutConnectionPolicy(portIndex);
-          if (!connections.empty() &&
-              outPolicy == NodeDataModel::ConnectionPolicy::One)
-          {
-            _scene.deleteConnection( *connections.begin()->second );
-          }
-
-          // todo add to FlowScene
-          auto connection = _scene.createConnection(portToCheck,
-                                                    _node,
-                                                    portIndex);
-
-          _node.nodeState().setConnection(portToCheck,
-                                          portIndex,
-                                          *connection);
-
-          connection->getConnectionGraphicsObject().grabMouse();
+        if (portToCheck == PortType::In) {
+          Q_ASSERT(_scene._temporaryConn == nullptr);
+          _scene._temporaryConn = new ConnectionGraphicsObject(NodeIndex{}, -1, _nodeIndex, portIndex, _scene);
+          _scene._temporaryConn->geometry().setEndPoint(PortType::Out, event->scenePos());
+        } else {
+          Q_ASSERT(_scene._temporaryConn == nullptr);
+          _scene._temporaryConn = new ConnectionGraphicsObject(_nodeIndex, portIndex, NodeIndex{}, -1, _scene);
+          _scene._temporaryConn->geometry().setEndPoint(PortType::In, event->scenePos());
         }
+
+        _scene._temporaryConn->grabMouse();
       }
     }
   }
 
   auto pos     = event->pos();
-  auto & geom  = _node.nodeGeometry();
-  auto & state = _node.nodeState();
 
-  if (_node.nodeDataModel()->resizable() &&
-      geom.resizeRect().contains(QPoint(pos.x(),
-                                        pos.y())))
+  if (flowScene().model()->nodeResizable(index()) &&
+    geometry().resizeRect().contains(QPoint(pos.x(), pos.y())))
   {
-    state.setResizing(true);
+    nodeState().setResizing(true);
   }
 }
 
@@ -266,14 +337,12 @@ void
 NodeGraphicsObject::
 mouseMoveEvent(QGraphicsSceneMouseEvent * event)
 {
-  auto & geom  = _node.nodeGeometry();
-  auto & state = _node.nodeState();
 
-  if (state.resizing())
+  if (nodeState().resizing())
   {
     auto diff = event->pos() - event->lastPos();
 
-    if (auto w = _node.nodeDataModel()->embeddedWidget())
+    if (auto w = flowScene().model()->nodeWidget(index()))
     {
       prepareGeometryChange();
 
@@ -285,9 +354,9 @@ mouseMoveEvent(QGraphicsSceneMouseEvent * event)
 
       _proxyWidget->setMinimumSize(oldSize);
       _proxyWidget->setMaximumSize(oldSize);
-      _proxyWidget->setPos(geom.widgetPosition());
+      _proxyWidget->setPos(geometry().widgetPosition());
 
-      geom.recalculateSize();
+      geometry().recalculateSize();
       update();
 
       moveConnections();
@@ -317,9 +386,7 @@ void
 NodeGraphicsObject::
 mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-  auto & state = _node.nodeState();
-
-  state.setResizing(false);
+  nodeState().setResizing(false);
 
   QGraphicsObject::mouseReleaseEvent(event);
 
@@ -345,9 +412,9 @@ hoverEnterEvent(QGraphicsSceneHoverEvent * event)
   // bring this node forward
   setZValue(1.0);
 
-  _node.nodeGeometry().setHovered(true);
+  geometry().setHovered(true);
   update();
-  _scene.nodeHovered(node(), event->screenPos());
+  flowScene().model()->nodeHovered(index(), event->screenPos(), true);
   event->accept();
 }
 
@@ -356,23 +423,20 @@ void
 NodeGraphicsObject::
 hoverLeaveEvent(QGraphicsSceneHoverEvent * event)
 {
-  _node.nodeGeometry().setHovered(false);
+  geometry().setHovered(false);
   update();
-  _scene.nodeHoverLeft(node());
+  flowScene().model()->nodeHovered(index(), event->screenPos(), false);
   event->accept();
 }
-
 
 void
 NodeGraphicsObject::
 hoverMoveEvent(QGraphicsSceneHoverEvent * event)
 {
   auto pos    = event->pos();
-  auto & geom = _node.nodeGeometry();
 
-
-  if (_node.nodeDataModel()->resizable() &&
-      geom.resizeRect().contains(QPoint(pos.x(), pos.y())))
+  if (flowScene().model()->nodeResizable(index()) &&
+    geometry().resizeRect().contains(QPoint(pos.x(), pos.y())))
   {
     setCursor(QCursor(Qt::SizeFDiagCursor));
   }
@@ -391,12 +455,14 @@ mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 {
   QGraphicsItem::mouseDoubleClickEvent(event);
 
-  _scene.nodeDoubleClicked(node());
+  flowScene().model()->nodeDoubleClicked(index(), event->screenPos());
 }
 
 void
 NodeGraphicsObject::
 contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
 {
-  _scene.nodeContextMenu(node(), mapToScene(event->pos()));
+  QGraphicsItem::contextMenuEvent(event);
+  
+  flowScene().model()->nodeContextMenu(index(), event->screenPos());
 }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -25,6 +25,7 @@ using QtNodes::NodeIndex;
 using QtNodes::NodeGeometry;
 using QtNodes::NodeState;
 using QtNodes::ConnectionPolicy;
+using QtNodes::PortType;
 
 NodeGraphicsObject::
 NodeGraphicsObject(FlowScene &scene,

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -26,6 +26,7 @@ using QtNodes::NodeGeometry;
 using QtNodes::NodeState;
 using QtNodes::ConnectionPolicy;
 using QtNodes::PortType;
+using QtNodes::NodeDataType;
 
 NodeGraphicsObject::
 NodeGraphicsObject(FlowScene &scene,

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -58,9 +58,9 @@ void
 NodePainter::
 drawNodeRect(QPainter* painter, NodeGraphicsObject const & graphicsObject)
 {
-  FlowSceneModel& model = *graphicsObject.flowScene().model();
+  FlowSceneModel& model      = *graphicsObject.flowScene().model();
   NodeStyle const& nodeStyle = model.nodeStyle(graphicsObject.index());
-  NodeGeometry const& geom = graphicsObject.geometry();
+  NodeGeometry const& geom   = graphicsObject.geometry();
 
   auto color = graphicsObject.isSelected()
                ? nodeStyle.SelectedBoundaryColor
@@ -101,14 +101,14 @@ void
 NodePainter::
 drawConnectionPoints(QPainter* painter, NodeGraphicsObject const & graphicsObject)
 {
-  const FlowSceneModel& model = *graphicsObject.flowScene().model();
+  const FlowSceneModel& model     = *graphicsObject.flowScene().model();
   NodeStyle const& nodeStyle      = model.nodeStyle(graphicsObject.index());
   auto const     &connectionStyle = StyleCollection::connectionStyle();
-  NodeState const& state = graphicsObject.nodeState();
-  NodeGeometry const& geom = graphicsObject.geometry();
+  NodeState const& state          = graphicsObject.nodeState();
+  NodeGeometry const& geom        = graphicsObject.geometry();
 
-  float diameter = nodeStyle.ConnectionPointDiameter;
-  auto  reducedDiameter = diameter * 0.6;
+  float diameter       = nodeStyle.ConnectionPointDiameter;
+  auto reducedDiameter = diameter * 0.6;
 
   for(PortType portType: {PortType::Out, PortType::In})
   {
@@ -122,7 +122,7 @@ drawConnectionPoints(QPainter* painter, NodeGraphicsObject const & graphicsObjec
 
       bool canConnect = (state.getEntries(portType)[i].empty() ||
                          (portType == PortType::Out &&
-                         model.nodePortConnectionPolicy(graphicsObject.index(), i, PortType::Out) == ConnectionPolicy::Many) );
+                          model.nodePortConnectionPolicy(graphicsObject.index(), i, PortType::Out) == ConnectionPolicy::Many) );
 
       double r = 1.0;
       if (state.isReacting() &&
@@ -130,9 +130,9 @@ drawConnectionPoints(QPainter* painter, NodeGraphicsObject const & graphicsObjec
           portType == state.reactingPortType())
       {
 
-        auto   diff = geom.draggingPos() - p;
-        double dist = std::sqrt(QPointF::dotProduct(diff, diff));
-        bool   typeConvertable = false;
+        auto diff            = geom.draggingPos() - p;
+        double dist          = std::sqrt(QPointF::dotProduct(diff, diff));
+        bool typeConvertable = false;
 
         {
           if (portType == PortType::In)
@@ -149,15 +149,15 @@ drawConnectionPoints(QPainter* painter, NodeGraphicsObject const & graphicsObjec
         {
           double const thres = 40.0;
           r = (dist < thres) ?
-                (2.0 - dist / thres ) :
-                1.0;
+              (2.0 - dist / thres ) :
+              1.0;
         }
         else
         {
           double const thres = 80.0;
           r = (dist < thres) ?
-                (dist / thres) :
-                1.0;
+              (dist / thres) :
+              1.0;
         }
       }
 
@@ -174,7 +174,8 @@ drawConnectionPoints(QPainter* painter, NodeGraphicsObject const & graphicsObjec
                            reducedDiameter * r,
                            reducedDiameter * r);
     }
-  };
+  }
+  ;
 }
 
 
@@ -187,7 +188,7 @@ drawFilledConnectionPoints(QPainter * painter, NodeGraphicsObject const & graphi
   auto const&           connectionStyle = StyleCollection::connectionStyle();
   NodeState const&      state           = graphicsObject.nodeState();
   NodeGeometry const&   geom            = graphicsObject.geometry();
-  
+
   auto diameter = nodeStyle.ConnectionPointDiameter;
 
   for(PortType portType: {PortType::Out, PortType::In})
@@ -229,12 +230,13 @@ drawModelName(QPainter * painter, NodeGraphicsObject const & graphicsObject)
 {
 
   FlowSceneModel const& model = *graphicsObject.index().model();
-  NodeStyle const& nodeStyle = model.nodeStyle(graphicsObject.index());
-  NodeGeometry const& geom = graphicsObject.geometry();
+  NodeStyle const& nodeStyle  = model.nodeStyle(graphicsObject.index());
+  NodeGeometry const& geom    = graphicsObject.geometry();
 
   QString const &name = model.nodeCaption(graphicsObject.index());
 
-  if (name.isEmpty()) {
+  if (name.isEmpty())
+  {
     return;
   }
 
@@ -262,9 +264,9 @@ void
 NodePainter::
 drawEntryLabels(QPainter * painter, NodeGraphicsObject const & graphicsObject)
 {
-  NodeState const& state = graphicsObject.nodeState();
-  NodeGeometry const& geom = graphicsObject.geometry();
-  FlowSceneModel const& model = *graphicsObject.index().model();
+  NodeState const& state       = graphicsObject.nodeState();
+  NodeGeometry const& geom     = graphicsObject.geometry();
+  FlowSceneModel const& model  = *graphicsObject.index().model();
   QFontMetrics const & metrics =
     painter->fontMetrics();
 
@@ -298,16 +300,16 @@ drawEntryLabels(QPainter * painter, NodeGraphicsObject const & graphicsObject)
 
       switch (portType)
       {
-      case PortType::In:
-        p.setX(5.0);
-        break;
+        case PortType::In:
+          p.setX(5.0);
+          break;
 
-      case PortType::Out:
-        p.setX(geom.width() - 5.0 - rect.width());
-        break;
+        case PortType::Out:
+          p.setX(geom.width() - 5.0 - rect.width());
+          break;
 
-      default:
-        break;
+        default:
+          break;
       }
 
       painter->drawText(p, s);
@@ -319,7 +321,7 @@ drawEntryLabels(QPainter * painter, NodeGraphicsObject const & graphicsObject)
 void
 NodePainter::
 drawResizeRect(QPainter * painter,
-                     NodeGraphicsObject const & graphicsObject)
+               NodeGraphicsObject const & graphicsObject)
 {
   FlowSceneModel const& model = *graphicsObject.index().model();
 
@@ -337,7 +339,7 @@ NodePainter::
 drawValidationRect(QPainter * painter, NodeGraphicsObject const & graphicsObject)
 {
   FlowSceneModel const& model = *graphicsObject.index().model();
-  NodeGeometry const& geom = graphicsObject.geometry();
+  NodeGeometry const& geom    = graphicsObject.geometry();
 
   auto modelValidationState = model.nodeValidationState(graphicsObject.index());
 

--- a/src/NodePainter.hpp
+++ b/src/NodePainter.hpp
@@ -5,11 +5,9 @@
 namespace QtNodes
 {
 
-class Node;
 class NodeState;
 class NodeGeometry;
 class NodeGraphicsObject;
-class NodeDataModel;
 class FlowItemEntry;
 class FlowScene;
 
@@ -24,56 +22,41 @@ public:
   static
   void
   paint(QPainter* painter,
-        Node& node,
-        FlowScene const& scene);
+        NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawNodeRect(QPainter* painter,
-               NodeGeometry const& geom,
-               NodeDataModel const* model,
                NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawModelName(QPainter* painter,
-                NodeGeometry const& geom,
-                NodeState const& state,
-                NodeDataModel const * model);
+                NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawEntryLabels(QPainter* painter,
-                  NodeGeometry const& geom,
-                  NodeState const& state,
-                  NodeDataModel const * model);
+                  NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawConnectionPoints(QPainter* painter,
-                       NodeGeometry const& geom,
-                       NodeState const& state,
-                       NodeDataModel const * model,
-                       FlowScene const & scene);
+                       NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawFilledConnectionPoints(QPainter* painter,
-                             NodeGeometry const& geom,
-                             NodeState const& state,
-                             NodeDataModel const * model);
+                             NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawResizeRect(QPainter* painter,
-                 NodeGeometry const& geom,
-                 NodeDataModel const * model);
+                 NodeGraphicsObject const & graphicsObject);
 
   static
   void
   drawValidationRect(QPainter * painter,
-                     NodeGeometry const & geom,
-                     NodeDataModel const * model,
                      NodeGraphicsObject const & graphicsObject);
 };
 }

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -14,6 +14,7 @@ using QtNodes::PortType;
 using QtNodes::PortIndex;
 using QtNodes::Connection;
 using QtNodes::NodeIndex;
+using QtNodes::ConnectionGraphicsObject;
 
 NodeState::
 NodeState(NodeIndex const &index)

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -1,6 +1,9 @@
 #include "NodeState.hpp"
 
 #include "NodeDataModel.hpp"
+#include "NodeIndex.hpp"
+#include "FlowSceneModel.hpp"
+#include "QUuidStdHash.hpp"
 
 #include "Connection.hpp"
 
@@ -12,16 +15,16 @@ using QtNodes::PortIndex;
 using QtNodes::Connection;
 
 NodeState::
-NodeState(std::unique_ptr<NodeDataModel> const &model)
-  : _inConnections(model->nPorts(PortType::In))
-  , _outConnections(model->nPorts(PortType::Out))
+NodeState(NodeIndex const &index)
+  : _inConnections(index.model()->nodePortCount(index, PortType::In))
+  , _outConnections(index.model()->nodePortCount(index, PortType::Out))
   , _reaction(NOT_REACTING)
   , _reactingPortType(PortType::None)
   , _resizing(false)
 {}
 
 
-std::vector<NodeState::ConnectionPtrSet> const &
+std::vector<NodeState::ConnectionPtrVec> const &
 NodeState::
 getEntries(PortType portType) const
 {
@@ -32,7 +35,7 @@ getEntries(PortType portType) const
 }
 
 
-std::vector<NodeState::ConnectionPtrSet> &
+std::vector<NodeState::ConnectionPtrVec> &
 NodeState::
 getEntries(PortType portType)
 {
@@ -43,7 +46,7 @@ getEntries(PortType portType)
 }
 
 
-NodeState::ConnectionPtrSet
+NodeState::ConnectionPtrVec
 NodeState::
 connections(PortType portType, PortIndex portIndex) const
 {
@@ -57,12 +60,11 @@ void
 NodeState::
 setConnection(PortType portType,
               PortIndex portIndex,
-              Connection& connection)
+              ConnectionGraphicsObject& connection)
 {
   auto &connections = getEntries(portType);
 
-  connections[portIndex].insert(std::make_pair(connection.id(),
-                                               &connection));
+  connections[portIndex].push_back(&connection);
 }
 
 
@@ -70,9 +72,14 @@ void
 NodeState::
 eraseConnection(PortType portType,
                 PortIndex portIndex,
-                QUuid id)
+                 ConnectionGraphicsObject& conn)
 {
-  getEntries(portType)[portIndex].erase(id);
+  auto& ptrSet = getEntries(portType)[portIndex];
+  auto iter = std::find(ptrSet.begin(), ptrSet.end(), &conn);
+  if (iter != ptrSet.end()) {
+    ptrSet.erase(iter);
+  }
+  
 }
 
 

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -72,14 +72,15 @@ void
 NodeState::
 eraseConnection(PortType portType,
                 PortIndex portIndex,
-                 ConnectionGraphicsObject& conn)
+                ConnectionGraphicsObject& conn)
 {
   auto& ptrSet = getEntries(portType)[portIndex];
-  auto iter = std::find(ptrSet.begin(), ptrSet.end(), &conn);
-  if (iter != ptrSet.end()) {
+  auto iter    = std::find(ptrSet.begin(), ptrSet.end(), &conn);
+  if (iter != ptrSet.end())
+  {
     ptrSet.erase(iter);
   }
-  
+
 }
 
 

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -13,6 +13,7 @@ using QtNodes::NodeDataModel;
 using QtNodes::PortType;
 using QtNodes::PortIndex;
 using QtNodes::Connection;
+using QtNodes::NodeIndex;
 
 NodeState::
 NodeState(NodeIndex const &index)

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -14,7 +14,8 @@
 
 using QtNodes::NodeStyle;
 
-inline void initResources() { Q_INIT_RESOURCE(resources); }
+inline void
+initResources() { Q_INIT_RESOURCE(resources); }
 
 NodeStyle::
 NodeStyle()
@@ -48,10 +49,10 @@ setNodeStyle(QString jsonText)
 
 #ifdef STYLE_DEBUG
   #define NODE_STYLE_CHECK_UNDEFINED_VALUE(v, variable) { \
-      if (v.type() == QJsonValue::Undefined || \
-          v.type() == QJsonValue::Null) \
-        qWarning() << "Undefined value for parameter:" << #variable; \
-  }
+    if (v.type() == QJsonValue::Undefined || \
+        v.type() == QJsonValue::Null) \
+      qWarning() << "Undefined value for parameter:" << #variable; \
+}
 #else
   #define NODE_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(test_nodes
 target_link_libraries(test_nodes
   PRIVATE
     NodeEditor::nodes
-    Catch2::Catch
+    Catch2::Catch2
     Qt5::Test
 )
 

--- a/test/include/Stringify.hpp
+++ b/test/include/Stringify.hpp
@@ -3,7 +3,7 @@
 #include <QtCore/QPoint>
 #include <QtCore/QPointF>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <QtTest>
 

--- a/test/include/StubNodeDataModel.hpp
+++ b/test/include/StubNodeDataModel.hpp
@@ -19,7 +19,8 @@ public:
     return _caption;
   }
 
-  unsigned int nPorts(QtNodes::PortType) const override { return 0; }
+  unsigned int
+  nPorts(QtNodes::PortType) const override { return 0; }
 
   QWidget*
   embeddedWidget() override
@@ -27,17 +28,20 @@ public:
     return nullptr;
   }
 
-  QtNodes::NodeDataType dataType(QtNodes::PortType, QtNodes::PortIndex) const override
+  QtNodes::NodeDataType
+  dataType(QtNodes::PortType, QtNodes::PortIndex) const override
   {
     return QtNodes::NodeDataType();
   }
 
-  std::shared_ptr<QtNodes::NodeData> outData(QtNodes::PortIndex) override
+  std::shared_ptr<QtNodes::NodeData>
+  outData(QtNodes::PortIndex) override
   {
     return nullptr;
   }
 
-  void setInData(std::shared_ptr<QtNodes::NodeData>, QtNodes::PortIndex) override
+  void
+  setInData(std::shared_ptr<QtNodes::NodeData>, QtNodes::PortIndex) override
   {
   }
 

--- a/test/src/TestDataModelRegistry.cpp
+++ b/test/src/TestDataModelRegistry.cpp
@@ -1,6 +1,6 @@
 #include <nodes/DataModelRegistry>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "StubNodeDataModel.hpp"
 

--- a/test/src/TestNodeGraphicsObject.cpp
+++ b/test/src/TestNodeGraphicsObject.cpp
@@ -24,8 +24,9 @@ TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
 {
   class MockModel : public StubNodeDataModel
   {
-  public:
-    unsigned int nPorts(PortType) const override { return 1; }
+public:
+    unsigned int
+    nPorts(PortType) const override { return 1; }
 
     ConnectionPolicy
     portOutConnectionPolicy(int index) const override
@@ -40,7 +41,7 @@ TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
   auto setup = applicationSetup();
 
   DataFlowScene scene;
-  FlowView  view(&scene);
+  FlowView view(&scene);
 
   // Ensure we have enough size to contain the node
   view.resize(640, 480);
@@ -58,7 +59,7 @@ TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
 
   // Compute the on-screen position of the input port
   QPointF scInPortPos = ngeom.portScenePosition(0, PortType::In, ngo.sceneTransform());
-  QPoint  vwInPortPos = view.mapFromScene(scInPortPos);
+  QPoint vwInPortPos  = view.mapFromScene(scInPortPos);
 
   // Create a partial connection by clicking on the input port of the node
   QTest::mousePress(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwInPortPos);

--- a/test/src/TestNodeGraphicsObject.cpp
+++ b/test/src/TestNodeGraphicsObject.cpp
@@ -1,21 +1,22 @@
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 #include <nodes/Node>
 #include <nodes/NodeDataModel>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <QtTest>
 
 #include "ApplicationSetup.hpp"
 #include "StubNodeDataModel.hpp"
 
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 using QtNodes::FlowView;
 using QtNodes::Node;
 using QtNodes::NodeDataModel;
 using QtNodes::NodeGraphicsObject;
 using QtNodes::PortType;
+using QtNodes::ConnectionPolicy;
 
 TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
           "connections (issue #127)",
@@ -26,11 +27,11 @@ TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
   public:
     unsigned int nPorts(PortType) const override { return 1; }
 
-    NodeDataModel::ConnectionPolicy
+    ConnectionPolicy
     portOutConnectionPolicy(int index) const override
     {
       portOutConnectionPolicyCalledCount++;
-      return NodeDataModel::ConnectionPolicy::One;
+      return ConnectionPolicy::One;
     }
 
     mutable int portOutConnectionPolicyCalledCount = 0;
@@ -38,7 +39,7 @@ TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
 
   auto setup = applicationSetup();
 
-  FlowScene scene;
+  DataFlowScene scene;
   FlowView  view(&scene);
 
   // Ensure we have enough size to contain the node
@@ -49,8 +50,8 @@ TEST_CASE("NodeDataModel::portOutConnectionPolicy(...) isn't called for input "
 
   auto& node  = scene.createNode(std::make_unique<MockModel>());
   auto& model = dynamic_cast<MockModel&>(*node.nodeDataModel());
-  auto& ngo   = node.nodeGraphicsObject();
-  auto& ngeom = node.nodeGeometry();
+  auto& ngo   = *scene.nodeGraphicsObject(scene.model()->nodeIndex(node.id()));
+  auto& ngeom = ngo.geometry();
 
   // Move the node to somewhere in the middle of the screen
   ngo.setPos(QPointF(50, 50));

--- a/test/src/test_dragging.cpp
+++ b/test/src/test_dragging.cpp
@@ -1,9 +1,9 @@
 #include <nodes/Connection>
-#include <nodes/FlowScene>
+#include <nodes/DataFlowScene>
 #include <nodes/FlowView>
 #include <nodes/Node>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <QtTest>
 #include <QtWidgets/QApplication>
@@ -16,7 +16,7 @@
 
 using QtNodes::Connection;
 using QtNodes::DataModelRegistry;
-using QtNodes::FlowScene;
+using QtNodes::DataFlowScene;
 using QtNodes::FlowView;
 using QtNodes::Node;
 using QtNodes::NodeData;
@@ -29,8 +29,8 @@ TEST_CASE("Dragging node changes position", "[gui]")
 {
   auto app = applicationSetup();
 
-  FlowScene scene;
-  FlowView  view(&scene);
+  DataFlowScene scene;
+  FlowView      view(&scene);
 
   view.show();
   REQUIRE(QTest::qWaitForWindowExposed(&view));
@@ -39,9 +39,9 @@ TEST_CASE("Dragging node changes position", "[gui]")
   {
     auto& node = scene.createNode(std::make_unique<StubNodeDataModel>());
 
-    auto& ngo = node.nodeGraphicsObject();
+    auto& ngo = *scene.nodeGraphicsObject(scene.model()->nodeIndex(node.id()));
 
-    QPointF scPosBefore = ngo.pos();
+    QPointF scPosBefore = node.position();
 
     QPointF scClickPos = ngo.boundingRect().center();
     scClickPos         = QPointF(ngo.sceneTransform().map(scClickPos).toPoint());
@@ -60,7 +60,7 @@ TEST_CASE("Dragging node changes position", "[gui]")
     QTest::mousePress(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwClickPos);
     QTest::mouseMove(view.windowHandle(), vwDestPos);
 
-    QPointF scDelta            = ngo.pos() - scPosBefore;
+    QPointF scDelta            = node.position() - scPosBefore;
     QPoint  roundDelta         = scDelta.toPoint();
     QPoint  roundExpectedDelta = scExpectedDelta.toPoint();
 

--- a/test/src/test_dragging.cpp
+++ b/test/src/test_dragging.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Dragging node changes position", "[gui]")
   auto app = applicationSetup();
 
   DataFlowScene scene;
-  FlowView      view(&scene);
+  FlowView view(&scene);
 
   view.show();
   REQUIRE(QTest::qWaitForWindowExposed(&view));
@@ -44,7 +44,7 @@ TEST_CASE("Dragging node changes position", "[gui]")
     QPointF scPosBefore = node.position();
 
     QPointF scClickPos = ngo.boundingRect().center();
-    scClickPos         = QPointF(ngo.sceneTransform().map(scClickPos).toPoint());
+    scClickPos = QPointF(ngo.sceneTransform().map(scClickPos).toPoint());
 
     QPoint vwClickPos = view.mapFromScene(scClickPos);
     QPoint vwDestPos  = vwClickPos + QPoint(10, 20);
@@ -60,9 +60,9 @@ TEST_CASE("Dragging node changes position", "[gui]")
     QTest::mousePress(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwClickPos);
     QTest::mouseMove(view.windowHandle(), vwDestPos);
 
-    QPointF scDelta            = node.position() - scPosBefore;
-    QPoint  roundDelta         = scDelta.toPoint();
-    QPoint  roundExpectedDelta = scExpectedDelta.toPoint();
+    QPointF scDelta           = node.position() - scPosBefore;
+    QPoint roundDelta         = scDelta.toPoint();
+    QPoint roundExpectedDelta = scExpectedDelta.toPoint();
 
     CHECK(roundDelta == roundExpectedDelta);
   }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>


### PR DESCRIPTION
For a while, @paceholder and I have been talking about having a separation between the node rendering and the logic of a data flow framework. This brings that.

Use case: When you already have a data structure representing a flow scene, you can easily map an interface to it without keeping two data structures in sync.

Abstract:
This is inspired by Qt's model view infrastructure where there is a index for a particular item, a model (an abstract class) and a view (that takes in a pointer to a model).

New/Totally refactored classes:
`NodeIndex`: This is similar to a [`QModelIndex`](http://doc.qt.io/qt-5/qmodelindex.html), but more specific to nodes. It holds nothing but an ID (QUuid), an internal pointer, and a pointer to the model.

`FlowSceneModel`: This is the abstract model class. It defines a bunch of functions for reading and manipulating flow scenes. 

`DataFlowScene`: This roughly replaces `FlowScene`, and is actually a drop-in replacement. It subclasses from `FlowScene` and adds an implementation of `FlowSceneModel` that does exactly what this library used to do (data flow, with propagating data etc)

`ConnectionGraphicsObject`: This class has kinda been merged with `Connection`, and it now does the functionality for both. Basically, it handles all the backend scene stuff for rendering connections.

`Connection`: This is now entirely broken away from the rendering part of the library. It is now just part of the `DataFlowScene`.

`NodeGraphicsObject`/`Node`: Same deal as connections

`ConnectionID`: Just a way to identify connections in a map. 

Among plenty of other changes, but most users should just be able to change `FlowScene` to `DataFlowScene` and it'll work exactly as before. 

it's kinda a complex pull request. Sorry :/