### PR TITLE
Allow setting node style from file

### DIFF
--- a/src/ConnectionStyle.cpp
+++ b/src/ConnectionStyle.cpp
@@ -28,19 +28,23 @@ ConnectionStyle()
 }
 
 
+void
 ConnectionStyle::
-ConnectionStyle(QString jsonText)
+setConnectionStyle(QString jsonText)
 {
-  loadJsonFile(":DefaultStyle.json");
-  loadJsonText(jsonText);
+  ConnectionStyle style;
+  style.loadJsonText(jsonText);
+
+  StyleCollection::setConnectionStyle(style);
 }
 
 
 void
 ConnectionStyle::
-setConnectionStyle(QString jsonText)
+setConnectionStyleFromFile(QString styleFile)
 {
-  ConnectionStyle style(jsonText);
+  ConnectionStyle style;
+  style.loadJsonFile(styleFile);
 
   StyleCollection::setConnectionStyle(style);
 }

--- a/src/ConnectionStyle.hpp
+++ b/src/ConnectionStyle.hpp
@@ -14,11 +14,11 @@ public:
 
   ConnectionStyle();
 
-  ConnectionStyle(QString jsonText);
-
 public:
 
   static void setConnectionStyle(QString jsonText);
+
+  static void setConnectionStyleFromFile(QString styleFile);
 
 private:
 

--- a/src/ConnectionStyle.hpp
+++ b/src/ConnectionStyle.hpp
@@ -24,7 +24,7 @@ private:
 
   void loadJsonText(QString jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void loadJsonFile(QString styleFile) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/src/FlowViewStyle.cpp
+++ b/src/FlowViewStyle.cpp
@@ -26,18 +26,23 @@ FlowViewStyle()
 }
 
 
+void
 FlowViewStyle::
-FlowViewStyle(QString jsonText)
+setStyle(QString jsonText)
 {
-  loadJsonText(jsonText);
+  FlowViewStyle style;
+  style.loadJsonText(jsonText);
+
+  StyleCollection::setFlowViewStyle(style);
 }
 
 
 void
 FlowViewStyle::
-setStyle(QString jsonText)
+setStyleFromFile(QString styleFile)
 {
-  FlowViewStyle style(jsonText);
+  FlowViewStyle style;
+  style.loadJsonFile(styleFile);
 
   StyleCollection::setFlowViewStyle(style);
 }

--- a/src/FlowViewStyle.hpp
+++ b/src/FlowViewStyle.hpp
@@ -24,7 +24,7 @@ private:
 
   void loadJsonText(QString jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void loadJsonFile(QString styleFile) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/src/FlowViewStyle.hpp
+++ b/src/FlowViewStyle.hpp
@@ -14,11 +14,11 @@ public:
 
   FlowViewStyle();
 
-  FlowViewStyle(QString jsonText);
-
 public:
 
   static void setStyle(QString jsonText);
+
+  static void setStyleFromFile(QString styleFile);
 
 private:
 

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -28,19 +28,23 @@ NodeStyle()
 }
 
 
+void
 NodeStyle::
-NodeStyle(QString jsonText)
+setNodeStyle(QString jsonText)
 {
-  loadJsonText(jsonText);
+  NodeStyle style;
+  style.loadJsonText(jsonText);
+
+  StyleCollection::setNodeStyle(style);
 }
 
 
 void
 NodeStyle::
-setNodeStyle(QString jsonText)
+setNodeStyleFromFile(QString styleFile)
 {
-  NodeStyle style(jsonText);
-
+  NodeStyle style;
+  style.loadJsonFile(styleFile);
 
   StyleCollection::setNodeStyle(style);
 }

--- a/src/NodeStyle.hpp
+++ b/src/NodeStyle.hpp
@@ -24,7 +24,7 @@ private:
 
   void loadJsonText(QString jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void loadJsonFile(QString styleFile) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/src/NodeStyle.hpp
+++ b/src/NodeStyle.hpp
@@ -14,11 +14,11 @@ public:
 
   NodeStyle();
 
-  NodeStyle(QString jsonText);
-
 public:
 
   static void setNodeStyle(QString jsonText);
+
+  static void setNodeStyleFromFile(QString styleFile);
 
 private:
 


### PR DESCRIPTION
Let an application ship their global style in a file, e.g.:
```c++
const QString styleFile = ":NodeEditorStyle.json";
QtNodes::ConnectionStyle::setConnectionStyleFromFile(styleFile);
QtNodes::FlowViewStyle::setStyleFromFile(styleFile);
QtNodes::NodeStyle::setNodeStyleFromFile(styleFile);
```

Also remove redundant constructor to avoid interface bloat.