### PR TITLE
Opacity handling fix

### DIFF
--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -40,7 +40,7 @@ NodeGraphicsObject(FlowScene &scene,
 
   setCacheMode( QGraphicsItem::DeviceCoordinateCache );
 
-  auto const &nodeStyle = StyleCollection::nodeStyle();
+  auto const &nodeStyle = node.nodeDataModel()->nodeStyle();
 
   {
     auto effect = new QGraphicsDropShadowEffect;


### PR DESCRIPTION
There is no possibility currently to set custom opacity. It is always set to the default one. This PR fixes the issue.

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@mobica.com>