### PR TITLE
Removed the need for clone()

### DIFF
--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -28,10 +28,6 @@ public:
   name() const override
   { return QStringLiteral("Addition"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<AdditionModel>(); }
-
 private:
 
   void

--- a/examples/calculator/DecimalToIntegerModel.hpp
+++ b/examples/calculator/DecimalToIntegerModel.hpp
@@ -41,10 +41,6 @@ public:
   name() const override
   { return QStringLiteral("DecimalToInteger"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<DecimalToIntegerModel>(); }
-
 public:
 
   QJsonObject

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -53,10 +53,6 @@ public:
   name() const override
   { return QStringLiteral("Division"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<DivisionModel>(); }
-
 private:
 
   void

--- a/examples/calculator/IntegerToDecimalModel.hpp
+++ b/examples/calculator/IntegerToDecimalModel.hpp
@@ -41,9 +41,6 @@ public:
   name() const override
   { return QStringLiteral("IntegerToDecimal"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<IntegerToDecimalModel>(); }
 
 public:
 

--- a/examples/calculator/ModuloModel.hpp
+++ b/examples/calculator/ModuloModel.hpp
@@ -67,9 +67,6 @@ public:
   name() const override
   { return QStringLiteral("Modulo"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<ModuloModel>(); }
 
 public:
 

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -28,9 +28,6 @@ public:
   name() const override
   { return QStringLiteral("Multiplication"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<MultiplicationModel>(); }
 
 private:
 

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -40,9 +40,6 @@ public:
   name() const override
   { return QStringLiteral("Result"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<NumberDisplayDataModel>(); }
 
 public:
 

--- a/examples/calculator/NumberSourceDataModel.hpp
+++ b/examples/calculator/NumberSourceDataModel.hpp
@@ -43,9 +43,6 @@ public:
   name() const override
   { return QStringLiteral("NumberSource"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<NumberSourceDataModel>(); }
 
 public:
 

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -54,9 +54,6 @@ public:
   name() const override
   { return QStringLiteral("Subtraction"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<SubtractionModel>(); }
 
 private:
 

--- a/examples/connection_colors/models.hpp
+++ b/examples/connection_colors/models.hpp
@@ -64,9 +64,6 @@ public:
   name() const override
   { return QString("NaiveDataModel"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<NaiveDataModel>(); }
 
 public:
 

--- a/examples/example2/TextDisplayDataModel.hpp
+++ b/examples/example2/TextDisplayDataModel.hpp
@@ -39,9 +39,6 @@ public:
   name() const override
   { return QString("TextDisplayDataModel"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<TextDisplayDataModel>(); }
 
 public:
 

--- a/examples/example2/TextSourceDataModel.hpp
+++ b/examples/example2/TextSourceDataModel.hpp
@@ -39,9 +39,6 @@ public:
   name() const override
   { return QString("TextSourceDataModel"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<TextSourceDataModel>(); }
 
 public:
 

--- a/examples/images/ImageLoaderModel.hpp
+++ b/examples/images/ImageLoaderModel.hpp
@@ -38,9 +38,6 @@ public:
   QString
   name() const override { return QString("ImageLoaderModel"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<ImageLoaderModel>(); }
 
 public:
 

--- a/examples/images/ImageShowModel.hpp
+++ b/examples/images/ImageShowModel.hpp
@@ -37,9 +37,6 @@ public:
   name() const override
   { return QString("ImageShowModel"); }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  { return std::make_unique<ImageShowModel>(); }
 
 public:
 

--- a/examples/styles/models.hpp
+++ b/examples/styles/models.hpp
@@ -52,11 +52,6 @@ public:
     return QString("MyDataModel");
   }
 
-  std::unique_ptr<NodeDataModel>
-  clone() const override
-  {
-    return std::make_unique<MyDataModel>();
-  }
 
 public:
 

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -10,11 +10,11 @@ std::unique_ptr<NodeDataModel>
 DataModelRegistry::
 create(QString const &modelName)
 {
-  auto it = _registeredModels.find(modelName);
+  auto it = _registeredModelCreators.find(modelName);
 
-  if (it != _registeredModels.end())
+  if (it != _registeredModelCreators.end())
   {
-    return it->second->clone();
+    return it->second();
   }
 
   return nullptr;
@@ -25,7 +25,7 @@ DataModelRegistry::RegisteredModelsMap const &
 DataModelRegistry::
 registeredModels() const
 {
-  return _registeredModels;
+  return _registeredModelCreators;
 }
 
 
@@ -54,7 +54,7 @@ getTypeConverter(QString const &sourceTypeID, QString const &destTypeID) const
 
   if (converter != _registeredTypeConverters.end())
   {
-    return converter->second->Model->clone();
+    return converter->second->ModelCloner();
   }
   return nullptr;
 }

--- a/src/NodeDataModel.hpp
+++ b/src/NodeDataModel.hpp
@@ -57,9 +57,6 @@ public:
   virtual QString
   name() const = 0;
 
-  /// Function creates instances of a model stored in DataModelRegistry
-  virtual std::unique_ptr<NodeDataModel>
-  clone() const = 0;
 
 public:
 


### PR DESCRIPTION
Hi,

I suggest to change the DataModelRegistry to store a function pointer of type 

        std::function<RegistryItemPtr()>

instead of a "prototype" instance of RegistryItemPtr that is used to call **clone()**.

The advantage is twofold:

- No need to have a pure visrtual function clone() anymore
- It was impossible to have derived classes of NodeDataModel which need arguments in the constructor. Now it is possible to use std::bind or capturing lambdas to deal with this use case.

For instance:

``` c++

class MyDataModel : public NodeDataModel
{
  Q_OBJECT

public:
  MyDataModel(QString name) : _name(name) {}

QString name() const override  { return QString("MyDataModel:") + _name; }

// More stuff
private:
   QString _name;
}

// code where you register
{
  auto ret = std::make_shared<DataModelRegistry>();
  ret->registerModel<MyDataModel>( [](){ return std::make_unique<MyDataModel>("NameA") ;  );
  ret->registerModel<MyDataModel>( [](){ return std::make_unique<MyDataModel>("NameB") ;  );
}

``` 
