### PR TITLE
added HTML text rendering support

### DIFF
--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -6,6 +6,7 @@
 #include <QtCore/QPointF>
 #include <QtGui/QTransform>
 #include <QtGui/QFontMetrics>
+#include <QtGui/QTextDocument>
 
 #include "PortType.hpp"
 #include "Export.hpp"
@@ -73,6 +74,8 @@ public:
   setDraggingPosition(QPointF const& pos)
   { _draggingPos = pos; }
 
+  unsigned int portsXoffset() const { return _portsXoffset; }
+
 public:
 
   QRectF
@@ -118,6 +121,11 @@ public:
   calculateNodePositionBetweenNodePorts(PortIndex targetPortIndex, PortType targetPort, Node* targetNode,
                                         PortIndex sourcePortIndex, PortType sourcePort, Node* sourceNode,
                                         Node& newNode);
+
+  static
+  QRectF
+  calculateDocRect(const QTextDocument& td);
+
 private:
 
   unsigned int
@@ -128,6 +136,8 @@ private:
 
   unsigned int
   portWidth(PortType portType) const;
+
+  QRectF portRect(PortType portType, const PortIndex& index) const;
 
 private:
 
@@ -143,6 +153,10 @@ private:
   mutable unsigned int _outputPortWidth;
   mutable unsigned int _entryHeight;
   unsigned int _spacing;
+  unsigned int _portsXoffset;
+
+  mutable qreal _captionHeight;
+  mutable qreal _captionWidth;
 
   bool _hovered;
 
@@ -155,5 +169,12 @@ private:
 
   mutable QFontMetrics _fontMetrics;
   mutable QFontMetrics _boldFontMetrics;
+  mutable QMap<PortIndex, QRectF> _cachedPortRects[2];
+
+  mutable bool _entryHeightCalculated;
+  mutable bool _portsWidthCalculated;
+
+  mutable bool _captionHeightCalculated;
+  mutable bool _captionWidthCalculated;
 };
 }

--- a/include/nodes/internal/NodeStyle.hpp
+++ b/include/nodes/internal/NodeStyle.hpp
@@ -38,7 +38,7 @@ public:
   QColor GradientColor3;
   QColor ShadowColor;
   QColor FontColor;
-  QColor FontColorFaded;
+  //QColor FontColorFaded;
 
   QColor ConnectionPointColor;
   QColor FilledConnectionPointColor;
@@ -52,5 +52,8 @@ public:
   float ConnectionPointDiameter;
 
   float Opacity;
+
+  QString PortTextCss;
+  QString NodeCaptionCss;
 };
 }

--- a/resources/DefaultStyle.json
+++ b/resources/DefaultStyle.json
@@ -24,7 +24,10 @@
 
     "ConnectionPointDiameter": 8.0,
 
-    "Opacity": 0.8
+    "Opacity": 0.8,
+
+    "PortTextCss": "p {margin : 0; padding : 0; font-size : 10px}",
+    "NodeCaptionCss": "p {margin : 0; padding : 0; font-size : 10px}"
   },
   "ConnectionStyle": {
     "ConstructionColor": "gray",

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -77,6 +77,12 @@ setNodeStyle(QString jsonText)
     variable = valueRef.toDouble(); \
 }
 
+#define NODE_STYLE_READ_STRING(values, variable)  { \
+    auto valueRef = values[#variable]; \
+    NODE_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+    variable = valueRef.toString(); \
+}
+
 void
 NodeStyle::
 loadJsonFile(QString styleFile)
@@ -122,7 +128,7 @@ loadJsonFromByteArray(QByteArray const &byteArray)
   NODE_STYLE_READ_COLOR(obj, GradientColor3);
   NODE_STYLE_READ_COLOR(obj, ShadowColor);
   NODE_STYLE_READ_COLOR(obj, FontColor);
-  NODE_STYLE_READ_COLOR(obj, FontColorFaded);
+  //NODE_STYLE_READ_COLOR(obj, FontColorFaded);
   NODE_STYLE_READ_COLOR(obj, ConnectionPointColor);
   NODE_STYLE_READ_COLOR(obj, FilledConnectionPointColor);
   NODE_STYLE_READ_COLOR(obj, WarningColor);
@@ -133,4 +139,8 @@ loadJsonFromByteArray(QByteArray const &byteArray)
   NODE_STYLE_READ_FLOAT(obj, ConnectionPointDiameter);
 
   NODE_STYLE_READ_FLOAT(obj, Opacity);
+
+  NODE_STYLE_READ_STRING(obj, PortTextCss);
+  NODE_STYLE_READ_STRING(obj, NodeCaptionCss);
+  
 }


### PR DESCRIPTION
Using QTextDocument for rendering node's text.
![image](https://user-images.githubusercontent.com/6782809/38882145-21280108-4272-11e8-8e68-2e11797a6ea4.png)
```
NodeDataType type() const override
  {
    return NodeDataType {"decimal",
                         "<p style=\"color:red;\"> Decimal</p> <p style=\"color:green;\"> Decimal</p>"};
  }
```