### PR TITLE
misc improvements (use std::move, use const&, etc)

### DIFF
--- a/include/nodes/internal/Connection.hpp
+++ b/include/nodes/internal/Connection.hpp
@@ -45,7 +45,7 @@ public:
              PortIndex portIndexIn,
              Node& nodeOut,
              PortIndex portIndexOut,
-             TypeConverter const & converter =
+             TypeConverter converter =
                TypeConverter{});
 
   Connection(const Connection&) = delete;

--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -66,11 +66,11 @@ public:
 
   void setRegistry(std::shared_ptr<DataModelRegistry> registry);
 
-  void iterateOverNodes(std::function<void(Node*)> visitor);
+  void iterateOverNodes(std::function<void(Node*)> const & visitor);
 
-  void iterateOverNodeData(std::function<void(NodeDataModel*)> visitor);
+  void iterateOverNodeData(std::function<void(NodeDataModel*)> const & visitor);
 
-  void iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> visitor);
+  void iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const & visitor);
 
   QPointF getNodePosition(const Node& node) const;
 
@@ -132,5 +132,5 @@ private:
 
 Node*
 locateNodeAt(QPointF scenePoint, FlowScene &scene,
-             QTransform viewTransform);
+             QTransform const & viewTransform);
 }

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -53,7 +53,7 @@ public:
   id() const;
 
   void reactToPossibleConnection(PortType,
-                                 NodeDataType,
+                                 NodeDataType const &,
                                  QPointF const & scenePoint);
 
   void

--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -92,12 +92,12 @@ public:
   QPointF
   portScenePosition(PortIndex index,
                     PortType portType,
-                    QTransform t = QTransform()) const;
+                    QTransform const & t = QTransform()) const;
 
   PortIndex
   checkHitScenePoint(PortType portType,
-                     QPointF const point,
-                     QTransform t = QTransform()) const;
+                     QPointF point,
+                     QTransform const & t = QTransform()) const;
 
   QRect
   resizeRect() const;

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -1,6 +1,7 @@
 #include "Connection.hpp"
 
-#include <math.h>
+#include <cmath>
+#include <utility>
 
 #include <QtWidgets/QtWidgets>
 #include <QtGlobal>
@@ -48,14 +49,14 @@ Connection(Node& nodeIn,
            PortIndex portIndexIn,
            Node& nodeOut,
            PortIndex portIndexOut,
-           TypeConverter const & typeConverter)
+           TypeConverter typeConverter)
   : _uid(QUuid::createUuid())
   , _outNode(&nodeOut)
   , _inNode(&nodeIn)
   , _outPortIndex(portIndexOut)
   , _inPortIndex(portIndexIn)
   , _connectionState()
-  , _converter(typeConverter)
+  , _converter(std::move(typeConverter))
 {
   setNodeToPort(nodeIn, PortType::In, portIndexIn);
   setNodeToPort(nodeOut, PortType::Out, portIndexOut);

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -2,6 +2,7 @@
 
 #include <QtCore/QObject>
 
+#include <utility>
 #include <iostream>
 
 #include "FlowScene.hpp"
@@ -39,7 +40,7 @@ Node(std::unique_ptr<NodeDataModel> && dataModel)
 
 
 Node::
-~Node() {}
+~Node() = default;
 
 QJsonObject
 Node::
@@ -86,7 +87,7 @@ id() const
 void
 Node::
 reactToPossibleConnection(PortType reactingPortType,
-                          NodeDataType reactingDataType,
+                          NodeDataType const &reactingDataType,
                           QPointF const &scenePoint)
 {
   QTransform const t = _nodeGraphicsObject->sceneTransform();
@@ -183,7 +184,7 @@ Node::
 propagateData(std::shared_ptr<NodeData> nodeData,
               PortIndex inPortIndex) const
 {
-  _nodeDataModel->setInData(nodeData, inPortIndex);
+  _nodeDataModel->setInData(std::move(nodeData), inPortIndex);
 
   //Recalculate the nodes visuals. A data change can result in the node taking more space than before, so this forces a recalculate+repaint on the affected node
   _nodeGraphicsObject->setGeometryChanged();

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -133,7 +133,7 @@ QPointF
 NodeGeometry::
 portScenePosition(PortIndex index,
                   PortType portType,
-                  QTransform t) const
+                  QTransform const & t) const
 {
   auto const &nodeStyle = StyleCollection::nodeStyle();
 
@@ -180,7 +180,7 @@ PortIndex
 NodeGeometry::
 checkHitScenePoint(PortType portType,
                    QPointF const scenePoint,
-                   QTransform sceneTransform) const
+                   QTransform const & sceneTransform) const
 {
   auto const &nodeStyle = StyleCollection::nodeStyle();
 

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -110,7 +110,7 @@ setReaction(ReactToConnectionState reaction,
 
   _reactingPortType = reactingPortType;
 
-  _reactingDataType = reactingDataType;
+  _reactingDataType = std::move(reactingDataType);
 }
 
 


### PR DESCRIPTION
Some other things I noticed:

* ConnectionGraphicsObject.cpp:172

  ```c++
   auto view = static_cast<QGraphicsView*>(event->widget());
  ```

  It might be better to make this a `dynamic_cast` (or Qt has an equivalent IIRC), which would make it an error if it was wrong, rather than silently failing.

* NodeGeometry.cpp
  The `_entryWidth` member is never set, but it's also never used, as `entryBoundingRect()` is never called