### PR TITLE
Improve registry / creator code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
       compiler: gcc
       env:
         - CXX=g++-5 CC=gcc-5 QT=5
-        - CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
-        - LDFLAGS=-fsanitize=address
+        - NODE_EDITOR_CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        - NODE_EDITOR_LDFLAGS=-fsanitize=address
           # Too many false positive leaks:
         - ASAN_OPTIONS=detect_leaks=0
       addons:
@@ -77,6 +77,8 @@ install:
 script:
   - mkdir build
   - cd build
+  - CXXFLAGS=$NODE_EDITOR_CXXFLAGS
+  - LDFLAGS=$NODE_EDITOR_LDFLAGS
   - cmake -DCMAKE_VERBOSE_MAKEFILE=$VERBOSE_BUILD .. && make -j
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x24" ./test/test_nodes; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./test/test_nodes; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,12 @@ matrix:
     - os: linux
       dist: trusty
       compiler: gcc
-      env: CXX=g++-5 CC=gcc-5 QT=5
-           CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
-           LDFLAGS=-fsanitize=address
-           # Too many false positive leaks:
-           ASAN_OPTIONS=detect_leaks=0
+      env:
+        - CXX=g++-5 CC=gcc-5 QT=5
+        - CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        - LDFLAGS=-fsanitize=address
+          # Too many false positive leaks:
+        - ASAN_OPTIONS=detect_leaks=0
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,21 @@ matrix:
           packages:
             - g++-5
 
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: CXX=g++-5 CC=gcc-5 QT=5
+           CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+           LDFLAGS=-fsanitize=address
+           # Too many false positive leaks:
+           ASAN_OPTIONS=detect_leaks=0
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+
     - os: osx
       osx_image: xcode8.3
       compiler: clang

--- a/include/nodes/internal/DataModelRegistry.hpp
+++ b/include/nodes/internal/DataModelRegistry.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include <set>
-#include <memory>
 #include <functional>
+#include <memory>
+#include <set>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <QtCore/QString>
@@ -76,6 +78,19 @@ public:
                      RegistryItemCreator creator)
   {
     registerModel<ModelType>(std::move(creator), category);
+  }
+
+  template <typename ModelCreator>
+  void registerModel(ModelCreator&& creator, QString const& category = "Nodes")
+  {
+    using ModelType = std::decay_t<decltype(creator())>;
+    registerModel<ModelType>(std::forward<ModelCreator>(creator), category);
+  }
+
+  template <typename ModelCreator>
+  void registerModel(QString const& category, ModelCreator&& creator)
+  {
+    registerModel(std::forward<ModelCreator>(creator), category);
   }
 
   void registerTypeConverter(TypeConverterId const & id,

--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -125,9 +125,14 @@ private:
   using SharedConnection = std::shared_ptr<Connection>;
   using UniqueNode       = std::unique_ptr<Node>;
 
+  // DO NOT reorder this member to go after the others.
+  // This should outlive all the connections and nodes of
+  // the graph, so that nodes can potentially have pointers into it,
+  // which is why it comes first in the class.
+  std::shared_ptr<DataModelRegistry> _registry;
+
   std::unordered_map<QUuid, SharedConnection> _connections;
   std::unordered_map<QUuid, UniqueNode>       _nodes;
-  std::shared_ptr<DataModelRegistry>          _registry;
 };
 
 Node*

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(test_nodes
   test_main.cpp
   src/test_dragging.cpp
   src/TestDataModelRegistry.cpp
+  src/TestFlowScene.cpp
   src/TestNodeGraphicsObject.cpp
 )
 

--- a/test/src/TestDataModelRegistry.cpp
+++ b/test/src/TestDataModelRegistry.cpp
@@ -42,4 +42,31 @@ TEST_CASE("DataModelRegistry::registerModel", "[interface]")
 
     CHECK(model->name() == "name");
   }
+  SECTION("From model creator function")
+  {
+    SECTION("non-static name()")
+    {
+      registry.registerModel([] {
+        return std::make_unique<StubNodeDataModel>();
+      });
+
+      auto model = registry.create("name");
+
+      REQUIRE(model != nullptr);
+      CHECK(model->name() == "name");
+      CHECK(dynamic_cast<StubNodeDataModel*>(model.get()));
+    }
+    SECTION("static Name()")
+    {
+      registry.registerModel([] {
+        return std::make_unique<StubModelStaticName>();
+      });
+
+      auto model = registry.create("Name");
+
+      REQUIRE(model != nullptr);
+      CHECK(model->name() == "name");
+      CHECK(dynamic_cast<StubModelStaticName*>(model.get()));
+    }
+  }
 }

--- a/test/src/TestFlowScene.cpp
+++ b/test/src/TestFlowScene.cpp
@@ -1,0 +1,70 @@
+#include <nodes/FlowScene>
+#include <nodes/Node>
+
+#include "ApplicationSetup.hpp"
+#include "StubNodeDataModel.hpp"
+
+#include <catch.hpp>
+
+using QtNodes::DataModelRegistry;
+using QtNodes::FlowScene;
+
+TEST_CASE("FlowScene's DataModelRegistry outlives nodes and connections", "[asan][gui]")
+{
+  class MockDataModel : public StubNodeDataModel
+  {
+  public:
+    MockDataModel(int* const& incrementOnDestruction)
+      : incrementOnDestruction(incrementOnDestruction)
+    {
+    }
+
+    ~MockDataModel()
+    {
+      (*incrementOnDestruction)++;
+    }
+
+    // The reference ensures that we point into the memory that would be free'd
+    // if the DataModelRegistry doesn't outlive this node
+    int* const& incrementOnDestruction;
+  };
+
+  struct MockDataModelCreator
+  {
+    MockDataModelCreator(int* shouldBeAliveWhenAssignedTo)
+      : shouldBeAliveWhenAssignedTo(shouldBeAliveWhenAssignedTo)
+    {
+    }
+
+    auto
+    operator()() const
+    {
+      return std::make_unique<MockDataModel>(shouldBeAliveWhenAssignedTo);
+    }
+
+    int* shouldBeAliveWhenAssignedTo;
+  };
+
+  int modelsDestroyed = 0;
+
+  // Introduce a new scope, so that modelsDestroyed will be alive even after the
+  // FlowScene is destroyed.
+  {
+    auto setup = applicationSetup();
+
+    auto registry = std::make_shared<DataModelRegistry>();
+    registry->registerModel(MockDataModelCreator(&modelsDestroyed));
+
+    modelsDestroyed = 0;
+
+    FlowScene scene(std::move(registry));
+
+    auto& node = scene.createNode(scene.registry().create("name"));
+
+    // On destruction, if this `node` outlives its MockDataModelCreator,
+    // (if it outlives the DataModelRegistry), then we trigger undefined
+    // behavior through use-after-free. ASAN will catch that.
+  }
+
+  CHECK(modelsDestroyed == 1);
+}


### PR DESCRIPTION
Simplifies the registration code, removing duplication, by using tag dispatching, and minimizing the compile-time branch code.

The only difference between the two `registerModelImpl` functions was the way the name was being computed, so rather than using `registerModelImpl` to do the compile-time branching, make a new `computeName` function.