### PR TITLE
Fix 168

### DIFF
--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -260,17 +260,23 @@ void
 FlowView::
 deleteSelectedNodes()
 {
-  // delete the nodes, this will delete many of the connections
-  for (QGraphicsItem * item : _scene->selectedItems())
-  {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
-      _scene->removeNode(n->node());
-  }
-
+  // Delete the selected connections first, ensuring that they won't be
+  // automatically deleted when selected nodes are deleted (deleting a node
+  // deletes some connections as well)
   for (QGraphicsItem * item : _scene->selectedItems())
   {
     if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
       _scene->deleteConnection(c->connection());
+  }
+
+  // Delete the nodes; this will delete many of the connections.
+  // Selected connections were already deleted prior to this loop, otherwise
+  // qgraphicsitem_cast<NodeGraphicsObject*>(item) could be a use-after-free
+  // when a selected connection is deleted by deleting the node.
+  for (QGraphicsItem * item : _scene->selectedItems())
+  {
+    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
+      _scene->removeNode(n->node());
   }
 }
 


### PR DESCRIPTION
Fixes the bug in #168 

This fixes the bug by swapping the two loops in `FlowView::deleteSelectedNodes()`