### PR TITLE
Fix Appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,14 +6,16 @@ environment:
       QTDIR: C:\Qt\5.6\mingw49_32
       PLATFORM: x86
     - GENERATOR : "Visual Studio 14 2015 Win64"
-      QTDIR: C:\Qt\5.7\msvc2015_64
+      QTDIR: C:\Qt\5.6.3\msvc2015_64
       PLATFORM: x64
     - GENERATOR : "Visual Studio 14 2015"
-      QTDIR: C:\Qt\5.7\msvc2015
+      QTDIR: C:\Qt\5.6.3\msvc2015
       PLATFORM: Win32
 
 configuration:
   - Release
+
+image: Visual Studio 2015
 
 #branches:
   #only:


### PR DESCRIPTION
The appveyor build was failing due to Qt 5.7 not being on the image we were using (https://www.appveyor.com/docs/build-environment/#qt). I specified a *build worker image* and changed the Qt version from 5.7 to 5.6.3.