### PR TITLE
Cleaner Cleanup

### DIFF
--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -59,10 +59,10 @@ public:
   setHovered(unsigned int h) { _hovered = h; }
 
   unsigned int
-  nSources() const { return _nSources; }
+  nSources() const;
 
   unsigned int
-  nSinks() const { return _nSinks; }
+  nSinks() const;
 
   QPointF const&
   draggingPos() const

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -425,15 +425,14 @@ clearScene()
   //Manual node cleanup. Simply clearing the holding datastructures doesn't work, the code crashes when
   // there are both nodes and connections in the scene. (The data propagation internal logic tries to propagate
   // data through already freed connections.)
-  std::vector<Node*> nodesToDelete;
-  for (auto& node : _nodes)
+  while (_connections.size() > 0)
   {
-    nodesToDelete.push_back(node.second.get());
+    deleteConnection( *_connections.begin()->second );
   }
 
-  for (auto& node : nodesToDelete)
+  while (_nodes.size() > 0)
   {
-    removeNode(*node);
+    removeNode( *_nodes.begin()->second );
   }
 }
 

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -38,6 +38,17 @@ NodeGeometry(std::unique_ptr<NodeDataModel> const &dataModel)
   _boldFontMetrics = QFontMetrics(f);
 }
 
+unsigned int
+NodeGeometry::nSources() const
+{
+  return _dataModel->nPorts(PortType::Out);
+}
+
+unsigned int
+NodeGeometry::nSinks() const
+{
+  return _dataModel->nPorts(PortType::In);
+}
 
 QRectF
 NodeGeometry::

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -61,7 +61,7 @@ setConnection(PortType portType,
 {
   auto &connections = getEntries(portType);
 
-  connections[portIndex].insert(std::make_pair(connection.id(),
+  connections.at(portIndex).insert(std::make_pair(connection.id(),
                                                &connection));
 }
 


### PR DESCRIPTION
Hi,

in my code I frequently create/remove programmatically nodes and connections.

Apparently I am doing something weird (or not) and during the cleanup some "zombie" connection still exist somewhere.

This PR will fix the symptom (crash in **Connection::save()** )  but, for the time being, not the actual illness (connection that still exist even if it was supposed to be deleted). 

In the worst case, this code is equivalent to the old one.

Davide

**P.S.**: at some point we migh start a discussion about making the code more robust using std::weak_ptr instead of raw pointers. 
