### PR TITLE
Signal that can be emitted when the size of the embedded widget changes

### DIFF
--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -97,6 +97,10 @@ public slots: // data propagation
   void
   onDataUpdated(PortIndex index);
 
+  /// update the graphic part if the size of the embeddedwidget changes
+  void
+  onNodeSizeUpdated();
+
 private:
 
   // addressing

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -136,6 +136,8 @@ signals:
   void
   computingFinished();
 
+  void embeddedWidgetSizeUpdated();
+
 private:
 
   NodeStyle _nodeStyle;

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -36,6 +36,9 @@ Node(std::unique_ptr<NodeDataModel> && dataModel)
   // propagate data: model => node
   connect(_nodeDataModel.get(), &NodeDataModel::dataUpdated,
           this, &Node::onDataUpdated);
+
+  connect(_nodeDataModel.get(), &NodeDataModel::embeddedWidgetSizeUpdated,
+          this, &Node::onNodeSizeUpdated );
 }
 
 
@@ -205,4 +208,26 @@ onDataUpdated(PortIndex index)
 
   for (auto const & c : connections)
     c.second->propagateData(nodeData);
+}
+
+void
+Node::
+onNodeSizeUpdated()
+{
+    if( nodeDataModel()->embeddedWidget() )
+    {
+        nodeDataModel()->embeddedWidget()->adjustSize();
+    }
+    nodeGeometry().recalculateSize();
+    for(PortType type: {PortType::In, PortType::Out})
+    {
+        for(auto& conn_set : nodeState().getEntries(type))
+        {
+            for(auto& pair: conn_set)
+            {
+                Connection* conn = pair.second;
+                conn->getConnectionGraphicsObject().move();
+            }
+        }
+    }
 }


### PR DESCRIPTION
In my application I resize the embedde widget of the NodeDataModel.

To correctly update the graphic part, I created an aditional signal/slot pair. See the video

[bt_editor_resize_node-2018-06-11_14.36.43.mkv.zip](https://github.com/paceholder/nodeeditor/files/2089948/bt_editor_resize_node-2018-06-11_14.36.43.mkv.zip)

Cheers