### PR TITLE
Automatically get Catch2 if needed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,15 +5,13 @@ environment:
     - GENERATOR : "Visual Studio 14 2015 Win64"
       QTDIR: C:\Qt\5.6.3\msvc2015_64
       PLATFORM: x64
-      BUILD_TESTING: ON
     - GENERATOR : "Visual Studio 14 2015"
       QTDIR: C:\Qt\5.6.3\msvc2015
       PLATFORM: Win32
-      BUILD_TESTING: ON
     - GENERATOR : "MinGW Makefiles"
       QTDIR: C:\Qt\5.6\mingw49_32
       PLATFORM: x86
-      BUILD_TESTING: OFF
+      CMAKE_CXX_FLAGS_INIT: -DCATCH_CONFIG_NO_CPP11_TO_STRING
 
 image: Visual Studio 2015
 
@@ -29,31 +27,16 @@ install:
   - set Qt5_DIR=%QTDIR%\lib\cmake\Qt5
   - set PATH=C:\MinGW\bin;C:\MinGW\msys\1.0;%PATH%
   - set PATH=%PATH:C:\Program Files\Git\usr\bin=% # trick to remove sh.exe
-  - mkdir dependencies
-  - cd dependencies
-  - mkdir install
-  - set CMAKE_INSTALL_PREFIX=%cd%\install
-  - set DEPENDENCIES=%cd%\install
-  - git clone https://github.com/catchorg/Catch2.git
-  - cd Catch2
-  - mkdir build
-  - cd build
-  - cmake "-G%GENERATOR%" -DBUILD_TESTING=OFF ..
-  - cmake --build . --target install
-  - set Catch2_DIR=%DEPENDENCIES=%cd%\install\lib\cmake\Catch2
-  - cd ..
-  - cd ..
-  - cd ..
 
 before_build:
   - mkdir build
   - cd build
   - mkdir bin
   - set OUTPUT_DIR=%cd%\bin
-  - echo %BUILD_TESTING%
-  - cmake "-G%GENERATOR%" -DBUILD_TESTING=%BUILD_TESTING%
+  - cmake "-G%GENERATOR%"
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG="%OUTPUT_DIR%"
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE="%OUTPUT_DIR%"
+    -DCMAKE_CXX_FLAGS_INIT="%CMAKE_CXX_FLAGS_INIT%"
     ..
 
 
@@ -61,7 +44,7 @@ build_script:
   - cmake --build .
 
 test_script:
-  - if "%BUILD_TESTING%" == "ON" .\bin\test_nodes.exe
+  - ctest --output-on-failure -C Debug
 
 
 after_build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,27 +43,12 @@ before_install:
    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install build-essential libgl1-mesa-dev ; fi
    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -yy install qtbase5-dev ; fi
 
-install:
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - |
-    mkdir -p ${DEPS_DIR}
-    pushd ${DEPS_DIR}
-  - travis_retry git clone https://github.com/catchorg/Catch2.git # Install Catch2
-  - |
-    pushd Catch2
-    git checkout tags/v2.2.2
-    mkdir build && cd build
-  - cmake .. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${DEPS_DIR}/install"
-  - cmake --build . -- install
-  - export CMAKE_PREFIX_PATH="${DEPS_DIR}/install/:$CMAKE_PREFIX_PATH"
-  - popd; popd
-
 script:
   - mkdir build
   - cd build
   - cmake -DCMAKE_VERBOSE_MAKEFILE=$VERBOSE_BUILD .. && make -j
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x24" ./test/test_nodes; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./test/test_nodes; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x24" ctest --output-on-failure; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ctest --output-on-failure; fi
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,31 @@ project(NodeEditor CXX)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES  ON)
 
-include(CTest)
+get_directory_property(_has_parent PARENT_DIRECTORY)
+if(_has_parent)
+  set(is_root_project OFF)
+else()
+  set(is_root_project ON)
+endif()
 
-option(BUILD_EXAMPLES "Build Examples" ON)
+set(NE_DEVELOPER_DEFAULTS "${is_root_project}" CACHE BOOL "Turns on default settings for development of NodeEditor")
+
+option(BUILD_TESTING "Build tests" "${NE_DEVELOPER_DEFAULTS}")
+option(BUILD_EXAMPLES "Build Examples" "${NE_DEVELOPER_DEFAULTS}")
+option(NE_FORCE_TEST_COLOR "Force colorized unit test output" OFF)
+
+enable_testing()
+
+if(NE_DEVELOPER_DEFAULTS)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+endif()
+
+add_subdirectory(external)
 
 # Find the QtWidgets library
 find_package(Qt5 COMPONENTS
@@ -57,7 +79,7 @@ add_library(nodes SHARED
 add_library(NodeEditor::nodes ALIAS nodes)
 
 target_include_directories(nodes
-  PUBLIC 
+  PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,13 @@
+if(BUILD_TESTING)
+  find_package(Catch2 2.3.0 QUIET)
+
+  if(NOT Catch2_FOUND)
+    add_subdirectory(Catch2)
+  endif()
+endif()
+
+macro(find_package pkg)
+  if(NOT TARGET "${pkg}")
+    _find_package(${ARGV})
+  endif()
+endmacro()

--- a/external/Catch2/CMakeLists.txt
+++ b/external/Catch2/CMakeLists.txt
@@ -1,0 +1,13 @@
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/single_include/catch2/catch.hpp")
+  file(DOWNLOAD https://raw.githubusercontent.com/catchorg/Catch2/v2.4.1/single_include/catch2/catch.hpp
+    "${CMAKE_CURRENT_BINARY_DIR}/single_include/catch2/catch.hpp"
+    EXPECTED_HASH SHA256=a4b90030cb813f0452bb00e97c92ca6c2ecf9386a2f000b6effb8e265a53959e
+  )
+endif()
+
+add_library(Catch2 INTERFACE)
+add_library(Catch2::Catch2 ALIAS Catch2)
+target_include_directories(Catch2
+  INTERFACE
+    "${CMAKE_CURRENT_BINARY_DIR}/single_include"
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Catch2 REQUIRED)
+find_package(Catch2 2.3.0 REQUIRED)
 find_package(Qt5 COMPONENTS Test)
 
 add_executable(test_nodes
@@ -18,8 +18,13 @@ target_include_directories(test_nodes
 target_link_libraries(test_nodes
   PRIVATE
     NodeEditor::nodes
-    Catch2::Catch
+    Catch2::Catch2
     Qt5::Test
 )
 
-add_test(test_nodes test_nodes)
+add_test(
+  NAME test_nodes
+  COMMAND
+    $<TARGET_FILE:test_nodes>
+    $<$<BOOL:${NE_FORCE_TEST_COLOR}>:--use-colour=yes>
+)

--- a/test/include/Stringify.hpp
+++ b/test/include/Stringify.hpp
@@ -3,7 +3,7 @@
 #include <QtCore/QPoint>
 #include <QtCore/QPointF>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <QtTest>
 

--- a/test/src/TestDataModelRegistry.cpp
+++ b/test/src/TestDataModelRegistry.cpp
@@ -1,6 +1,6 @@
 #include <nodes/DataModelRegistry>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "StubNodeDataModel.hpp"
 

--- a/test/src/TestNodeGraphicsObject.cpp
+++ b/test/src/TestNodeGraphicsObject.cpp
@@ -3,7 +3,7 @@
 #include <nodes/Node>
 #include <nodes/NodeDataModel>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <QtTest>
 

--- a/test/src/test_dragging.cpp
+++ b/test/src/test_dragging.cpp
@@ -3,7 +3,7 @@
 #include <nodes/FlowView>
 #include <nodes/Node>
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <QtTest>
 #include <QtWidgets/QApplication>

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>


### PR DESCRIPTION
* Automatically downloads Catch2 if `BUILD_TESTING` is on and Catch2 is not otherwise found.
* Fix usage of Catch2
  * Use `#include <catch2/catch.hpp>` (Catch2 v2.3.0+)
  * Use `Catch2::Catch2` (Catch2 v2.3.0+)
* Fix appveyor build
  * MinGW can now build tests (passed [`-DCATCH_CONFIG_NO_CPP11_TO_STRING`](https://github.com/catchorg/Catch2/blob/master/docs/configuration.md#c11-toggles))
    * Running the tests fail, though...
* Updated project options
  * Play nicely with `add_subdirectory(nodeeditor)` workflow.
  * Add a `NE_FORCE_TEST_COLOR` option which, when turned on, forces the Catch2 executable to output with color. Useful for running ctest from the commandline
  * If we are the root project, set the `bin` and `lib` directories. We don't want to interfere with anyone else's `CMAKE_*_OUTPUT_DIRECTORY` settings, but it's okay if we do so for ourselves.