### PR TITLE
Add embed/dembed widget posibility

### DIFF
--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -147,7 +147,7 @@ private Q_SLOTS:
   
   void sendConnectionCreatedToNodes(Connection const& c);
   void sendConnectionDeletedToNodes(Connection const& c);
-
+  void sceneContextMenuEvent(Node &node, const QPointF &pos);
 };
 
 Node*

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -124,6 +124,9 @@ public:
   virtual
   NodePainterDelegate* painterDelegate() const { return nullptr; }
 
+  bool wembed() const;
+  void setWembed(bool wembed);
+
 public Q_SLOTS:
 
   virtual void
@@ -162,6 +165,8 @@ Q_SIGNALS:
 
   void embeddedWidgetSizeUpdated();
 
+protected:
+    bool m_wembed;
 private:
 
   NodeStyle _nodeStyle;

--- a/include/nodes/internal/NodeGraphicsObject.hpp
+++ b/include/nodes/internal/NodeGraphicsObject.hpp
@@ -54,6 +54,9 @@ public:
   void
   lock(bool locked);
 
+  void
+  embedQWidget(bool embed=true);
+
 protected:
   void
   paint(QPainter*                       painter,
@@ -88,10 +91,6 @@ protected:
   contextMenuEvent(QGraphicsSceneContextMenuEvent* event) override;
 
 private:
-  void
-  embedQWidget();
-
-private:
 
   FlowScene & _scene;
 
@@ -101,5 +100,6 @@ private:
 
   // either nullptr or owned by parent QGraphicsItem
   QGraphicsProxyWidget * _proxyWidget;
+
 };
 }

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include <QMenu>
 #include <QtWidgets/QGraphicsSceneMoveEvent>
 #include <QtWidgets/QFileDialog>
 #include <QtCore/QByteArray>
@@ -50,6 +51,8 @@ FlowScene(std::shared_ptr<DataModelRegistry> registry,
   connect(this, &FlowScene::connectionCreated, this, &FlowScene::setupConnectionSignals);
   connect(this, &FlowScene::connectionCreated, this, &FlowScene::sendConnectionCreatedToNodes);
   connect(this, &FlowScene::connectionDeleted, this, &FlowScene::sendConnectionDeletedToNodes);
+  connect(this, &FlowScene::nodeContextMenu  , this, &FlowScene::sceneContextMenuEvent);
+
 }
 
 FlowScene::
@@ -605,6 +608,24 @@ sendConnectionDeletedToNodes(Connection const& c)
 
   from->nodeDataModel()->outputConnectionDeleted(c);
   to->nodeDataModel()->inputConnectionDeleted(c);
+}
+
+void
+FlowScene::
+sceneContextMenuEvent(Node &node, const QPointF &pos)
+{
+    QMenu menu;
+    QAction *embedAction    = menu.addAction("Embed");
+    QAction *deembedAction  = menu.addAction("Deembed");
+    QGraphicsView *v = node.nodeGraphicsObject().scene()->views().first();
+    QPoint viewP = v->mapFromScene(pos);
+    QAction *selectedAction = menu.exec( v->viewport()->mapToGlobal(viewP) );
+    if(  selectedAction == embedAction  ){
+        node.nodeGraphicsObject().embedQWidget(true);
+    }
+    else if(selectedAction == deembedAction){
+        node.nodeGraphicsObject().embedQWidget(false);
+    }
 }
 
 

--- a/src/NodeDataModel.cpp
+++ b/src/NodeDataModel.cpp
@@ -7,7 +7,8 @@ using QtNodes::NodeStyle;
 
 NodeDataModel::
 NodeDataModel()
-  : _nodeStyle(StyleCollection::nodeStyle())
+  : m_wembed(false), _nodeStyle(StyleCollection::nodeStyle())
+
 {
   // Derived classes can initialize specific style here
 }
@@ -38,4 +39,14 @@ NodeDataModel::
 setNodeStyle(NodeStyle const& style)
 {
   _nodeStyle = style;
+}
+
+bool NodeDataModel::wembed() const
+{
+    return m_wembed;
+}
+
+void NodeDataModel::setWembed(bool wembed)
+{
+    m_wembed = wembed;
 }

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -90,6 +90,7 @@ recalculateSize() const
     _height = step * maxNumOfEntries;
   }
 
+  if(_dataModel->wembed())
   if (auto w = _dataModel->embeddedWidget())
   {
     _height = std::max(_height, static_cast<unsigned>(w->height()));
@@ -104,6 +105,7 @@ recalculateSize() const
            _outputPortWidth +
            2 * _spacing;
 
+  if(_dataModel->wembed())
   if (auto w = _dataModel->embeddedWidget())
   {
     _width += w->width();

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -29,6 +29,7 @@ NodeGraphicsObject(FlowScene &scene,
   , _node(node)
   , _locked(false)
   , _proxyWidget(nullptr)
+
 {
   _scene.addItem(this);
 
@@ -57,7 +58,7 @@ NodeGraphicsObject(FlowScene &scene,
 
   setZValue(0);
 
-  embedQWidget();
+  embedQWidget( true );
 
   // connect to the move signals to emit the move signals in FlowScene
   auto onMoveSlot = [this] {
@@ -93,27 +94,44 @@ node() const
 
 void
 NodeGraphicsObject::
-embedQWidget()
+embedQWidget( bool embed )
 {
-  NodeGeometry & geom = _node.nodeGeometry();
+    NodeGeometry & geom = _node.nodeGeometry();
+    _node.nodeDataModel()->setWembed( embed );
+    if (auto w = _node.nodeDataModel()->embeddedWidget())
+    {
+        if ( embed ){
+            if ( nullptr == _proxyWidget ) {
+                _proxyWidget = new QGraphicsProxyWidget(this);
+                w->setParent(nullptr);
 
-  if (auto w = _node.nodeDataModel()->embeddedWidget())
-  {
-    _proxyWidget = new QGraphicsProxyWidget(this);
+                _proxyWidget->setWidget(w);
 
-    _proxyWidget->setWidget(w);
+                _proxyWidget->setPreferredWidth(5);
+                geom.recalculateSize();
 
-    _proxyWidget->setPreferredWidth(5);
+                _proxyWidget->setPos(geom.widgetPosition());
 
-    geom.recalculateSize();
+                update();
 
-    _proxyWidget->setPos(geom.widgetPosition());
+                _proxyWidget->setOpacity(1.0);
+                _proxyWidget->setFlag(QGraphicsItem::ItemIgnoresParentOpacity);
+            }
 
-    update();
-
-    _proxyWidget->setOpacity(1.0);
-    _proxyWidget->setFlag(QGraphicsItem::ItemIgnoresParentOpacity);
-  }
+        }else{
+            if ( nullptr != _proxyWidget ){
+                _proxyWidget->setWidget(nullptr);
+                  QPoint pos = QCursor::pos();
+                delete _proxyWidget;
+                _proxyWidget = nullptr;
+                w->setWindowTitle(_node.nodeDataModel()->caption());
+                w->setWindowFlags(Qt::Widget);
+                w->move(pos.x(),pos.y());
+                w->show();
+                w->raise();
+            }
+        }
+    }
 }
 
 
@@ -345,6 +363,11 @@ hoverEnterEvent(QGraphicsSceneHoverEvent * event)
   // bring this node forward
   setZValue(1.0);
 
+  if (auto w = _node.nodeDataModel()->embeddedWidget())
+  {
+      w->raise();
+  }
+
   _node.nodeGeometry().setHovered(true);
   update();
   _scene.nodeHovered(node(), event->screenPos());
@@ -398,5 +421,7 @@ void
 NodeGraphicsObject::
 contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
 {
-  _scene.nodeContextMenu(node(), mapToScene(event->pos()));
+
+        _scene.nodeContextMenu(node(), mapToScene(event->pos()));
+
 }


### PR DESCRIPTION
Add possibility to embed and deembed (detach) Node widget from scene. From popup menu on right button click you can select embedding state. When the widget is detached you can change it size and if you embed again the Node resized to new size.