### PR TITLE
Make NodeDataType to be extendable by open/closed principle

### DIFF
--- a/examples/calculator/DecimalData.hpp
+++ b/examples/calculator/DecimalData.hpp
@@ -19,10 +19,10 @@ public:
     : _number(number)
   {}
 
-  NodeDataType type() const override
+  std::shared_ptr<NodeDataType> type() const override
   {
-    return NodeDataType {"decimal",
-                         "Decimal"};
+    return std::make_shared<NodeDataType>("decimal",
+                         "Decimal");
   }
 
   double number() const

--- a/examples/calculator/IntegerData.hpp
+++ b/examples/calculator/IntegerData.hpp
@@ -19,10 +19,10 @@ public:
     : _number(number)
   {}
 
-  NodeDataType type() const override
+  std::shared_ptr<NodeDataType> type() const override
   {
-    return NodeDataType {"integer",
-                         "Integer"};
+    return std::make_shared<NodeDataType>("integer",
+                         "Integer");
   }
 
   int number() const

--- a/examples/calculator/MathOperationDataModel.cpp
+++ b/examples/calculator/MathOperationDataModel.cpp
@@ -17,7 +17,7 @@ nPorts(PortType portType) const
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 MathOperationDataModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/calculator/MathOperationDataModel.hpp
+++ b/examples/calculator/MathOperationDataModel.hpp
@@ -33,7 +33,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType,
            PortIndex portIndex) const override;
 

--- a/examples/calculator/ModuloModel.cpp
+++ b/examples/calculator/ModuloModel.cpp
@@ -39,7 +39,7 @@ nPorts(PortType portType) const
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 ModuloModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/calculator/ModuloModel.hpp
+++ b/examples/calculator/ModuloModel.hpp
@@ -77,7 +77,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType, PortIndex portIndex) const override;
 
   std::shared_ptr<NodeData>

--- a/examples/calculator/NumberDisplayDataModel.cpp
+++ b/examples/calculator/NumberDisplayDataModel.cpp
@@ -33,7 +33,7 @@ nPorts(PortType portType) const
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 NumberDisplayDataModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -45,7 +45,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType,
            PortIndex portIndex) const override;
 

--- a/examples/calculator/NumberSourceDataModel.cpp
+++ b/examples/calculator/NumberSourceDataModel.cpp
@@ -100,7 +100,7 @@ onTextEdited(QString const &string)
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 NumberSourceDataModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/calculator/NumberSourceDataModel.hpp
+++ b/examples/calculator/NumberSourceDataModel.hpp
@@ -56,7 +56,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType, PortIndex portIndex) const override;
 
   std::shared_ptr<NodeData>

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -45,14 +45,14 @@ registerDataModels()
 
   ret->registerModel<ModuloModel>("Operators");
 
-  ret->registerTypeConverter(std::make_pair(DecimalData().type(),
-                                            IntegerData().type()),
+  ret->registerTypeConverter(std::make_pair(DecimalData().type()->id,
+                                            IntegerData().type()->id),
                              TypeConverter{DecimalToIntegerConverter()});
 
 
 
-  ret->registerTypeConverter(std::make_pair(IntegerData().type(),
-                                            DecimalData().type()),
+  ret->registerTypeConverter(std::make_pair(IntegerData().type()->id,
+                                            DecimalData().type()->id),
                              TypeConverter{IntegerToDecimalConverter()});
 
   return ret;

--- a/examples/connection_colors/models.hpp
+++ b/examples/connection_colors/models.hpp
@@ -19,11 +19,11 @@ class MyNodeData : public NodeData
 {
 public:
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   type() const override
   {
-    return NodeDataType {"MyNodeData",
-                         "My Node Data"};
+    return std::make_shared<NodeDataType>("MyNodeData",
+                         "My Node Data");
   }
 };
 
@@ -31,11 +31,11 @@ class SimpleNodeData : public NodeData
 {
 public:
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   type() const override
   {
-    return NodeDataType {"SimpleData",
-                         "Simple Data"};
+    return std::make_shared<NodeDataType>("SimpleData",
+                         "Simple Data");
   }
 };
 
@@ -87,7 +87,7 @@ public:
     return result;
   }
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType,
            PortIndex portIndex) const override
   {
@@ -117,7 +117,7 @@ public:
         break;
     }
     // FIXME: control may reach end of non-void function [-Wreturn-type]
-    return NodeDataType();
+    return std::make_shared<NodeDataType>();
   }
 
   std::shared_ptr<NodeData>

--- a/examples/example2/TextData.hpp
+++ b/examples/example2/TextData.hpp
@@ -17,8 +17,8 @@ public:
     : _text(text)
   {}
 
-  NodeDataType type() const override
-  { return NodeDataType {"text", "Text"}; }
+  std::shared_ptr<NodeDataType> type() const override
+  { return std::make_shared<NodeDataType>("text", "Text"); }
 
   QString text() const { return _text; }
 

--- a/examples/example2/TextDisplayDataModel.cpp
+++ b/examples/example2/TextDisplayDataModel.cpp
@@ -31,7 +31,7 @@ nPorts(PortType portType) const
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 TextDisplayDataModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/example2/TextDisplayDataModel.hpp
+++ b/examples/example2/TextDisplayDataModel.hpp
@@ -48,7 +48,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType, PortIndex portIndex) const override;
 
   std::shared_ptr<NodeData>

--- a/examples/example2/TextSourceDataModel.cpp
+++ b/examples/example2/TextSourceDataModel.cpp
@@ -42,7 +42,7 @@ onTextEdited(QString const &string)
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 TextSourceDataModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/example2/TextSourceDataModel.hpp
+++ b/examples/example2/TextSourceDataModel.hpp
@@ -48,7 +48,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType, PortIndex portIndex) const override;
 
   std::shared_ptr<NodeData>

--- a/examples/images/ImageLoaderModel.cpp
+++ b/examples/images/ImageLoaderModel.cpp
@@ -83,7 +83,7 @@ eventFilter(QObject *object, QEvent *event)
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 ImageLoaderModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/images/ImageLoaderModel.hpp
+++ b/examples/images/ImageLoaderModel.hpp
@@ -47,7 +47,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType, PortIndex portIndex) const override;
 
   std::shared_ptr<NodeData>

--- a/examples/images/ImageShowModel.cpp
+++ b/examples/images/ImageShowModel.cpp
@@ -72,7 +72,7 @@ eventFilter(QObject *object, QEvent *event)
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 ImageShowModel::
 dataType(PortType, PortIndex) const
 {

--- a/examples/images/ImageShowModel.hpp
+++ b/examples/images/ImageShowModel.hpp
@@ -46,7 +46,7 @@ public:
   unsigned int
   nPorts(PortType portType) const override;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType, PortIndex portIndex) const override;
 
   std::shared_ptr<NodeData>

--- a/examples/images/PixmapData.hpp
+++ b/examples/images/PixmapData.hpp
@@ -19,11 +19,11 @@ public:
     : _pixmap(pixmap)
   {}
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   type() const override
   {
     //       id      name
-    return {"pixmap", "P"};
+    return std::make_shared<NodeDataType>("pixmap", "P");
   }
 
   QPixmap

--- a/examples/styles/models.hpp
+++ b/examples/styles/models.hpp
@@ -20,9 +20,9 @@ class MyNodeData : public NodeData
 {
 public:
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   type() const override
-  { return NodeDataType {"MyNodeData", "My Node Data"}; }
+  { return std::make_shared<NodeDataType>("MyNodeData", "My Node Data"); }
 };
 
 //------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ public:
     return 3;
   }
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType, PortIndex) const override
   {
     return MyNodeData().type();

--- a/include/nodes/internal/Connection.hpp
+++ b/include/nodes/internal/Connection.hpp
@@ -112,7 +112,7 @@ public:
   void
   clearNode(PortType portType);
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   dataType(PortType portType) const;
 
   void

--- a/include/nodes/internal/DataModelRegistry.hpp
+++ b/include/nodes/internal/DataModelRegistry.hpp
@@ -17,15 +17,6 @@
 namespace QtNodes
 {
 
-inline
-bool
-operator<(QtNodes::NodeDataType const & d1,
-          QtNodes::NodeDataType const & d2)
-{
-  return d1.id < d2.id;
-}
-
-
 /// Class uses map for storing models (name, model)
 class NODE_EDITOR_PUBLIC DataModelRegistry
 {
@@ -86,8 +77,8 @@ public:
 
   CategoriesSet const &categories() const;
 
-  TypeConverter getTypeConverter(NodeDataType const & d1,
-                                 NodeDataType const & d2) const;
+  TypeConverter getTypeConverter(NodeDataTypeId const & d1,
+                                 NodeDataTypeId const & d2) const;
 
 private:
 

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -53,7 +53,7 @@ public:
   id() const;
 
   void reactToPossibleConnection(PortType,
-                                 NodeDataType const &,
+                                 std::shared_ptr<NodeDataType>,
                                  QPointF const & scenePoint);
 
   void

--- a/include/nodes/internal/NodeData.hpp
+++ b/include/nodes/internal/NodeData.hpp
@@ -1,16 +1,59 @@
 #pragma once
 
 #include <QtCore/QString>
+#include <QtCore/QStringList>
 
 #include "Export.hpp"
+
+#include <memory>
 
 namespace QtNodes
 {
 
-struct NodeDataType
+using NodeDataTypeId = QString;
+
+class NodeDataType
 {
-  QString id;
-  QString name;
+public:
+  NodeDataType() = default;
+
+  virtual ~NodeDataType() = default;
+
+  NodeDataType(const QString& id, const QString& name)
+    : _id(id)
+    , _name(name)
+  {
+
+  }
+
+  virtual bool operator ==(const NodeDataType& other) const
+  {
+    return id() == other.id();
+  }
+
+  virtual bool operator !=(const NodeDataType& other) const
+  {
+    return !(*this == other);
+  }
+
+  virtual bool operator <(const NodeDataType& other) const
+  {
+    return id() < other.id();
+  }
+
+  NodeDataTypeId id() const
+  {
+    return _id;
+  }
+
+  QString name() const
+  {
+    return _name;
+  }
+
+private:
+  NodeDataTypeId _id;
+  QString _name;
 };
 
 /// Class represents data transferred between nodes.
@@ -24,10 +67,10 @@ public:
 
   virtual bool sameType(NodeData const &nodeData) const
   {
-    return (this->type().id == nodeData.type().id);
+    return (this->type() == nodeData.type());
   }
 
   /// Type for inner use
-  virtual NodeDataType type() const = 0;
+  virtual std::shared_ptr<NodeDataType> type() const = 0;
 };
 }

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -70,7 +70,8 @@ public:
   unsigned int nPorts(PortType portType) const = 0;
 
   virtual
-  NodeDataType dataType(PortType portType, PortIndex portIndex) const = 0;
+  std::shared_ptr<NodeDataType>
+  dataType(PortType portType, PortIndex portIndex) const = 0;
 
 public:
 

--- a/include/nodes/internal/NodeState.hpp
+++ b/include/nodes/internal/NodeState.hpp
@@ -64,15 +64,14 @@ public:
   PortType
   reactingPortType() const;
 
-  NodeDataType
+  std::shared_ptr<NodeDataType>
   reactingDataType() const;
 
   void
   setReaction(ReactToConnectionState reaction,
               PortType reactingPortType = PortType::None,
-
-              NodeDataType reactingDataType =
-                NodeDataType());
+              std::shared_ptr<NodeDataType> reactingDataType =
+                std::make_shared<NodeDataType>());
 
   bool
   isReacting() const;
@@ -90,7 +89,7 @@ private:
 
   ReactToConnectionState _reaction;
   PortType     _reactingPortType;
-  NodeDataType _reactingDataType;
+  std::shared_ptr<NodeDataType> _reactingDataType;
 
   bool _resizing;
 };

--- a/include/nodes/internal/TypeConverter.hpp
+++ b/include/nodes/internal/TypeConverter.hpp
@@ -16,6 +16,6 @@ using TypeConverter =
 
 // data-type-in, data-type-out
 using TypeConverterId =
-  std::pair<NodeDataType, NodeDataType>;
+  std::pair<NodeDataTypeId, NodeDataTypeId>;
 
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -100,9 +100,9 @@ save() const
       auto getTypeJson = [this](PortType type)
       {
         QJsonObject typeJson;
-        NodeDataType nodeType = this->dataType(type);
-        typeJson["id"] = nodeType.id;
-        typeJson["name"] = nodeType.name;
+        auto nodeType = this->dataType(type);
+        typeJson["id"] = nodeType->id();
+        typeJson["name"] = nodeType->name();
 
         return typeJson;
       };
@@ -369,7 +369,7 @@ clearNode(PortType portType)
 }
 
 
-NodeDataType
+std::shared_ptr<NodeDataType>
 Connection::
 dataType(PortType portType) const
 {

--- a/src/ConnectionPainter.cpp
+++ b/src/ConnectionPainter.cpp
@@ -199,10 +199,10 @@ drawNormalLine(QPainter * painter,
     auto dataTypeOut = connection.dataType(PortType::Out);
     auto dataTypeIn = connection.dataType(PortType::In);
 
-    gradientColor = (dataTypeOut.id != dataTypeIn.id);
+    gradientColor = (*dataTypeOut != *dataTypeIn);
 
-    normalColorOut  = connectionStyle.normalColor(dataTypeOut.id);
-    normalColorIn   = connectionStyle.normalColor(dataTypeIn.id);
+    normalColorOut  = connectionStyle.normalColor(dataTypeOut->id());
+    normalColorIn   = connectionStyle.normalColor(dataTypeIn->id());
     selectedColor = normalColorOut.darker(200);
   }
 

--- a/src/DataModelRegistry.cpp
+++ b/src/DataModelRegistry.cpp
@@ -49,8 +49,8 @@ categories() const
 
 TypeConverter
 DataModelRegistry::
-getTypeConverter(NodeDataType const & d1,
-                 NodeDataType const & d2) const
+getTypeConverter(NodeDataTypeId const & d1,
+                 NodeDataTypeId const & d2) const
 {
   TypeConverterId converterId = std::make_pair(d1, d2);
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -159,7 +159,7 @@ restoreConnection(QJsonObject const &connectionJson)
                              converterJson["out"].toObject()["name"].toString() };
 
       auto converter  =
-        registry().getTypeConverter(outType, inType);
+        registry().getTypeConverter(outType.id(), inType.id());
 
       if (converter)
         return converter;

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -90,7 +90,7 @@ id() const
 void
 Node::
 reactToPossibleConnection(PortType reactingPortType,
-                          NodeDataType const &reactingDataType,
+                          std::shared_ptr<NodeDataType> reactingDataType,
                           QPointF const &scenePoint)
 {
   QTransform const t = _nodeGraphicsObject->sceneTransform();

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -68,17 +68,17 @@ canConnect(PortIndex &portIndex, TypeConverter & converter) const
     _connection->dataType(oppositePort(requiredPort));
 
   auto const   &modelTarget = _node->nodeDataModel();
-  NodeDataType candidateNodeDataType = modelTarget->dataType(requiredPort, portIndex);
+  auto candidateNodeDataType = modelTarget->dataType(requiredPort, portIndex);
 
-  if (connectionDataType.id != candidateNodeDataType.id)
+  if (*connectionDataType != *candidateNodeDataType)
   {
     if (requiredPort == PortType::In)
     {
-      converter = _scene->registry().getTypeConverter(connectionDataType, candidateNodeDataType);
+      converter = _scene->registry().getTypeConverter(connectionDataType->id(), candidateNodeDataType->id());
     }
     else if (requiredPort == PortType::Out)
     {
-      converter = _scene->registry().getTypeConverter(candidateNodeDataType , connectionDataType);
+      converter = _scene->registry().getTypeConverter(candidateNodeDataType->id(), connectionDataType->id());
     }
 
     return (converter != nullptr);

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -335,7 +335,7 @@ portWidth(PortType portType) const
     }
     else
     {
-      name = _dataModel->dataType(portType, i).name;
+      name = _dataModel->dataType(portType, i)->name();
     }
 
     width = std::max(unsigned(_fontMetrics.width(name)),

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -145,15 +145,15 @@ drawConnectionPoints(QPainter* painter,
         {
           if (portType == PortType::In)
           {
-            typeConvertable = scene.registry().getTypeConverter(state.reactingDataType(), dataType) != nullptr;
+            typeConvertable = scene.registry().getTypeConverter(state.reactingDataType()->id(), dataType->id()) != nullptr;
           }
           else
           {
-            typeConvertable = scene.registry().getTypeConverter(dataType, state.reactingDataType()) != nullptr;
+            typeConvertable = scene.registry().getTypeConverter(dataType->id(), state.reactingDataType()->id()) != nullptr;
           }
         }
 
-        if (state.reactingDataType().id == dataType.id || typeConvertable)
+        if (*state.reactingDataType() == *dataType || typeConvertable)
         {
           double const thres = 40.0;
           r = (dist < thres) ?
@@ -171,7 +171,7 @@ drawConnectionPoints(QPainter* painter,
 
       if (connectionStyle.useDataDefinedColors())
       {
-        painter->setBrush(connectionStyle.normalColor(dataType.id));
+        painter->setBrush(connectionStyle.normalColor(dataType->id()));
       }
       else
       {
@@ -212,7 +212,7 @@ drawFilledConnectionPoints(QPainter * painter,
 
         if (connectionStyle.useDataDefinedColors())
         {
-          QColor const c = connectionStyle.normalColor(dataType.id);
+          QColor const c = connectionStyle.normalColor(dataType->id());
           painter->setPen(c);
           painter->setBrush(c);
         }
@@ -302,7 +302,7 @@ drawEntryLabels(QPainter * painter,
       }
       else
       {
-        s = model->dataType(portType, i).name;
+        s = model->dataType(portType, i)->name();
       }
 
       auto rect = metrics.boundingRect(s);

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -92,9 +92,7 @@ reactingPortType() const
 }
 
 
-NodeDataType
-NodeState::
-reactingDataType() const
+std::shared_ptr<QtNodes::NodeDataType> NodeState::reactingDataType() const
 {
   return _reactingDataType;
 }
@@ -104,7 +102,7 @@ void
 NodeState::
 setReaction(ReactToConnectionState reaction,
             PortType reactingPortType,
-            NodeDataType reactingDataType)
+            std::shared_ptr<NodeDataType> reactingDataType)
 {
   _reaction = reaction;
 


### PR DESCRIPTION
This is needed when DataType is not a simple data object,
but a larger and smarter object that should not be copied by value.
Having it as a pointer with virtual operators allows the model to
extend it and control the operations done with it (in NodeConnectionInteraction::canConnect, etc),
where TypeConverter is not possible to use.