### PR TITLE
Make deleteConnection take const.

### DIFF
--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -54,7 +54,7 @@ public:
 
   std::shared_ptr<Connection> restoreConnection(QJsonObject const &connectionJson);
 
-  void deleteConnection(Connection& connection);
+  void deleteConnection(const Connection& connection);
 
   Node&createNode(std::unique_ptr<NodeDataModel> && dataModel);
 

--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -54,7 +54,7 @@ public:
 
   std::shared_ptr<Connection> restoreConnection(QJsonObject const &connectionJson);
 
-  void deleteConnection(const Connection& connection);
+  void deleteConnection(Connection const& connection);
 
   Node&createNode(std::unique_ptr<NodeDataModel> && dataModel);
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -182,7 +182,7 @@ restoreConnection(QJsonObject const &connectionJson)
 
 void
 FlowScene::
-deleteConnection(const Connection& connection)
+deleteConnection(Connection const& connection)
 {
   auto it = _connections.find(connection.id());
   if (it != _connections.end()) {

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -182,7 +182,7 @@ restoreConnection(QJsonObject const &connectionJson)
 
 void
 FlowScene::
-deleteConnection(Connection& connection)
+deleteConnection(const Connection& connection)
 {
   auto it = _connections.find(connection.id());
   if (it != _connections.end()) {


### PR DESCRIPTION
A few months ago a change was made which meant the FlowScene::connectionCreated signal provided a const connection. Unfortunately, this meant I can't later use it to call deleteConnection, which currently expects non-const. This change makes delete connection take a const& connection.