### PR TITLE
Mimimum expanding widgets

### DIFF
--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -106,6 +106,10 @@ public:
   QPointF
   widgetPosition() const;
 
+  /// Returns the maximum height a widget can be without causing the node to grow.
+  int
+  equivalentWidgetHeight() const;
+
   unsigned int
   validationHeight() const;
 

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -241,7 +241,7 @@ widgetPosition() const
 {
   if (auto w = _dataModel->embeddedWidget())
   {
-    if (w->sizePolicy().verticalPolicy() == QSizePolicy::MinimumExpanding)
+    if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag)
     {
       // If the widget wants to use as much vertical space as possible, place it immediately after the caption.
       return QPointF(_spacing + portWidth(PortType::In), captionHeight());

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -241,19 +241,37 @@ widgetPosition() const
 {
   if (auto w = _dataModel->embeddedWidget())
   {
-    if (_dataModel->validationState() != NodeValidationState::Valid)
+    if (w->sizePolicy().verticalPolicy() == QSizePolicy::MinimumExpanding)
     {
-      return QPointF(_spacing + portWidth(PortType::In),
-                     (captionHeight() + _height - validationHeight() - _spacing - w->height()) / 2.0);
+      // If the widget wants to use as much vertical space as possible, place it immediately after the caption.
+      return QPointF(_spacing + portWidth(PortType::In), captionHeight());
     }
+    else
+    {
+      if (_dataModel->validationState() != NodeValidationState::Valid)
+      {
+        return QPointF(_spacing + portWidth(PortType::In),
+                      (captionHeight() + _height - validationHeight() - _spacing - w->height()) / 2.0);
+      }
 
-    return QPointF(_spacing + portWidth(PortType::In),
-                   (captionHeight() + _height - w->height()) / 2.0);
+      return QPointF(_spacing + portWidth(PortType::In), 
+                    (captionHeight() + _height - w->height()) / 2.0);
+    }
   }
-
   return QPointF();
 }
 
+int
+NodeGeometry::
+equivalentWidgetHeight() const
+{
+  if (_dataModel->validationState() != NodeValidationState::Valid)
+  {
+    return height() - captionHeight() + validationHeight();
+  }
+
+  return height() - captionHeight();
+}
 
 unsigned int
 NodeGeometry::

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -107,6 +107,12 @@ embedQWidget()
 
     geom.recalculateSize();
 
+    if (w->sizePolicy().verticalPolicy() == QSizePolicy::MinimumExpanding)
+    {
+      // If the widget wants to use as much vertical space as possible, set it to have the geom's equivalentWidgetHeight.
+      _proxyWidget->setMinimumHeight(geom.equivalentWidgetHeight());
+    }
+
     _proxyWidget->setPos(geom.widgetPosition());
 
     update();

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -107,7 +107,7 @@ embedQWidget()
 
     geom.recalculateSize();
 
-    if (w->sizePolicy().verticalPolicy() == QSizePolicy::MinimumExpanding)
+    if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag)
     {
       // If the widget wants to use as much vertical space as possible, set it to have the geom's equivalentWidgetHeight.
       _proxyWidget->setMinimumHeight(geom.equivalentWidgetHeight());


### PR DESCRIPTION
In my application, I want to put QTableViews as the widget in a node. Because these widgets are scrollable,the value they return from size() is not ideal for positioning them in a node. If I have several ports, then I end up with a small scrollable table floating in the middle of a large node, rather than a table which shows the maximum number of rows using up the whole vertical space. 

This change special-cases widgets which have the "QSizePolicy::ExpandFlag" set in their SizePolicy. 
* If a widget with the expand flag is smaller than the node (because there are several ports) the widget is given the entire vertical space. 
* When the widget is taller than the space required by the ports, the behaviour the same as before.

I've attached before and after screenshots. 

Without change:
![withoutChange](https://user-images.githubusercontent.com/6072126/61998985-16841b80-b0b0-11e9-8064-dca47b450904.png)

With change:
![withChange](https://user-images.githubusercontent.com/6072126/61998986-184ddf00-b0b0-11e9-9547-bcffb782d6f6.png)

These were generated by replacing the _lineEdit in NumberSourceDataModel by a QTableWidget* _table, and replacing its constructor by:
```C++
NumberSourceDataModel::
NumberSourceDataModel()
  : _table(new QTableWidget())
{
  _table->setColumnCount(2);
  _table->setRowCount(18);
  _table->horizontalHeader()->setStretchLastSection(true);
  _table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
  _table->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
}
```

As an alternative to what I'm providing here, I tried placing a QVBoxLayout into every node, and having it manage the inner widget. I just could not get it to work, although note that I am not a Qt guru. To be honest, I actually prefer the low-level approach I've taken. Firstly, it is more consistent with the current nodeeditor code, and secondly, it strictly implements the desired behaviour. An approach exploiting Qt components would probably require many layout and sizing operations to get just the desired behaviour, which I would consider brittle.