### PR TITLE
Hide ports with a null type.

### DIFF
--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -223,6 +223,16 @@ mousePressEvent(QGraphicsSceneMouseEvent * event)
     {
       NodeState const & nodeState = _node.nodeState();
 
+      // Ports with no data type cannot make a connection.
+      {
+        const NodeDataModel* model = _node.nodeDataModel();
+        const NodeDataType dataType = model->dataType(portToCheck, portIndex);
+        if (dataType.id.isEmpty())
+        {
+          continue;
+        }
+      }
+      
       std::unordered_map<QUuid, Connection*> connections =
         nodeState.connections(portToCheck, portIndex);
 

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -128,6 +128,12 @@ drawConnectionPoints(QPainter* painter,
 
       auto const & dataType = model->dataType(portType, i);
 
+      // Empty data types are not drawn.
+      if (dataType.id.isEmpty())
+      {
+        continue;
+      }
+
       bool canConnect = (state.getEntries(portType)[i].empty() ||
                          (portType == PortType::Out &&
                           model->portOutConnectionPolicy(i) == NodeDataModel::ConnectionPolicy::Many) );


### PR DESCRIPTION
This change allows some additional flexibility in node layout, by letting the ports in certain port positions be hidden.

The API for hiding a port is simply to have a null id.

No port graphics are drawn and no connection can be made to or from such a port.

In the attached image, there are five out ports, but the second and third have a null id and name.

![hiddenPorts](https://user-images.githubusercontent.com/6072126/62077380-deacdd80-b241-11e9-8be4-b20b42ff2536.png)

As well has having null id and null name, you can also have a null id with a meaningful name. In this case, the port name is drawn, but the port is not. A use-case for this might arise where you have set of very similar node types, so you want them all to have the same layout, but not all ports are active in every node type.