### PR TITLE
Dynamic port number

### DIFF
--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -150,6 +150,8 @@ private Q_SLOTS:
   void sendConnectionCreatedToNodes(Connection const& c);
   void sendConnectionDeletedToNodes(Connection const& c);
 
+  void killConnection(Connection& connection);
+
 };
 
 Node*

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -107,6 +107,12 @@ public Q_SLOTS: // data propagation
   onPortCountChanged();
 
 private:
+  /// Recalculate the nodes visuals. A data change can result in the node
+  /// taking more space than before, so this forces a recalculate+repaint on
+  /// the affected node
+  void recalculateVisuals() const;
+
+private:
 
   // addressing
 

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -101,6 +101,11 @@ public Q_SLOTS: // data propagation
   void
   onNodeSizeUpdated();
 
+  /// Reallocate NodeState's connection sets to account for the new number of
+  /// input/output ports
+  void
+  onPortCountChanged();
+
 private:
 
   // addressing

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -103,8 +103,20 @@ public Q_SLOTS: // data propagation
 
   /// Reallocate NodeState's connection sets to account for the new number of
   /// input/output ports
+  /// NB: There is no general way of knowing how to maintain connections when
+  /// port count changes, especially when the removed ones are not the last
+  /// one, resulting in port shift that may plug connections of the wrong data
+  /// type. For now, the best thing to do is to first remove all connections,
+  /// change port count and then rebuild the connections appropriately, all of
+  /// this from the node's data model. A more generic solution would be to
+  /// split this port into insertPorts(row, count) and removePorts(row, count)
   void
   onPortCountChanged();
+
+Q_SIGNALS:
+  /// Ask flow scene to remove this connection
+  void
+  killConnection(Connection& connection);
 
 private:
   /// Recalculate the nodes visuals. A data change can result in the node

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -152,6 +152,9 @@ Q_SIGNALS:
   dataUpdated(PortIndex index);
 
   void
+  portCountChanged();
+
+  void
   dataInvalidated(PortIndex index);
 
   void

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -148,9 +148,13 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 
+  /// Emit this when the output 'index' needs to be recomputed/queried by a
+  /// call to ouData
   void
   dataUpdated(PortIndex index);
 
+  /// Emit when the number of input or output ports has changed, or when their
+  /// data type changed.
   void
   portCountChanged();
 
@@ -163,7 +167,8 @@ Q_SIGNALS:
   void
   computingFinished();
 
-  void embeddedWidgetSizeUpdated();
+  void
+  embeddedWidgetSizeUpdated();
 
 private:
 

--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -64,6 +64,9 @@ public:
   unsigned int
   nSinks() const;
 
+  void
+  updatePortCount();
+
   QPointF const&
   draggingPos() const
   { return _draggingPos; }

--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -152,6 +152,10 @@ private:
 
   bool _hovered;
 
+  // TODO: Do we really need to keep these? The information can be accessed any
+  // time through _dataModel and is used only on geometry update. If we remove
+  // this, we can get rid of updatePortCount() (and its use in
+  // Node::onPortCountChanged)
   unsigned int _nSources;
   unsigned int _nSinks;
 

--- a/include/nodes/internal/NodeState.hpp
+++ b/include/nodes/internal/NodeState.hpp
@@ -83,6 +83,9 @@ public:
   bool
   resizing() const;
 
+  void
+  updatePortCount(int inPorts, int outPorts);
+
 private:
 
   std::vector<ConnectionPtrSet> _inConnections;

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -202,6 +202,7 @@ createNode(std::unique_ptr<NodeDataModel> && dataModel)
   node->setGraphicsObject(std::move(ngo));
 
   auto nodePtr = node.get();
+  connect(nodePtr, &Node::killConnection, this, &FlowScene::deleteConnection);
   _nodes[node->id()] = std::move(node);
 
   nodeCreated(*nodePtr);
@@ -228,6 +229,7 @@ restoreNode(QJsonObject const& nodeJson)
   node->restore(nodeJson);
 
   auto nodePtr = node.get();
+  connect(nodePtr, &Node::killConnection, this, &FlowScene::deleteConnection);
   _nodes[node->id()] = std::move(node);
 
   nodePlaced(*nodePtr);
@@ -337,7 +339,7 @@ iterateOverNodeDataDependentOrder(std::function<void(NodeDataModel*)> const & vi
     {
       for (size_t i = 0; i < model.nPorts(PortType::In); ++i)
       {
-        auto connections = node.nodeState().connections(PortType::In, i);
+        auto connections = node.nodeState().connections(PortType::In, static_cast<PortIndex>(i));
 
         for (auto& conn : connections)
         {
@@ -621,6 +623,13 @@ sendConnectionDeletedToNodes(Connection const& c)
 
   from->nodeDataModel()->outputConnectionDeleted(c);
   to->nodeDataModel()->inputConnectionDeleted(c);
+}
+
+void
+FlowScene::
+killConnection(Connection& connection)
+{
+	deleteConnection(connection);
 }
 
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -39,6 +39,9 @@ Node(std::unique_ptr<NodeDataModel> && dataModel)
 
   connect(_nodeDataModel.get(), &NodeDataModel::embeddedWidgetSizeUpdated,
           this, &Node::onNodeSizeUpdated );
+
+  connect(_nodeDataModel.get(), &NodeDataModel::portCountChanged,
+          this, &Node::onPortCountChanged);
 }
 
 
@@ -230,4 +233,15 @@ onNodeSizeUpdated()
             }
         }
     }
+}
+
+void
+Node::
+onPortCountChanged()
+{
+	// TODO: delete links to removed ports
+	_nodeState.updatePortCount(_nodeDataModel->nPorts(PortType::In),
+		                       _nodeDataModel->nPorts(PortType::Out));
+	nodeGeometry().updatePortCount();
+	onNodeSizeUpdated();
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -235,9 +235,21 @@ void
 Node::
 onPortCountChanged()
 {
-	// TODO: delete links to removed ports
+	// Remove connections
+	for (auto portType : {PortType::In, PortType::Out}) {
+		auto & entries = _nodeState.getEntries(portType);
+		int oldCount = static_cast<int>(entries.size());
+		int newCount = _nodeDataModel->nPorts(portType);
+		for (PortIndex index = newCount ; index < oldCount ; ++index) {
+			auto connections = entries[index];
+			for (auto const & c : connections) {
+				Q_EMIT killConnection(*c.second);
+			}
+		}
+	}
+	
 	_nodeState.updatePortCount(_nodeDataModel->nPorts(PortType::In),
-		                       _nodeDataModel->nPorts(PortType::Out));
+	                           _nodeDataModel->nPorts(PortType::Out));
 	nodeGeometry().updatePortCount();
 	recalculateVisuals();
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -192,11 +192,7 @@ propagateData(std::shared_ptr<NodeData> nodeData,
 {
   _nodeDataModel->setInData(std::move(nodeData), inPortIndex);
 
-  //Recalculate the nodes visuals. A data change can result in the node taking more space than before, so this forces a recalculate+repaint on the affected node
-  _nodeGraphicsObject->setGeometryChanged();
-  _nodeGeometry.recalculateSize();
-  _nodeGraphicsObject->update();
-  _nodeGraphicsObject->moveConnections();
+  recalculateVisuals();
 }
 
 
@@ -243,5 +239,15 @@ onPortCountChanged()
 	_nodeState.updatePortCount(_nodeDataModel->nPorts(PortType::In),
 		                       _nodeDataModel->nPorts(PortType::Out));
 	nodeGeometry().updatePortCount();
-	onNodeSizeUpdated();
+	recalculateVisuals();
+}
+
+void
+Node::
+recalculateVisuals() const
+{
+  _nodeGraphicsObject->setGeometryChanged();
+  _nodeGeometry.recalculateSize();
+  _nodeGraphicsObject->update();
+  _nodeGraphicsObject->moveConnections();
 }

--- a/src/NodeGeometry.cpp
+++ b/src/NodeGeometry.cpp
@@ -50,6 +50,13 @@ NodeGeometry::nSinks() const
   return _dataModel->nPorts(PortType::In);
 }
 
+void
+NodeGeometry::updatePortCount()
+{
+	_nSources = _dataModel->nPorts(PortType::Out);
+	_nSinks = _dataModel->nPorts(PortType::In);
+}
+
 QRectF
 NodeGeometry::
 entryBoundingRect() const

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -204,11 +204,12 @@ drawFilledConnectionPoints(QPainter * painter,
 
     for (size_t i = 0; i < n; ++i)
     {
-      QPointF p = geom.portScenePosition(i, portType);
+      PortIndex portIndex = static_cast<PortIndex>(i);
+      QPointF p = geom.portScenePosition(portIndex, portType);
 
       if (!state.getEntries(portType)[i].empty())
       {
-        auto const & dataType = model->dataType(portType, i);
+        auto const & dataType = model->dataType(portType, portIndex);
 
         if (connectionStyle.useDataDefinedColors())
         {
@@ -287,7 +288,8 @@ drawEntryLabels(QPainter * painter,
 
     for (size_t i = 0; i < n; ++i)
     {
-      QPointF p = geom.portScenePosition(i, portType);
+      PortIndex portIndex = static_cast<PortIndex>(i);
+      QPointF p = geom.portScenePosition(portIndex, portType);
 
       if (entries[i].empty())
         painter->setPen(nodeStyle.FontColorFaded);
@@ -296,13 +298,13 @@ drawEntryLabels(QPainter * painter,
 
       QString s;
 
-      if (model->portCaptionVisible(portType, i))
+      if (model->portCaptionVisible(portType, portIndex))
       {
-        s = model->portCaption(portType, i);
+        s = model->portCaption(portType, portIndex);
       }
       else
       {
-        s = model->dataType(portType, i).name;
+        s = model->dataType(portType, portIndex).name;
       }
 
       auto rect = metrics.boundingRect(s);

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -136,3 +136,11 @@ resizing() const
 {
   return _resizing;
 }
+
+void
+NodeState::
+updatePortCount(int inPorts, int outPorts)
+{
+  _inConnections.resize(inPorts);
+  _outConnections.resize(outPorts);
+}


### PR DESCRIPTION
When an operation changes the number of ports. one can emit the new signal `portCountChanged()` from a `NodeDataModel` to trigger an update of the node.

**Related issues:** This is an alternative to #209 and #212. I had not noticed that there were already PRs for this before implementing it fo another project.

**Key differences with #209:** We handle the removal of connections. This implementation does not require to add a `friend class Node`. We use a single signal instead of both `portAdded` and `portRemoved`.

**Limitations:** As noticed in the comments, the removal of connections is not perfect. It assumes that the removed ports are always the last ones, so if it is not true and port types differe, this may lead to connections between ports of different types. In the RiverList example though there would be no problem. To address this, the signal should be replaced by two different signals `portAdded` and `portRemoved` taking as arguments the index of the added/removed ports.

This also includes somes `static_cast`s to prevent msvc from raising some warnings. I can remove them if needed, as well as reduce the comments. Also, should I add an example like the river list of #209? Or some kind of unit test?

