### PR TITLE
Clearing scene only if file open doesn't fail

### DIFF
--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -500,10 +500,6 @@ void
 FlowScene::
 load()
 {
-  clearScene();
-
-  //-------------
-
   QString fileName =
     QFileDialog::getOpenFileName(nullptr,
                                  tr("Open Flow Scene"),
@@ -517,6 +513,8 @@ load()
 
   if (!file.open(QIODevice::ReadOnly))
     return;
+
+  clearScene();
 
   QByteArray wholeFile = file.readAll();
 


### PR DESCRIPTION
Currently, if a node topology file fails during load, the scene is cleared anyhow.

This fix only calls `clearScene()` after the file open check is performed.