### PR TITLE
Dynamic port nodes with saving and loading

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(connection_colors)
 
+add_subdirectory(dynamic_node)
+
 add_subdirectory(example2)
 
 add_subdirectory(calculator)

--- a/examples/dynamic_node/CMakeLists.txt
+++ b/examples/dynamic_node/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB_RECURSE CPPS  ./*.cpp )
+
+add_executable(dynamic_node ${CPPS})
+
+target_link_libraries(dynamic_node nodes)

--- a/examples/dynamic_node/RiverData.h
+++ b/examples/dynamic_node/RiverData.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <nodes/NodeData>
+
+
+using QtNodes::NodeData;
+using QtNodes::NodeDataType;
+
+
+class RiverData : public NodeData {
+public:
+    RiverData() : data_( "" ) {
+    }
+
+    explicit RiverData( const QString &s ) : data_( s ) {
+    }
+
+    NodeDataType type() const override {
+        return NodeDataType{ "River", "" };
+    }
+
+    const QString &data() const {
+        return data_;
+    }
+
+
+private:
+    QString data_;
+};

--- a/examples/dynamic_node/RiverListData.cpp
+++ b/examples/dynamic_node/RiverListData.cpp
@@ -1,0 +1,29 @@
+#include "RiverListData.h"
+
+
+RiverListData::RiverListData() {
+}
+
+
+
+
+RiverListData::d_t &
+RiverListData::data( int i ) {
+    return *std::next( data_.begin(), i );
+}
+
+
+
+
+void
+RiverListData::addBack( const d_t &d ) {
+    data_.emplace_back( d );
+}
+
+
+
+
+void RiverListData::remove( int i ) {
+    const auto it = std::next( data_.cbegin(), i );
+    data_.erase( it );
+}

--- a/examples/dynamic_node/RiverListData.h
+++ b/examples/dynamic_node/RiverListData.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <nodes/NodeData>
+#include <QCoreApplication>
+
+
+using QtNodes::NodeData;
+using QtNodes::NodeDataType;
+
+
+class RiverListData : public NodeData {
+    Q_DECLARE_TR_FUNCTIONS( RiverListData )
+
+    typedef QString d_t;
+    typedef std::vector< d_t > data_t;
+
+
+public:
+    RiverListData();
+
+    NodeDataType type() const override {
+        const QString name = tr( "RiverList" );
+        return NodeDataType{ "RiverList", name };
+    }
+
+    const data_t &data() const {
+        return data_;
+    }
+
+    d_t &data( int i );
+
+    void addBack( const d_t & );
+
+    void remove( int i );
+
+
+private:
+    data_t data_;
+};

--- a/examples/dynamic_node/RiverListModel.cpp
+++ b/examples/dynamic_node/RiverListModel.cpp
@@ -1,0 +1,106 @@
+#include "RiverListModel.h"
+#include "RiverData.h"
+
+
+RiverListModel::RiverListModel() :
+    data_( new RiverListData )
+{
+    data_->addBack( "" );
+}
+
+
+
+
+RiverListModel::~RiverListModel() {
+}
+
+
+
+
+unsigned int
+RiverListModel::nPorts( PortType portType ) const {
+
+    switch ( portType ) {
+        case PortType::In:
+            return data_->data().size();
+
+        case PortType::Out:
+            return 1;
+    }
+
+    return 0;
+}
+
+
+
+
+QString
+RiverListModel::portCaption( PortType portType, PortIndex portIndex ) const {
+
+    if ( portType == PortType::In ) {
+        const QString text = data_->data( portIndex );
+        return QString::number( portIndex + 1 ) + ") " + text;
+    }
+
+    return "";
+}
+
+
+
+
+NodeDataType
+RiverListModel::dataType( PortType portType, PortIndex ) const {
+
+    switch ( portType ) {
+        case PortType::In:
+            return RiverData().type();
+
+        case PortType::Out:
+            return RiverListData().type();
+    }
+
+    return RiverData().type();
+}
+
+
+
+
+std::shared_ptr< NodeData >
+RiverListModel::outData( PortIndex ) {
+    return data_;
+}
+
+
+
+
+void
+RiverListModel::setInData( std::shared_ptr< NodeData > nd, PortIndex portIndex ) {
+
+    const auto v = std::dynamic_pointer_cast< RiverData >( nd );
+    if ( !v ) {
+        // data removed (disconnected)
+        // \todo We have the problems when reassign connections. Not good.
+        if ( portIndex < data_->data().size() ) {
+            data_->remove( portIndex );
+            emit portRemoved();
+        }
+        return;
+    }
+
+    // data added (connected)
+    data_->data( portIndex ) = v->data();
+
+    // always add one more river when last input port connected
+    if ( portIndex == (data_->data().size() - 1) ) {
+        data_->addBack( "" );
+        emit portAdded();
+    }
+}
+
+
+
+
+QWidget *
+RiverListModel::embeddedWidget() {
+    return nullptr;
+}

--- a/examples/dynamic_node/RiverListModel.h
+++ b/examples/dynamic_node/RiverListModel.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "RiverListData.h"
+#include <nodes/NodeData>
+#include <nodes/NodeDataModel>
+#include <memory>
+#include <QCoreApplication>
+
+
+using QtNodes::NodeData;
+using QtNodes::NodeDataModel;
+using QtNodes::NodeDataType;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
+
+
+class RiverListModel : public NodeDataModel {
+    Q_DECLARE_TR_FUNCTIONS( RiverListModel )
+
+
+public:
+    RiverListModel();
+
+    virtual ~RiverListModel() override;
+
+
+public:
+    QString caption() const override {
+        return tr( "RiverList" );
+    }
+
+    bool captionVisible() const override {
+        return true;
+    }
+
+    QString name() const override {
+        return "RiverList";
+    }
+
+    unsigned int nPorts( PortType ) const override;
+
+    QString portCaption( PortType, PortIndex ) const override;
+
+    bool portCaptionVisible( PortType, PortIndex ) const override {
+        return true;
+    }
+
+    NodeDataType dataType( PortType, PortIndex ) const override;
+
+    ConnectionPolicy portOutConnectionPolicy( PortIndex ) const override {
+      return ConnectionPolicy::One;
+    }
+
+    std::shared_ptr< NodeData > outData( PortIndex ) override;
+
+    void setInData( std::shared_ptr< NodeData >, PortIndex ) override;
+
+    QWidget *embeddedWidget() override;
+
+
+private:
+  std::shared_ptr< RiverListData > data_;
+};

--- a/examples/dynamic_node/RiverModel.cpp
+++ b/examples/dynamic_node/RiverModel.cpp
@@ -1,0 +1,76 @@
+#include "RiverModel.h"
+
+
+RiverModel::RiverModel() :
+    data_( new RiverData() ),
+    lineEdit_( new QLineEdit() )
+{
+  lineEdit_->setMaximumSize( lineEdit_->sizeHint() );
+  connect( lineEdit_, &QLineEdit::textChanged,
+          this, &RiverModel::onTextEdited);
+}
+
+
+
+
+RiverModel::~RiverModel() {
+}
+
+
+
+
+unsigned int
+RiverModel::nPorts( PortType portType ) const {
+
+    switch ( portType ) {
+        case PortType::In:
+            return 0;
+
+        case PortType::Out:
+            return 1;
+    }
+
+    return 0;
+}
+
+
+
+
+NodeDataType
+RiverModel::dataType( PortType, PortIndex ) const {
+    return RiverData().type();
+}
+
+
+
+
+std::shared_ptr< NodeData >
+RiverModel::outData( PortIndex ) {
+    return data_;
+}
+
+
+
+
+void
+RiverModel::setInData( std::shared_ptr< NodeData >, PortIndex ) {
+}
+
+
+
+
+QWidget *
+RiverModel::embeddedWidget() {
+    return lineEdit_;
+}
+
+
+
+
+void
+RiverModel::onTextEdited( const QString &s ) {
+
+    data_.reset( new RiverData( s ) );
+    constexpr PortIndex portIndex = 0;
+    emit dataUpdated( portIndex );
+}

--- a/examples/dynamic_node/RiverModel.h
+++ b/examples/dynamic_node/RiverModel.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "RiverData.h"
+#include <nodes/NodeData>
+#include <nodes/NodeDataModel>
+#include <memory>
+#include <QLineEdit>
+#include <QCoreApplication>
+
+
+using QtNodes::NodeData;
+using QtNodes::NodeDataModel;
+using QtNodes::NodeDataType;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
+
+
+class RiverModel : public NodeDataModel {
+    Q_DECLARE_TR_FUNCTIONS( RiverModel )
+
+
+public:
+    RiverModel();
+
+    virtual ~RiverModel() override;
+
+
+public:
+    QString caption() const override {
+        return tr( "River" );
+    }
+
+    bool captionVisible() const override {
+        return false;
+    }
+
+    QString name() const override {
+        return "River";
+    }
+
+    unsigned int nPorts( PortType ) const override;
+
+    NodeDataType dataType( PortType, PortIndex ) const override;
+
+    ConnectionPolicy portOutConnectionPolicy( PortIndex ) const override {
+      return ConnectionPolicy::One;
+    }
+
+    std::shared_ptr< NodeData > outData( PortIndex ) override;
+
+    void setInData( std::shared_ptr< NodeData >, PortIndex ) override;
+
+    QWidget *embeddedWidget() override;
+
+
+private slots:
+  void onTextEdited( const QString & );
+
+
+private:
+  std::shared_ptr< RiverData > data_;
+  QLineEdit *lineEdit_;
+};

--- a/examples/dynamic_node/main.cpp
+++ b/examples/dynamic_node/main.cpp
@@ -1,0 +1,43 @@
+#include <QtWidgets/QApplication>
+
+#include <nodes/NodeData>
+#include <nodes/FlowScene>
+#include <nodes/FlowView>
+#include <nodes/DataModelRegistry>
+
+#include "RiverListModel.h"
+#include "RiverModel.h"
+
+
+using QtNodes::DataModelRegistry;
+using QtNodes::FlowScene;
+using QtNodes::FlowView;
+
+
+static std::shared_ptr<DataModelRegistry>
+registerDataModels()
+{
+  auto ret = std::make_shared<DataModelRegistry>();
+
+  ret->registerModel<RiverListModel>();
+  ret->registerModel<RiverModel>();
+
+  return ret;
+}
+
+
+int
+main(int argc, char* argv[])
+{
+  QApplication app(argc, argv);
+
+  FlowScene scene(registerDataModels());
+
+  FlowView view(&scene);
+
+  view.setWindowTitle("Dynamic ports example");
+  view.resize(800, 600);
+  view.show();
+
+  return app.exec();
+}

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -97,9 +97,20 @@ public Q_SLOTS: // data propagation
   void
   onDataUpdated(PortIndex index);
 
-  /// update the graphic part if the size of the embeddedwidget changes
+  /// Port added to the end.
   void
-  onNodeSizeUpdated();
+  onPortAdded();
+
+  /// Port removed from the end.
+  void
+  onPortRemoved();
+
+protected:
+
+  /// Recalculates the nodes images.
+  /// A data change can result in the node taking more space than before,
+  /// so this forces a recalculate + repaint on the affected node.
+  void recalculateVisuals() const;
 
 private:
 

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -160,7 +160,11 @@ Q_SIGNALS:
   void
   computingFinished();
 
-  void embeddedWidgetSizeUpdated();
+  void
+  portAdded();
+
+  void
+  portRemoved();
 
 private:
 

--- a/include/nodes/internal/NodeGeometry.hpp
+++ b/include/nodes/internal/NodeGeometry.hpp
@@ -158,5 +158,7 @@ private:
 
   mutable QFontMetrics _fontMetrics;
   mutable QFontMetrics _boldFontMetrics;
+
+  friend class Node;
 };
 }

--- a/include/nodes/internal/NodeState.hpp
+++ b/include/nodes/internal/NodeState.hpp
@@ -93,5 +93,7 @@ private:
   NodeDataType _reactingDataType;
 
   bool _resizing;
+
+  friend class Node;
 };
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -60,6 +60,8 @@ save() const
   obj["x"] = _nodeGraphicsObject->pos().x();
   obj["y"] = _nodeGraphicsObject->pos().y();
   nodeJson["position"] = obj;
+  nodeJson["in"]  = (int)_nodeDataModel->nPorts(PortType::In);
+  nodeJson["out"] = (int)_nodeDataModel->nPorts(PortType::Out);
 
   return nodeJson;
 }
@@ -77,6 +79,11 @@ restore(QJsonObject const& json)
   _nodeGraphicsObject->setPos(point);
 
   _nodeDataModel->restore(json["model"].toObject());
+
+  if(json.contains("in"))
+    _nodeState._inConnections.resize(json["in"].toInt());
+  if(json.contains("out"))
+    _nodeState._outConnections.resize(json["out"].toInt());
 }
 
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -36,9 +36,10 @@ Node(std::unique_ptr<NodeDataModel> && dataModel)
   // propagate data: model => node
   connect(_nodeDataModel.get(), &NodeDataModel::dataUpdated,
           this, &Node::onDataUpdated);
-
-  connect(_nodeDataModel.get(), &NodeDataModel::embeddedWidgetSizeUpdated,
-          this, &Node::onNodeSizeUpdated );
+  connect(_nodeDataModel.get(), &NodeDataModel::portAdded,
+          this, &Node::onPortAdded);
+  connect(_nodeDataModel.get(), &NodeDataModel::portRemoved,
+          this, &Node::onPortRemoved);
 }
 
 
@@ -189,11 +190,7 @@ propagateData(std::shared_ptr<NodeData> nodeData,
 {
   _nodeDataModel->setInData(std::move(nodeData), inPortIndex);
 
-  //Recalculate the nodes visuals. A data change can result in the node taking more space than before, so this forces a recalculate+repaint on the affected node
-  _nodeGraphicsObject->setGeometryChanged();
-  _nodeGeometry.recalculateSize();
-  _nodeGraphicsObject->update();
-  _nodeGraphicsObject->moveConnections();
+  recalculateVisuals();
 }
 
 
@@ -212,22 +209,54 @@ onDataUpdated(PortIndex index)
 
 void
 Node::
-onNodeSizeUpdated()
+onPortAdded()
 {
-    if( nodeDataModel()->embeddedWidget() )
-    {
-        nodeDataModel()->embeddedWidget()->adjustSize();
-    }
-    nodeGeometry().recalculateSize();
-    for(PortType type: {PortType::In, PortType::Out})
-    {
-        for(auto& conn_set : nodeState().getEntries(type))
-        {
-            for(auto& pair: conn_set)
-            {
-                Connection* conn = pair.second;
-                conn->getConnectionGraphicsObject().move();
-            }
-        }
-    }
+  // port In
+  const unsigned int nNewIn = _nodeDataModel->nPorts(PortType::In);
+  _nodeGeometry._nSources = nNewIn;
+  _nodeState._inConnections.resize( nNewIn );
+
+  // port Out
+  const unsigned int nNewOut = _nodeDataModel->nPorts(PortType::Out);
+  _nodeGeometry._nSinks = nNewOut;
+  _nodeState._outConnections.resize( nNewOut );
+
+  //Recalculate the nodes visuals. A data change can result in the node taking more space than before, so this forces a recalculate+repaint on the affected node
+  _nodeGraphicsObject->setGeometryChanged();
+  _nodeGeometry.recalculateSize();
+  _nodeGraphicsObject->update();
+
+  recalculateVisuals();
+}
+
+
+void
+Node::
+onPortRemoved()
+{
+  // port In
+  const unsigned int nNewIn = _nodeDataModel->nPorts(PortType::In);
+  _nodeGeometry._nSources = nNewIn;
+  _nodeState._inConnections.resize( nNewIn );
+  // \todo Remove the lost connections.
+
+  // port Out
+  const unsigned int nNewOut = _nodeDataModel->nPorts(PortType::Out);
+  _nodeGeometry._nSinks = nNewOut;
+  _nodeState._outConnections.resize( nNewOut );
+  // \todo Remove the lost connections.
+
+  recalculateVisuals();
+}
+
+
+void
+Node::
+recalculateVisuals() const
+{
+  //Recalculate the nodes visuals. A data change can result in the node taking more space than before, so this forces a recalculate+repaint on the affected node
+  _nodeGraphicsObject->setGeometryChanged();
+  _nodeGeometry.recalculateSize();
+  _nodeGraphicsObject->update();
+  _nodeGraphicsObject->moveConnections();
 }


### PR DESCRIPTION
Small fix to the dynamic port nodes PR https://github.com/paceholder/nodeeditor/pull/209 by @signmotion to work with loading and saving of scenes.

Input/Output connection vectors in NodeState would go out of range when loading scenes containing nodes with dynamically set number of ports. I added additional key/value pairs to the saved JSON files which will determine the number of connections of the restored nodes. 