### PR TITLE
Models can now be unregisted from DataModelRegistry

### DIFF
--- a/include/nodes/internal/DataModelRegistry.hpp
+++ b/include/nodes/internal/DataModelRegistry.hpp
@@ -72,21 +72,27 @@ public:
     registerModelImpl<ModelType>(std::move(creator), category);
   }
 
+  void unregisterModel(QString const &name)
+  {
+	  _registeredItemCreators.erase(name);
+	  _registeredModelsCategory.erase(name);
+  }
+
   void registerTypeConverter(TypeConverterId const & id,
                              TypeConverter typeConverter)
   {
     _registeredTypeConverters[id] = std::move(typeConverter);
   }
 
-  std::unique_ptr<NodeDataModel>create(QString const &modelName);
+  virtual std::unique_ptr<NodeDataModel>create(QString const &modelName);
 
-  RegisteredModelCreatorsMap const &registeredModelCreators() const;
+  virtual RegisteredModelCreatorsMap const &registeredModelCreators() const;
 
-  RegisteredModelsCategoryMap const &registeredModelsCategoryAssociation() const;
+  virtual RegisteredModelsCategoryMap const &registeredModelsCategoryAssociation() const;
 
-  CategoriesSet const &categories() const;
+  virtual CategoriesSet const &categories() const;
 
-  TypeConverter getTypeConverter(NodeDataType const & d1,
+  virtual TypeConverter getTypeConverter(NodeDataType const & d1,
                                  NodeDataType const & d2) const;
 
 private:


### PR DESCRIPTION
I also made some of the interface methods virtual because I need to override them in my application