### PR TITLE
Clazy cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.py
 *.pyc
 CMakeLists.txt.user
+build/*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 ### About this Fork
 
 This repository keeps master branch aligned with the original repository [paceholder/nodeeditor](https://github.com/paceholder/nodeeditor).
-In the develop branch can be found some fix or feature never merged in the original repository and some additional feature.
 
+In the **develop branch** can be found some fix or feature never merged in the original repository and some additional feature.
+The status of the current improvements can be found in issues tracker. 
+However the main changes involve:
+* Copy/paste functionality.
+* Allow multiple connection for a single input port.
+* Subcategories for nodes.
+* Dynamic ports nodes.
 
 ### Purpose
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-### About this Fork
-
-This repository keeps master branch aligned with the original repository [paceholder/nodeeditor](https://github.com/paceholder/nodeeditor).
-
-In the **develop branch** can be found some fix or feature never merged in the original repository and some additional feature.
-The status of the current improvements can be found in issues tracker. 
-However the main changes involve:
-* Copy/paste functionality.
-* Allow multiple connection for a single input port.
-* Subcategories for nodes.
-* Dynamic ports nodes.
-
 ### Purpose
 
 **NodeEditor** is conceived as a general-purpose Qt-based library aimed at

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+### About this Fork
+
+This repository keeps master branch aligned with the original repository [paceholder/nodeeditor](https://github.com/paceholder/nodeeditor).
+In the develop branch can be found some fix or feature never merged in the original repository and some additional feature.
+
+
 ### Purpose
 
 **NodeEditor** is conceived as a general-purpose Qt-based library aimed at

--- a/include/nodes/StyleCollection
+++ b/include/nodes/StyleCollection
@@ -1,0 +1,1 @@
+#include "internal/StyleCollection.hpp"

--- a/include/nodes/internal/Connection.hpp
+++ b/include/nodes/internal/Connection.hpp
@@ -51,7 +51,7 @@ public:
   Connection(const Connection&) = delete;
   Connection operator=(const Connection&) = delete;
 
-  ~Connection();
+  ~Connection() override;
 
 public:
 
@@ -132,10 +132,10 @@ public: // data propagation
 Q_SIGNALS:
 
   void
-  connectionCompleted(Connection const&) const;
+  connectionCompleted(QtNodes::Connection const&);
 
   void
-  connectionMadeIncomplete(Connection const&) const;
+  connectionMadeIncomplete(QtNodes::Connection const&);
 
 private:
 
@@ -161,6 +161,6 @@ private:
 Q_SIGNALS:
 
   void
-  updated(Connection& conn) const;
+  updated(Connection& conn);
 };
 }

--- a/include/nodes/internal/ConnectionGraphicsObject.hpp
+++ b/include/nodes/internal/ConnectionGraphicsObject.hpp
@@ -25,8 +25,7 @@ public:
   ConnectionGraphicsObject(FlowScene &scene,
                            Connection &connection);
 
-  virtual
-  ~ConnectionGraphicsObject();
+  ~ConnectionGraphicsObject() override;
 
   enum { Type = UserType + 2 };
   int

--- a/include/nodes/internal/ConnectionState.hpp
+++ b/include/nodes/internal/ConnectionState.hpp
@@ -21,8 +21,8 @@ public:
     : _requiredPort(port)
   {}
 
-  ConnectionState(const ConnectionState&) = delete;
-  ConnectionState operator=(const ConnectionState&) = delete;
+  ConnectionState(ConnectionState const&) = delete;
+  ConnectionState operator=(ConnectionState const&) = delete;
 
   ~ConnectionState();
 

--- a/include/nodes/internal/ConnectionStyle.hpp
+++ b/include/nodes/internal/ConnectionStyle.hpp
@@ -14,17 +14,17 @@ public:
 
   ConnectionStyle();
 
-  ConnectionStyle(const QString& jsonText);
+  ConnectionStyle(QString const& jsonText);
 
 public:
 
-  static void setConnectionStyle(const QString& jsonText);
+  static void setConnectionStyle(QString const& jsonText);
 
 private:
 
-  void loadJsonText(const QString& jsonText) override;
+  void loadJsonText(QString const& jsonText) override;
 
-  void loadJsonFile(const QString& fileName) override;
+  void loadJsonFile(QString const& fileName) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 
@@ -32,7 +32,7 @@ public:
 
   QColor constructionColor() const;
   QColor normalColor() const;
-  QColor normalColor(const QString& typeId) const;
+  QColor normalColor(QString const& typeId) const;
   QColor selectedColor() const;
   QColor selectedHaloColor() const;
   QColor hoveredColor() const;

--- a/include/nodes/internal/ConnectionStyle.hpp
+++ b/include/nodes/internal/ConnectionStyle.hpp
@@ -14,17 +14,17 @@ public:
 
   ConnectionStyle();
 
-  ConnectionStyle(QString jsonText);
+  ConnectionStyle(const QString& jsonText);
 
 public:
 
-  static void setConnectionStyle(QString jsonText);
+  static void setConnectionStyle(const QString& jsonText);
 
 private:
 
-  void loadJsonText(QString jsonText) override;
+  void loadJsonText(const QString& jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void loadJsonFile(const QString& fileName) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 
@@ -32,7 +32,7 @@ public:
 
   QColor constructionColor() const;
   QColor normalColor() const;
-  QColor normalColor(QString typeId) const;
+  QColor normalColor(const QString& typeId) const;
   QColor selectedColor() const;
   QColor selectedHaloColor() const;
   QColor hoveredColor() const;

--- a/include/nodes/internal/FlowScene.hpp
+++ b/include/nodes/internal/FlowScene.hpp
@@ -36,7 +36,7 @@ public:
 
   FlowScene(QObject * parent = Q_NULLPTR);
 
-  ~FlowScene();
+  ~FlowScene() override;
 
 public:
 
@@ -106,33 +106,46 @@ Q_SIGNALS:
    * @brief Node has been created but not on the scene yet.
    * @see nodePlaced()
    */
-  void nodeCreated(Node &n);
+  void
+  nodeCreated(QtNodes::Node &n);
 
   /**
    * @brief Node has been added to the scene.
    * @details Connect to this signal if need a correct position of node.
    * @see nodeCreated()
    */
-  void nodePlaced(Node &n);
+  void
+  nodePlaced(QtNodes::Node &n);
 
-  void nodeDeleted(Node &n);
+  void
+  nodeDeleted(QtNodes::Node &n);
 
-  void connectionCreated(Connection const &c);
-  void connectionDeleted(Connection const &c);
+  void
+  connectionCreated(QtNodes::Connection const &c);
 
-  void nodeMoved(Node& n, const QPointF& newLocation);
+  void
+  connectionDeleted(QtNodes::Connection const &c);
 
-  void nodeDoubleClicked(Node& n);
+  void
+  nodeMoved(QtNodes::Node& n, const QPointF& newLocation);
 
-  void connectionHovered(Connection& c, QPoint screenPos);
+  void
+  nodeDoubleClicked(QtNodes::Node& n);
 
-  void nodeHovered(Node& n, QPoint screenPos);
+  void
+  connectionHovered(QtNodes::Connection& c, QPoint screenPos);
 
-  void connectionHoverLeft(Connection& c);
+  void
+  nodeHovered(QtNodes::Node& n, QPoint screenPos);
 
-  void nodeHoverLeft(Node& n);
+  void
+  connectionHoverLeft(QtNodes::Connection& c);
 
-  void nodeContextMenu(Node& n, const QPointF& pos);
+  void
+  nodeHoverLeft(QtNodes::Node& n);
+
+  void
+  nodeContextMenu(QtNodes::Node& n, const QPointF& pos);
 
 private:
 
@@ -145,10 +158,10 @@ private:
 
 private Q_SLOTS:
 
-  void setupConnectionSignals(Connection const& c);
+  void setupConnectionSignals(QtNodes::Connection const& c);
 
-  void sendConnectionCreatedToNodes(Connection const& c);
-  void sendConnectionDeletedToNodes(Connection const& c);
+  void sendConnectionCreatedToNodes(QtNodes::Connection const& c);
+  void sendConnectionDeletedToNodes(QtNodes::Connection const& c);
 
 };
 

--- a/include/nodes/internal/FlowViewStyle.hpp
+++ b/include/nodes/internal/FlowViewStyle.hpp
@@ -14,17 +14,17 @@ public:
 
   FlowViewStyle();
 
-  FlowViewStyle(const QString& jsonText);
+  FlowViewStyle(QString const& jsonText);
 
 public:
 
-  static void setStyle(const QString& jsonText);
+  static void setStyle(QString const& jsonText);
 
 private:
 
-  void loadJsonText(const QString& jsonText) override;
+  void loadJsonText(QString const& jsonText) override;
 
-  void loadJsonFile(const QString& fileName) override;
+  void loadJsonFile(QString const& fileName) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/include/nodes/internal/FlowViewStyle.hpp
+++ b/include/nodes/internal/FlowViewStyle.hpp
@@ -14,17 +14,17 @@ public:
 
   FlowViewStyle();
 
-  FlowViewStyle(QString jsonText);
+  FlowViewStyle(const QString& jsonText);
 
 public:
 
-  static void setStyle(QString jsonText);
+  static void setStyle(const QString& jsonText);
 
 private:
 
-  void loadJsonText(QString jsonText) override;
+  void loadJsonText(const QString& jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void loadJsonFile(const QString& fileName) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/include/nodes/internal/Node.hpp
+++ b/include/nodes/internal/Node.hpp
@@ -36,8 +36,7 @@ public:
   /// NodeDataModel should be an rvalue and is moved into the Node
   Node(std::unique_ptr<NodeDataModel> && dataModel);
 
-  virtual
-  ~Node();
+  ~Node() override;
 
 public:
 
@@ -90,12 +89,12 @@ public Q_SLOTS: // data propagation
   /// Propagates incoming data to the underlying model.
   void
   propagateData(std::shared_ptr<NodeData> nodeData,
-                PortIndex inPortIndex) const;
+                QtNodes::PortIndex inPortIndex) const;
 
   /// Fetches data from model's OUT #index port
   /// and propagates it to the connection
   void
-  onDataUpdated(PortIndex index);
+  onDataUpdated(QtNodes::PortIndex index);
 
   /// update the graphic part if the size of the embeddedwidget changes
   void

--- a/include/nodes/internal/NodeDataModel.hpp
+++ b/include/nodes/internal/NodeDataModel.hpp
@@ -36,9 +36,6 @@ public:
 
   NodeDataModel();
 
-  virtual
-  ~NodeDataModel() = default;
-
   /// Caption is used in GUI
   virtual QString
   caption() const = 0;
@@ -127,32 +124,32 @@ public:
 public Q_SLOTS:
 
   virtual void
-  inputConnectionCreated(Connection const&)
+  inputConnectionCreated(QtNodes::Connection const&)
   {
   }
 
   virtual void
-  inputConnectionDeleted(Connection const&)
+  inputConnectionDeleted(QtNodes::Connection const&)
   {
   }
 
   virtual void
-  outputConnectionCreated(Connection const&)
+  outputConnectionCreated(QtNodes::Connection const&)
   {
   }
 
   virtual void
-  outputConnectionDeleted(Connection const&)
+  outputConnectionDeleted(QtNodes::Connection const&)
   {
   }
 
 Q_SIGNALS:
 
   void
-  dataUpdated(PortIndex index);
+  dataUpdated(QtNodes::PortIndex index);
 
   void
-  dataInvalidated(PortIndex index);
+  dataInvalidated(QtNodes::PortIndex index);
 
   void
   computingStarted();
@@ -160,7 +157,8 @@ Q_SIGNALS:
   void
   computingFinished();
 
-  void embeddedWidgetSizeUpdated();
+  void
+  embeddedWidgetSizeUpdated();
 
 private:
 

--- a/include/nodes/internal/NodeGraphicsObject.hpp
+++ b/include/nodes/internal/NodeGraphicsObject.hpp
@@ -26,8 +26,7 @@ public:
   NodeGraphicsObject(FlowScene &scene,
                      Node& node);
 
-  virtual
-  ~NodeGraphicsObject();
+  ~NodeGraphicsObject() override;
 
   Node&
   node();

--- a/include/nodes/internal/NodeStyle.hpp
+++ b/include/nodes/internal/NodeStyle.hpp
@@ -14,17 +14,17 @@ public:
 
   NodeStyle();
 
-  NodeStyle(QString jsonText);
+  NodeStyle(const QString& jsonText);
 
 public:
 
-  static void setNodeStyle(QString jsonText);
+  static void setNodeStyle(const QString& jsonText);
 
 private:
 
-  void loadJsonText(QString jsonText) override;
+  void loadJsonText(const QString& jsonText) override;
 
-  void loadJsonFile(QString fileName) override;
+  void loadJsonFile(const QString& fileName) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/include/nodes/internal/NodeStyle.hpp
+++ b/include/nodes/internal/NodeStyle.hpp
@@ -14,17 +14,17 @@ public:
 
   NodeStyle();
 
-  NodeStyle(const QString& jsonText);
+  NodeStyle(QString const& jsonText);
 
 public:
 
-  static void setNodeStyle(const QString& jsonText);
+  static void setNodeStyle(QString const& jsonText);
 
 private:
 
-  void loadJsonText(const QString& jsonText) override;
+  void loadJsonText(QString const& jsonText) override;
 
-  void loadJsonFile(const QString& fileName) override;
+  void loadJsonFile(QString const& fileName) override;
 
   void loadJsonFromByteArray(QByteArray const &byteArray) override;
 

--- a/include/nodes/internal/PortType.hpp
+++ b/include/nodes/internal/PortType.hpp
@@ -58,6 +58,7 @@ oppositePort(PortType port)
       result = PortType::In;
       break;
 
+    case PortType::None:
     default:
       break;
   }

--- a/include/nodes/internal/Style.hpp
+++ b/include/nodes/internal/Style.hpp
@@ -15,10 +15,10 @@ public:
 private:
 
   virtual void
-  loadJsonText(const QString& jsonText) = 0;
+  loadJsonText(QString const& jsonText) = 0;
 
   virtual void
-  loadJsonFile(const QString& fileName) = 0;
+  loadJsonFile(QString const& fileName) = 0;
 
   virtual void
   loadJsonFromByteArray(QByteArray const &byteArray) = 0;

--- a/include/nodes/internal/Style.hpp
+++ b/include/nodes/internal/Style.hpp
@@ -15,10 +15,10 @@ public:
 private:
 
   virtual void
-  loadJsonText(QString jsonText) = 0;
+  loadJsonText(const QString& jsonText) = 0;
 
   virtual void
-  loadJsonFile(QString fileName) = 0;
+  loadJsonFile(const QString& fileName) = 0;
 
   virtual void
   loadJsonFromByteArray(QByteArray const &byteArray) = 0;

--- a/include/nodes/internal/StyleCollection.hpp
+++ b/include/nodes/internal/StyleCollection.hpp
@@ -3,11 +3,12 @@
 #include "NodeStyle.hpp"
 #include "ConnectionStyle.hpp"
 #include "FlowViewStyle.hpp"
+#include "Export.hpp"
 
 namespace QtNodes
 {
 
-class StyleCollection
+class NODE_EDITOR_PUBLIC StyleCollection
 {
 public:
 

--- a/include/nodes/internal/StyleCollection.hpp
+++ b/include/nodes/internal/StyleCollection.hpp
@@ -28,15 +28,15 @@ public:
 
   static
   void
-  setNodeStyle(NodeStyle);
+  setNodeStyle(const NodeStyle&);
 
   static
   void
-  setConnectionStyle(ConnectionStyle);
+  setConnectionStyle(const ConnectionStyle&);
 
   static
   void
-  setFlowViewStyle(FlowViewStyle);
+  setFlowViewStyle(const FlowViewStyle&);
 
 private:
 

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -66,7 +66,10 @@ Connection(Node& nodeIn,
 Connection::
 ~Connection()
 {
-  if (complete()) connectionMadeIncomplete(*this);
+  if (complete())
+  {
+    Q_EMIT connectionMadeIncomplete(*this);
+  }
   propagateEmptyData();
 
   if (_inNode)
@@ -249,9 +252,9 @@ setNodeToPort(Node& node,
 
   _connectionState.setNoRequiredPort();
 
-  updated(*this);
+  Q_EMIT updated(*this);
   if (complete() && wasIncomplete) {
-    connectionCompleted(*this);
+    Q_EMIT connectionCompleted(*this);
   }
 }
 
@@ -316,14 +319,12 @@ getNode(PortType portType) const
   {
     case PortType::In:
       return _inNode;
-      break;
 
     case PortType::Out:
       return _outNode;
-      break;
 
+    case PortType::None:
     default:
-      // not possible
       break;
   }
   return nullptr;
@@ -338,12 +339,11 @@ getNode(PortType portType)
   {
     case PortType::In:
       return _inNode;
-      break;
 
     case PortType::Out:
       return _outNode;
-      break;
 
+    case PortType::None:
     default:
       // not possible
       break;
@@ -356,8 +356,9 @@ void
 Connection::
 clearNode(PortType portType)
 {
-  if (complete()) {
-    connectionMadeIncomplete(*this);
+  if (complete())
+  {
+    Q_EMIT connectionMadeIncomplete(*this);
   }
 
   getNode(portType) = nullptr;

--- a/src/ConnectionGeometry.cpp
+++ b/src/ConnectionGeometry.cpp
@@ -42,6 +42,7 @@ setEndPoint(PortType portType, QPointF const& point)
       _in = point;
       break;
 
+    case PortType::None:
     default:
       break;
   }
@@ -62,6 +63,7 @@ moveEndPoint(PortType portType, QPointF const &offset)
       _in += offset;
       break;
 
+    case PortType::None:
     default:
       break;
   }

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -205,7 +205,7 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   event->accept();
 
   auto node = locateNodeAt(event->scenePos(), _scene,
-                           _scene.views()[0]->transform());
+                           _scene.views().at(0)->transform());
 
   NodeConnectionInteraction interaction(*node, _connection, _scene);
 
@@ -228,7 +228,7 @@ hoverEnterEvent(QGraphicsSceneHoverEvent* event)
   _connection.connectionGeometry().setHovered(true);
 
   update();
-  _scene.connectionHovered(connection(), event->screenPos());
+  Q_EMIT _scene.connectionHovered(connection(), event->screenPos());
   event->accept();
 }
 
@@ -240,7 +240,7 @@ hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
   _connection.connectionGeometry().setHovered(false);
 
   update();
-  _scene.connectionHoverLeft(connection());
+  Q_EMIT _scene.connectionHoverLeft(connection());
   event->accept();
 }
 

--- a/src/ConnectionStyle.cpp
+++ b/src/ConnectionStyle.cpp
@@ -30,7 +30,7 @@ ConnectionStyle()
 
 
 ConnectionStyle::
-ConnectionStyle(const QString& jsonText)
+ConnectionStyle(QString const& jsonText)
 {
   loadJsonFile(":DefaultStyle.json");
   loadJsonText(jsonText);
@@ -39,7 +39,7 @@ ConnectionStyle(const QString& jsonText)
 
 void
 ConnectionStyle::
-setConnectionStyle(const QString& jsonText)
+setConnectionStyle(QString const& jsonText)
 {
   ConnectionStyle style(jsonText);
 
@@ -94,7 +94,7 @@ setConnectionStyle(const QString& jsonText)
 
 void
 ConnectionStyle::
-loadJsonFile(const QString& styleFile)
+loadJsonFile(QString const& styleFile)
 {
   QFile file(styleFile);
 
@@ -111,7 +111,7 @@ loadJsonFile(const QString& styleFile)
 
 void
 ConnectionStyle::
-loadJsonText(const QString& jsonText)
+loadJsonText(QString const& jsonText)
 {
   loadJsonFromByteArray(jsonText.toUtf8());
 }
@@ -161,7 +161,7 @@ normalColor() const
 
 QColor
 ConnectionStyle::
-normalColor(const QString& typeId) const
+normalColor(QString const& typeId) const
 {
   std::size_t hash = qHash(typeId);
 

--- a/src/ConnectionStyle.cpp
+++ b/src/ConnectionStyle.cpp
@@ -9,6 +9,7 @@
 #include <QtCore/QJsonArray>
 
 #include <QDebug>
+#include <QRandomGenerator>
 
 #include "StyleCollection.hpp"
 
@@ -29,7 +30,7 @@ ConnectionStyle()
 
 
 ConnectionStyle::
-ConnectionStyle(QString jsonText)
+ConnectionStyle(const QString& jsonText)
 {
   loadJsonFile(":DefaultStyle.json");
   loadJsonText(jsonText);
@@ -38,7 +39,7 @@ ConnectionStyle(QString jsonText)
 
 void
 ConnectionStyle::
-setConnectionStyle(QString jsonText)
+setConnectionStyle(const QString& jsonText)
 {
   ConnectionStyle style(jsonText);
 
@@ -93,7 +94,7 @@ setConnectionStyle(QString jsonText)
 
 void
 ConnectionStyle::
-loadJsonFile(QString styleFile)
+loadJsonFile(const QString& styleFile)
 {
   QFile file(styleFile);
 
@@ -110,7 +111,7 @@ loadJsonFile(QString styleFile)
 
 void
 ConnectionStyle::
-loadJsonText(QString jsonText)
+loadJsonText(const QString& jsonText)
 {
   loadJsonFromByteArray(jsonText.toUtf8());
 }
@@ -128,17 +129,17 @@ loadJsonFromByteArray(QByteArray const &byteArray)
 
   QJsonObject obj = nodeStyleValues.toObject();
 
-  CONNECTION_STYLE_READ_COLOR(obj, ConstructionColor);
-  CONNECTION_STYLE_READ_COLOR(obj, NormalColor);
-  CONNECTION_STYLE_READ_COLOR(obj, SelectedColor);
-  CONNECTION_STYLE_READ_COLOR(obj, SelectedHaloColor);
-  CONNECTION_STYLE_READ_COLOR(obj, HoveredColor);
+  CONNECTION_STYLE_READ_COLOR(obj, ConstructionColor)
+  CONNECTION_STYLE_READ_COLOR(obj, NormalColor)
+  CONNECTION_STYLE_READ_COLOR(obj, SelectedColor)
+  CONNECTION_STYLE_READ_COLOR(obj, SelectedHaloColor)
+  CONNECTION_STYLE_READ_COLOR(obj, HoveredColor)
 
-  CONNECTION_STYLE_READ_FLOAT(obj, LineWidth);
-  CONNECTION_STYLE_READ_FLOAT(obj, ConstructionLineWidth);
-  CONNECTION_STYLE_READ_FLOAT(obj, PointDiameter);
+  CONNECTION_STYLE_READ_FLOAT(obj, LineWidth)
+  CONNECTION_STYLE_READ_FLOAT(obj, ConstructionLineWidth)
+  CONNECTION_STYLE_READ_FLOAT(obj, PointDiameter)
 
-  CONNECTION_STYLE_READ_BOOL(obj, UseDataDefinedColors);
+  CONNECTION_STYLE_READ_BOOL(obj, UseDataDefinedColors)
 }
 
 
@@ -160,14 +161,14 @@ normalColor() const
 
 QColor
 ConnectionStyle::
-normalColor(QString typeId) const
+normalColor(const QString& typeId) const
 {
   std::size_t hash = qHash(typeId);
 
   std::size_t const hue_range = 0xFF;
 
-  qsrand(hash);
-  std::size_t hue = qrand() % hue_range;
+  QRandomGenerator rand(hash);
+  std::size_t hue = rand.generate() % hue_range;
 
   std::size_t sat = 120 + hash % 129;
 

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -90,7 +90,7 @@ createConnection(PortType connectedPort,
           &Connection::connectionCompleted,
           this,
           [this](Connection const& c) {
-            connectionCreated(c);
+            Q_EMIT connectionCreated(c);
           });
 
   return connection;
@@ -125,7 +125,7 @@ createConnection(Node& nodeIn,
 
   _connections[connection->id()] = connection;
 
-  connectionCreated(*connection);
+  Q_EMIT connectionCreated(*connection);
 
   return connection;
 }
@@ -204,7 +204,7 @@ createNode(std::unique_ptr<NodeDataModel> && dataModel)
   auto nodePtr = node.get();
   _nodes[node->id()] = std::move(node);
 
-  nodeCreated(*nodePtr);
+  Q_EMIT nodeCreated(*nodePtr);
   return *nodePtr;
 }
 
@@ -230,8 +230,8 @@ restoreNode(QJsonObject const& nodeJson)
   auto nodePtr = node.get();
   _nodes[node->id()] = std::move(node);
 
-  nodePlaced(*nodePtr);
-  nodeCreated(*nodePtr);
+  Q_EMIT nodePlaced(*nodePtr);
+  Q_EMIT nodeCreated(*nodePtr);
   return *nodePtr;
 }
 
@@ -241,7 +241,7 @@ FlowScene::
 removeNode(Node& node)
 {
   // call signal
-  nodeDeleted(node);
+  Q_EMIT nodeDeleted(node);
 
   for(auto portType: {PortType::In,PortType::Out})
   {

--- a/src/FlowView.cpp
+++ b/src/FlowView.cpp
@@ -151,7 +151,7 @@ contextMenuEvent(QContextMenuEvent *event)
 
   treeView->expandAll();
 
-  connect(treeView, &QTreeWidget::itemClicked, [&](QTreeWidgetItem *item, int)
+  connect(treeView, &QTreeWidget::itemClicked, &modelMenu, [&](QTreeWidgetItem *item, int)
   {
     QString modelName = item->data(0, Qt::UserRole).toString();
 
@@ -172,7 +172,7 @@ contextMenuEvent(QContextMenuEvent *event)
 
       node.nodeGraphicsObject().setPos(posView);
 
-      _scene->nodePlaced(node);
+      Q_EMIT _scene->nodePlaced(node);
     }
     else
     {
@@ -378,8 +378,6 @@ drawBackground(QPainter* painter, const QRectF& r)
     };
 
   auto const &flowViewStyle = StyleCollection::flowViewStyle();
-
-  QBrush bBrush = backgroundBrush();
 
   QPen pfine(flowViewStyle.FineGridColor, 1.0);
 

--- a/src/FlowViewStyle.cpp
+++ b/src/FlowViewStyle.cpp
@@ -27,7 +27,7 @@ FlowViewStyle()
 
 
 FlowViewStyle::
-FlowViewStyle(QString jsonText)
+FlowViewStyle(const QString& jsonText)
 {
   loadJsonText(jsonText);
 }
@@ -35,7 +35,7 @@ FlowViewStyle(QString jsonText)
 
 void
 FlowViewStyle::
-setStyle(QString jsonText)
+setStyle(const QString& jsonText)
 {
   FlowViewStyle style(jsonText);
 
@@ -70,7 +70,7 @@ setStyle(QString jsonText)
 
 void
 FlowViewStyle::
-loadJsonFile(QString styleFile)
+loadJsonFile(const QString& styleFile)
 {
   QFile file(styleFile);
 
@@ -87,7 +87,7 @@ loadJsonFile(QString styleFile)
 
 void
 FlowViewStyle::
-loadJsonText(QString jsonText)
+loadJsonText(const QString& jsonText)
 {
   loadJsonFromByteArray(jsonText.toUtf8());
 }
@@ -105,7 +105,7 @@ loadJsonFromByteArray(QByteArray const &byteArray)
 
   QJsonObject obj = nodeStyleValues.toObject();
 
-  FLOW_VIEW_STYLE_READ_COLOR(obj, BackgroundColor);
-  FLOW_VIEW_STYLE_READ_COLOR(obj, FineGridColor);
-  FLOW_VIEW_STYLE_READ_COLOR(obj, CoarseGridColor);
+  FLOW_VIEW_STYLE_READ_COLOR(obj, BackgroundColor)
+  FLOW_VIEW_STYLE_READ_COLOR(obj, FineGridColor)
+  FLOW_VIEW_STYLE_READ_COLOR(obj, CoarseGridColor)
 }

--- a/src/FlowViewStyle.cpp
+++ b/src/FlowViewStyle.cpp
@@ -27,7 +27,7 @@ FlowViewStyle()
 
 
 FlowViewStyle::
-FlowViewStyle(const QString& jsonText)
+FlowViewStyle(QString const& jsonText)
 {
   loadJsonText(jsonText);
 }
@@ -35,7 +35,7 @@ FlowViewStyle(const QString& jsonText)
 
 void
 FlowViewStyle::
-setStyle(const QString& jsonText)
+setStyle(QString const& jsonText)
 {
   FlowViewStyle style(jsonText);
 
@@ -70,7 +70,7 @@ setStyle(const QString& jsonText)
 
 void
 FlowViewStyle::
-loadJsonFile(const QString& styleFile)
+loadJsonFile(QString const& styleFile)
 {
   QFile file(styleFile);
 
@@ -87,7 +87,7 @@ loadJsonFile(const QString& styleFile)
 
 void
 FlowViewStyle::
-loadJsonText(const QString& jsonText)
+loadJsonText(QString const& jsonText)
 {
   loadJsonFromByteArray(jsonText.toUtf8());
 }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -61,7 +61,7 @@ NodeGraphicsObject(FlowScene &scene,
 
   // connect to the move signals to emit the move signals in FlowScene
   auto onMoveSlot = [this] {
-    _scene.nodeMoved(_node, pos());
+    Q_EMIT _scene.nodeMoved(_node, pos());
   };
   connect(this, &QGraphicsObject::xChanged, this, onMoveSlot);
   connect(this, &QGraphicsObject::yChanged, this, onMoveSlot);
@@ -360,7 +360,7 @@ hoverEnterEvent(QGraphicsSceneHoverEvent * event)
 
   _node.nodeGeometry().setHovered(true);
   update();
-  _scene.nodeHovered(node(), event->screenPos());
+  Q_EMIT _scene.nodeHovered(node(), event->screenPos());
   event->accept();
 }
 
@@ -371,7 +371,7 @@ hoverLeaveEvent(QGraphicsSceneHoverEvent * event)
 {
   _node.nodeGeometry().setHovered(false);
   update();
-  _scene.nodeHoverLeft(node());
+  Q_EMIT _scene.nodeHoverLeft(node());
   event->accept();
 }
 
@@ -403,7 +403,7 @@ mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 {
   QGraphicsItem::mouseDoubleClickEvent(event);
 
-  _scene.nodeDoubleClicked(node());
+  Q_EMIT _scene.nodeDoubleClicked(node());
 }
 
 
@@ -411,5 +411,5 @@ void
 NodeGraphicsObject::
 contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
 {
-  _scene.nodeContextMenu(node(), mapToScene(event->pos()));
+  Q_EMIT _scene.nodeContextMenu(node(), mapToScene(event->pos()));
 }

--- a/src/NodePainter.cpp
+++ b/src/NodePainter.cpp
@@ -182,7 +182,7 @@ drawConnectionPoints(QPainter* painter,
                            reducedDiameter * r,
                            reducedDiameter * r);
     }
-  };
+  }
 }
 
 
@@ -240,7 +240,7 @@ drawModelName(QPainter * painter,
 {
   NodeStyle const& nodeStyle = model->nodeStyle();
 
-  Q_UNUSED(state);
+  Q_UNUSED(state)
 
   if (!model->captionVisible())
     return;

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -29,7 +29,7 @@ NodeStyle()
 
 
 NodeStyle::
-NodeStyle(const QString& jsonText)
+NodeStyle(QString const& jsonText)
 {
   loadJsonText(jsonText);
 }
@@ -37,7 +37,7 @@ NodeStyle(const QString& jsonText)
 
 void
 NodeStyle::
-setNodeStyle(const QString& jsonText)
+setNodeStyle(QString const& jsonText)
 {
   NodeStyle style(jsonText);
 
@@ -79,7 +79,7 @@ setNodeStyle(const QString& jsonText)
 
 void
 NodeStyle::
-loadJsonFile(const QString& styleFile)
+loadJsonFile(QString const& styleFile)
 {
   QFile file(styleFile);
 
@@ -96,7 +96,7 @@ loadJsonFile(const QString& styleFile)
 
 void
 NodeStyle::
-loadJsonText(const QString& jsonText)
+loadJsonText(QString const& jsonText)
 {
   loadJsonFromByteArray(jsonText.toUtf8());
 }

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -29,7 +29,7 @@ NodeStyle()
 
 
 NodeStyle::
-NodeStyle(QString jsonText)
+NodeStyle(const QString& jsonText)
 {
   loadJsonText(jsonText);
 }
@@ -37,7 +37,7 @@ NodeStyle(QString jsonText)
 
 void
 NodeStyle::
-setNodeStyle(QString jsonText)
+setNodeStyle(const QString& jsonText)
 {
   NodeStyle style(jsonText);
 
@@ -79,7 +79,7 @@ setNodeStyle(QString jsonText)
 
 void
 NodeStyle::
-loadJsonFile(QString styleFile)
+loadJsonFile(const QString& styleFile)
 {
   QFile file(styleFile);
 
@@ -96,7 +96,7 @@ loadJsonFile(QString styleFile)
 
 void
 NodeStyle::
-loadJsonText(QString jsonText)
+loadJsonText(const QString& jsonText)
 {
   loadJsonFromByteArray(jsonText.toUtf8());
 }
@@ -114,23 +114,23 @@ loadJsonFromByteArray(QByteArray const &byteArray)
 
   QJsonObject obj = nodeStyleValues.toObject();
 
-  NODE_STYLE_READ_COLOR(obj, NormalBoundaryColor);
-  NODE_STYLE_READ_COLOR(obj, SelectedBoundaryColor);
-  NODE_STYLE_READ_COLOR(obj, GradientColor0);
-  NODE_STYLE_READ_COLOR(obj, GradientColor1);
-  NODE_STYLE_READ_COLOR(obj, GradientColor2);
-  NODE_STYLE_READ_COLOR(obj, GradientColor3);
-  NODE_STYLE_READ_COLOR(obj, ShadowColor);
-  NODE_STYLE_READ_COLOR(obj, FontColor);
-  NODE_STYLE_READ_COLOR(obj, FontColorFaded);
-  NODE_STYLE_READ_COLOR(obj, ConnectionPointColor);
-  NODE_STYLE_READ_COLOR(obj, FilledConnectionPointColor);
-  NODE_STYLE_READ_COLOR(obj, WarningColor);
-  NODE_STYLE_READ_COLOR(obj, ErrorColor);
+  NODE_STYLE_READ_COLOR(obj, NormalBoundaryColor)
+  NODE_STYLE_READ_COLOR(obj, SelectedBoundaryColor)
+  NODE_STYLE_READ_COLOR(obj, GradientColor0)
+  NODE_STYLE_READ_COLOR(obj, GradientColor1)
+  NODE_STYLE_READ_COLOR(obj, GradientColor2)
+  NODE_STYLE_READ_COLOR(obj, GradientColor3)
+  NODE_STYLE_READ_COLOR(obj, ShadowColor)
+  NODE_STYLE_READ_COLOR(obj, FontColor)
+  NODE_STYLE_READ_COLOR(obj, FontColorFaded)
+  NODE_STYLE_READ_COLOR(obj, ConnectionPointColor)
+  NODE_STYLE_READ_COLOR(obj, FilledConnectionPointColor)
+  NODE_STYLE_READ_COLOR(obj, WarningColor)
+  NODE_STYLE_READ_COLOR(obj, ErrorColor)
 
-  NODE_STYLE_READ_FLOAT(obj, PenWidth);
-  NODE_STYLE_READ_FLOAT(obj, HoveredPenWidth);
-  NODE_STYLE_READ_FLOAT(obj, ConnectionPointDiameter);
+  NODE_STYLE_READ_FLOAT(obj, PenWidth)
+  NODE_STYLE_READ_FLOAT(obj, HoveredPenWidth)
+  NODE_STYLE_READ_FLOAT(obj, ConnectionPointDiameter)
 
-  NODE_STYLE_READ_FLOAT(obj, Opacity);
+  NODE_STYLE_READ_FLOAT(obj, Opacity)
 }

--- a/src/StyleCollection.cpp
+++ b/src/StyleCollection.cpp
@@ -31,7 +31,7 @@ flowViewStyle()
 
 void
 StyleCollection::
-setNodeStyle(NodeStyle nodeStyle)
+setNodeStyle(const QtNodes::NodeStyle& nodeStyle)
 {
   instance()._nodeStyle = nodeStyle;
 }
@@ -39,7 +39,7 @@ setNodeStyle(NodeStyle nodeStyle)
 
 void
 StyleCollection::
-setConnectionStyle(ConnectionStyle connectionStyle)
+setConnectionStyle(const QtNodes::ConnectionStyle& connectionStyle)
 {
   instance()._connectionStyle = connectionStyle;
 }
@@ -47,7 +47,7 @@ setConnectionStyle(ConnectionStyle connectionStyle)
 
 void
 StyleCollection::
-setFlowViewStyle(FlowViewStyle flowViewStyle)
+setFlowViewStyle(const QtNodes::FlowViewStyle& flowViewStyle)
 {
   instance()._flowViewStyle = flowViewStyle;
 }


### PR DESCRIPTION
Clazy analysis and code cleanup. Except for narrowing and vice-versa, most of warning was about:

warning: overrides a destructor but is not marked 'override' [inconsistent-missing-destructor-override]
warning: signal shouldn't be const [clazy-const-signal-or-slot]
warning: signal arguments need to be fully-qualified  [clazy-fully-qualified-moc-types]
warning: slot arguments need to be fully-qualified [clazy-fully-qualified-moc-types]
warning: enumeration value 'None' not explicitly handled in switch [switch-enum]
warning: Missing emit keyword on signal call [clazy-incorrect-emit]
warning: 'break' will never be executed [unreachable-code-break]
warning: Don't call QList::operator[]() on temporary [clazy-detaching-temporary]
warning: 'qsrand' is deprecated: use QRandomGenerator instead [deprecated-declarations]