### PR TITLE
Adjust the behavior of Connection's destructor

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -71,8 +71,6 @@ Connection::
     connectionMadeIncomplete(*this);
   }
 
-  propagateEmptyData();
-
   if (_inNode)
   {
     _inNode->nodeGraphicsObject().update();
@@ -80,6 +78,7 @@ Connection::
 
   if (_outNode)
   {
+    propagateEmptyData();
     _outNode->nodeGraphicsObject().update();
   }
 }


### PR DESCRIPTION
Modify Connection's destructor so that it doesn't fire propagateEmptyData without an output node connected to it previously.