### PR TITLE
Support Qt5 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_subdirectory(external)
 
 
 # Find the QtWidgets library
-find_package(Qt6
+find_package(Qt6 QUIET
   COMPONENTS
    Core
    Widgets
@@ -46,7 +46,7 @@ find_package(Qt6
 )
 
 if (NOT Qt6_FOUND)
-  find_package(Qt5 5.13
+  find_package(Qt5 REQUIRED
     COMPONENTS
      Core
      Widgets
@@ -59,8 +59,13 @@ if (NOT (Qt6_FOUND OR Qt5_FOUND))
   message(FATAL_ERRROR "Qt libraries were not found.")
 endif()
 
-
-qt_add_resources(RESOURCES ./resources/resources.qrc)
+if (Qt6_FOUND)
+  qt_add_resources(RESOURCES ./resources/resources.qrc)
+  set(Qt Qt)
+else()
+  qt5_add_resources(RESOURCES ./resources/resources.qrc)
+  set(Qt Qt5)
+endif()
 
 # Unfortunately, as we have a split include/src, AUTOMOC doesn't work.
 # We'll have to manually specify some files
@@ -109,10 +114,10 @@ target_include_directories(nodes
 
 target_link_libraries(nodes
   PUBLIC
-    Qt::Core
-    Qt::Widgets
-    Qt::Gui
-    Qt::OpenGL
+    ${Qt}::Core
+    ${Qt}::Widgets
+    ${Qt}::Gui
+    ${Qt}::OpenGL
 )
 
 target_compile_definitions(nodes
@@ -155,11 +160,19 @@ set_target_properties(nodes
 
 file(GLOB_RECURSE HEADERS_TO_MOC include/nodes/internal/*.hpp)
 
-qt_wrap_cpp(nodes_moc
-    ${HEADERS_TO_MOC}
+if (Qt6_FOUND)
+  qt_wrap_cpp(nodes_moc
+      ${HEADERS_TO_MOC}
+    TARGET nodes
+    OPTIONS --no-notes # Don't display a note for the headers which don't produce a moc_*.cpp
+  )
+else()
+  qt5_wrap_cpp(nodes_moc
+  ${HEADERS_TO_MOC}
   TARGET nodes
   OPTIONS --no-notes # Don't display a note for the headers which don't produce a moc_*.cpp
-)
+  )
+endif()
 
 target_sources(nodes PRIVATE ${nodes_moc})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ find_package(Qt6 QUIET
 )
 
 if (NOT Qt6_FOUND)
-  find_package(Qt5 REQUIRED
+  find_package(Qt5 QUIET
     COMPONENTS
      Core
      Widgets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,10 @@ find_package(Catch2 2.3.0 REQUIRED)
 
 if (Qt6_FOUND)
   find_package(Qt6 COMPONENTS Test)
+  set(Qt Qt)
 else()
   find_package(Qt5 COMPONENTS Test)
+  set(Qt Qt5)
 endif()
 
 add_executable(test_nodes
@@ -25,7 +27,7 @@ target_link_libraries(test_nodes
   PRIVATE
     NodeEditor::nodes
     Catch2::Catch2
-    Qt::Test
+    ${Qt}::Test
 )
 
 add_test(


### PR DESCRIPTION
This PR makes slight tweaks to the `CMakeLists.txt` file to allow this package to also be built with `Qt5`. Previously, even if `Qt6` was not found, an error would be thrown.

It addresses the issue here https://github.com/paceholder/nodeeditor/issues/314

Signed-off-by: Yadunund <yadunund@gmail.com>