### PR TITLE
Fix redefined find_package macro for vcpkg (#328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ connections updating  the whole graph.
 - [Building](#building)
   - [Linux](#linux)
   - [Qt Creator](#qt-creator)
+- [With Cmake using `vcpkg`](#with-cmake-using-vcpkg)
 - [>>> Version 3 Roadmap <<<](#-version-3-roadmap-)
 - [Citing](#citing)
 - [Youtube video:](#youtube-video)
@@ -78,6 +79,15 @@ make -j && make install
 4. `Build -> Build All`
 5. Click the button `Run`
 
+### With Cmake using [`vcpkg`](https://github.com/microsoft/vcpkg)
+
+1. Install `vcpkg`
+2. Add the following flag in configuration step of `CMake`
+   ```bash
+   -DCMAKE_TOOLCHAIN_FILE=<vcpkg_dir>/scripts/buildsystems/scripts/buildsystems/vcpkg.cmake
+   ```
+
+
 ## >>> Version 3 Roadmap <<<
 
 1. Headless mode. [done]
@@ -88,12 +98,12 @@ make -j && make install
    data propagation.
 2. Build data propagation on top of the graph code [done].
    - Fix old unit-tests. [in progress].
-   - Fix save/restore. [in progress].
+   - Fix save/restore. [done].
    - Fix CI scriptst on travis and appveyor. [not started].
 3. Backward compatibility with Qt5 [not started/help needed].
 3. Write improved documentation based on Sphynx platform [done].
 4. Extend set of examples [partially done].
-5. Undo Redo [not started].
+5. Undo Redo [done].
 6. Python wrappring using PySide [HELP NEEDED].
 7. Implement grouping nodes [not started].
 8. GUI: fix scrolling for scene view window scrolling [need to check Qt6]

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,13 +1,7 @@
 if(BUILD_TESTING)
-  find_package(Catch2 2.13.7 QUIET)
+  find_package(Catch2 QUIET)
 
   if(NOT Catch2_FOUND)
     add_subdirectory(Catch2)
   endif()
 endif()
-
-macro(find_package pkg)
-  if(NOT TARGET "${pkg}")
-    _find_package(${ARGV})
-  endif()
-endmacro()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(Catch2 2.3.0 REQUIRED)
-
 if (Qt6_FOUND)
   find_package(Qt6 COMPONENTS Test)
   set(Qt Qt)


### PR DESCRIPTION
The original idea was to be able to include the NodeEditor library to some super-project along with the included Catch2 (also as a subprobject), i.e.:

```
add_subdirectory(catch2)
add_subdirectory(NodeEditor)
```

To do this we need to detect inside NodeEditor's CMake scripts whether the Catch2 target was already included. If not, we included our own Catch2 subdirectory.

The chosen names of the macro caused recursion when called from within vcpkg.