### PR TITLE
Add header files to CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,42 @@ set(CPP_SOURCE_FILES
   src/StyleCollection.cpp
 )
 
+set(HPP_HEADER_FILES
+  include/nodes/internal/Compiler.hpp
+  include/nodes/internal/Connection.hpp
+  include/nodes/internal/ConnectionGeometry.hpp
+  include/nodes/internal/ConnectionGraphicsObject.hpp
+  include/nodes/internal/ConnectionState.hpp
+  include/nodes/internal/ConnectionStyle.hpp
+  include/nodes/internal/DataModelRegistry.hpp
+  include/nodes/internal/Export.hpp
+  include/nodes/internal/FlowScene.hpp
+  include/nodes/internal/FlowView.hpp
+  include/nodes/internal/FlowViewStyle.hpp
+  include/nodes/internal/memory.hpp
+  include/nodes/internal/Node.hpp
+  include/nodes/internal/NodeData.hpp
+  include/nodes/internal/NodeDataModel.hpp
+  include/nodes/internal/NodeGeometry.hpp
+  include/nodes/internal/NodeGraphicsObject.hpp
+  include/nodes/internal/NodePainterDelegate.hpp
+  include/nodes/internal/NodeState.hpp
+  include/nodes/internal/NodeStyle.hpp
+  include/nodes/internal/OperatingSystem.hpp
+  include/nodes/internal/PortType.hpp
+  include/nodes/internal/QStringStdHash.hpp
+  include/nodes/internal/QUuidStdHash.hpp
+  include/nodes/internal/Serializable.hpp
+  include/nodes/internal/Style.hpp
+  include/nodes/internal/StyleCollection.hpp
+  include/nodes/internal/TypeConverter.hpp
+)
+
 # If we want to give the option to build a static library,
 # set BUILD_SHARED_LIBS option to OFF
 add_library(nodes
   ${CPP_SOURCE_FILES}
+  ${HPP_HEADER_FILES}
   ${RESOURCES}
 )
 add_library(NodeEditor::nodes ALIAS nodes)

--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB_RECURSE CPPS  ./*.cpp )
+file(GLOB_RECURSE HPPS  ./*.hpp)
 
-add_executable(calculator ${CPPS})
+add_executable(calculator ${CPPS} ${HPPS})
 
 target_link_libraries(calculator nodes)

--- a/examples/connection_colors/CMakeLists.txt
+++ b/examples/connection_colors/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB_RECURSE CPPS  ./*.cpp )
+file(GLOB_RECURSE HPPS  ./*.hpp )
 
-add_executable(connection_colors ${CPPS})
+add_executable(connection_colors ${CPPS} ${HPPS})
 
 target_link_libraries(connection_colors nodes)

--- a/examples/example2/CMakeLists.txt
+++ b/examples/example2/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB_RECURSE CPPS  ./*.cpp )
+file(GLOB_RECURSE HPPS  ./*.hpp )
 
-add_executable(example2 ${CPPS})
+add_executable(example2 ${CPPS} ${HPPS})
 
 target_link_libraries(example2 nodes)

--- a/examples/images/CMakeLists.txt
+++ b/examples/images/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB_RECURSE CPPS  ./*.cpp )
+file(GLOB_RECURSE HPPS  ./*.hpp )
 
-add_executable(images ${CPPS})
+add_executable(images ${CPPS} ${HPPS})
 
 target_link_libraries(images nodes)

--- a/examples/styles/CMakeLists.txt
+++ b/examples/styles/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB_RECURSE CPPS  ./*.cpp )
+file(GLOB_RECURSE HPPS  ./*.hpp )
 
-add_executable(styles ${CPPS})
+add_executable(styles ${CPPS} ${HPPS})
 
 target_link_libraries(styles nodes)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,9 @@ add_executable(test_nodes
   src/TestDataModelRegistry.cpp
   src/TestFlowScene.cpp
   src/TestNodeGraphicsObject.cpp
+  include/ApplicationSetup.hpp
+  include/Stringify.hpp
+  include/StubNodeDataModel.hpp
 )
 
 target_include_directories(test_nodes


### PR DESCRIPTION
This allows QtCreator and other IDEs to show header files in the source tree.