### PR TITLE
fix: The node resize will now be based on the embedded widget policy

### DIFF
--- a/examples/resizable_images/ImageLoaderModel.cpp
+++ b/examples/resizable_images/ImageLoaderModel.cpp
@@ -17,7 +17,8 @@ ImageLoaderModel()
 
   _label->setFont(f);
 
-  _label->setFixedSize(200, 200);
+  _label->setMinimumSize(200, 200);
+  _label->setMaximumSize(500, 300);
 
   _label->installEventFilter(this);
 }

--- a/examples/resizable_images/ImageShowModel.cpp
+++ b/examples/resizable_images/ImageShowModel.cpp
@@ -21,7 +21,7 @@ ImageShowModel()
 
   _label->setFont(f);
 
-  _label->setFixedSize(200, 200);
+  _label->setMinimumSize(200, 200);
 
   _label->installEventFilter(this);
 }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -318,12 +318,10 @@ mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 
       oldSize += QSize(diff.x(), diff.y());
 
-      w->setFixedSize(oldSize);
+      w->resize(oldSize);
 
       AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
 
-      _proxyWidget->setMinimumSize(oldSize);
-      _proxyWidget->setMaximumSize(oldSize);
       _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
 
       // Passes the new size to the model.

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -322,7 +322,7 @@ mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 
       AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
 
-      _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
+      // _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
 
       // Passes the new size to the model.
       geometry.recomputeSize(_nodeId);


### PR DESCRIPTION
> You can try using resizeable_images

Win10 
Qt5.15.2&6.3.0
MVSC

**Before:**
You can change the size at will and even make the widget so small that it is invisible.
![image](https://user-images.githubusercontent.com/55644167/206861637-4f2b3224-e6da-44ff-9c55-45ae40e5d60f.png)

**After:**
Depends on the size property of the inline widget.
You can use `setMinimumSize()` and `setMaximumSize()` to limit the size of the node

If `setFixSize()` is set, even if resizeable is equal to true, it will not be possible to zoom in and out.

*Inadequate:*
When the node is minimized, the mouse continues to move but the node no longer changes. If you move the mouse to zoom in without releasing it, then the starting point of the calculation is the current mouse point.


