### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,102 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:    100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - forever # avoids { wrapped to next line
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^<Q.*'
+    Priority:        200
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+# Do not add QT_BEGIN_NAMESPACE/QT_END_NAMESPACE as this will indent lines in between.
+MacroBlockBegin: ""
+MacroBlockEnd:   ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 150
+PenaltyBreakBeforeFirstCallParameter: 300
+PenaltyBreakComment: 500
+PenaltyBreakFirstLessLess: 400
+PenaltyBreakString: 600
+PenaltyExcessCharacter: 50
+PenaltyReturnTypeOnItsOwnLine: 300
+PointerAlignment: Right
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/examples/calculator/AdditionModel.hpp
+++ b/examples/calculator/AdditionModel.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "MathOperationDataModel.hpp"
 #include "DecimalData.hpp"
+#include "MathOperationDataModel.hpp"
 
 #include <QtNodes/NodeDelegateModel>
 
@@ -13,41 +13,27 @@
 class AdditionModel : public MathOperationDataModel
 {
 public:
-
-  ~AdditionModel() = default;
+    ~AdditionModel() = default;
 
 public:
+    QString caption() const override { return QStringLiteral("Addition"); }
 
-  QString
-  caption() const override
-  { return QStringLiteral("Addition"); }
-
-  QString
-  name() const override
-  { return QStringLiteral("Addition"); }
+    QString name() const override { return QStringLiteral("Addition"); }
 
 private:
-
-  void
-  compute() override
-  {
-    PortIndex const outPortIndex = 0;
-
-    auto n1 = _number1.lock();
-    auto n2 = _number2.lock();
-
-    if (n1 && n2)
+    void compute() override
     {
-      _result = std::make_shared<DecimalData>(n1->number() +
-                                              n2->number());
+        PortIndex const outPortIndex = 0;
+
+        auto n1 = _number1.lock();
+        auto n2 = _number2.lock();
+
+        if (n1 && n2) {
+            _result = std::make_shared<DecimalData>(n1->number() + n2->number());
+        } else {
+            _result.reset();
+        }
+
+        Q_EMIT dataUpdated(outPortIndex);
     }
-    else
-    {
-      _result.reset();
-    }
-
-    Q_EMIT dataUpdated(outPortIndex);
-  }
-
-
 };

--- a/examples/calculator/DecimalData.hpp
+++ b/examples/calculator/DecimalData.hpp
@@ -2,40 +2,28 @@
 
 #include <QtNodes/NodeData>
 
-using QtNodes::NodeDataType;
 using QtNodes::NodeData;
+using QtNodes::NodeDataType;
 
 /// The class can potentially incapsulate any user data which
 /// need to be transferred within the Node Editor graph
 class DecimalData : public NodeData
 {
 public:
+    DecimalData()
+        : _number(0.0)
+    {}
 
-  DecimalData()
-    : _number(0.0)
-  {}
+    DecimalData(double const number)
+        : _number(number)
+    {}
 
-  DecimalData(double const number)
-    : _number(number)
-  {}
+    NodeDataType type() const override { return NodeDataType{"decimal", "Decimal"}; }
 
-  NodeDataType
-  type() const override
-  {
-    return NodeDataType {"decimal",
-                         "Decimal"};
-  }
+    double number() const { return _number; }
 
-
-  double
-  number() const
-  { return _number; }
-
-  QString
-  numberAsText() const
-  { return QString::number(_number, 'f'); }
+    QString numberAsText() const { return QString::number(_number, 'f'); }
 
 private:
-
-  double _number;
+    double _number;
 };

--- a/examples/calculator/DivisionModel.hpp
+++ b/examples/calculator/DivisionModel.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "MathOperationDataModel.hpp"
 #include "DecimalData.hpp"
+#include "MathOperationDataModel.hpp"
 
 #include <QtNodes/NodeDelegateModel>
 
@@ -13,79 +13,62 @@
 class DivisionModel : public MathOperationDataModel
 {
 public:
-
-  virtual
-  ~DivisionModel() {}
+    virtual ~DivisionModel() {}
 
 public:
-  QString
-  caption() const override
-  { return QStringLiteral("Division"); }
+    QString caption() const override { return QStringLiteral("Division"); }
 
-  bool
-  portCaptionVisible(PortType portType, PortIndex portIndex) const override
-  {
-    Q_UNUSED(portType); Q_UNUSED(portIndex);
-    return true;
-  }
-
-  QString
-  portCaption(PortType portType, PortIndex portIndex) const override
-  {
-    switch (portType)
+    bool portCaptionVisible(PortType portType, PortIndex portIndex) const override
     {
-      case PortType::In:
-        if (portIndex == 0)
-          return QStringLiteral("Dividend");
-        else if (portIndex == 1)
-          return QStringLiteral("Divisor");
-
-        break;
-
-      case PortType::Out:
-        return QStringLiteral("Result");
-
-      default:
-        break;
+        Q_UNUSED(portType);
+        Q_UNUSED(portIndex);
+        return true;
     }
-    return QString();
-  }
 
-  QString
-  name() const override
-  { return QStringLiteral("Division"); }
+    QString portCaption(PortType portType, PortIndex portIndex) const override
+    {
+        switch (portType) {
+        case PortType::In:
+            if (portIndex == 0)
+                return QStringLiteral("Dividend");
+            else if (portIndex == 1)
+                return QStringLiteral("Divisor");
+
+            break;
+
+        case PortType::Out:
+            return QStringLiteral("Result");
+
+        default:
+            break;
+        }
+        return QString();
+    }
+
+    QString name() const override { return QStringLiteral("Division"); }
 
 private:
-
-  void
-  compute() override
-  {
-    PortIndex const outPortIndex = 0;
-
-    auto n1 = _number1.lock();
-    auto n2 = _number2.lock();
-
-    if (n2 && (n2->number() == 0.0))
+    void compute() override
     {
-      //modelValidationState = NodeValidationState::Error;
-      //modelValidationError = QStringLiteral("Division by zero error");
-      _result.reset();
-    }
-    else if (n1 && n2)
-    {
-      //modelValidationState = NodeValidationState::Valid;
-      //modelValidationError = QString();
-      _result = std::make_shared<DecimalData>(n1->number() /
-                                              n2->number());
-    }
-    else
-    {
-      //modelValidationState = NodeValidationState::Warning;
-      //modelValidationError = QStringLiteral("Missing or incorrect inputs");
-      _result.reset();
-    }
+        PortIndex const outPortIndex = 0;
 
-    Q_EMIT dataUpdated(outPortIndex);
-  }
+        auto n1 = _number1.lock();
+        auto n2 = _number2.lock();
 
+        if (n2 && (n2->number() == 0.0)) {
+            //modelValidationState = NodeValidationState::Error;
+            //modelValidationError = QStringLiteral("Division by zero error");
+            _result.reset();
+        } else if (n1 && n2) {
+            //modelValidationState = NodeValidationState::Valid;
+            //modelValidationError = QString();
+            _result = std::make_shared<DecimalData>(n1->number() / n2->number());
+        } else {
+            //modelValidationState = NodeValidationState::Warning;
+            //modelValidationError = QStringLiteral("Missing or incorrect inputs");
+            _result.reset();
+        }
+
+        Q_EMIT dataUpdated(outPortIndex);
+    }
 };

--- a/examples/calculator/MathOperationDataModel.cpp
+++ b/examples/calculator/MathOperationDataModel.cpp
@@ -2,58 +2,41 @@
 
 #include "DecimalData.hpp"
 
-unsigned int
-MathOperationDataModel::
-nPorts(PortType portType) const
+unsigned int MathOperationDataModel::nPorts(PortType portType) const
 {
-  unsigned int result;
+    unsigned int result;
 
-  if (portType == PortType::In)
-    result = 2;
-  else
-    result = 1;
+    if (portType == PortType::In)
+        result = 2;
+    else
+        result = 1;
 
-  return result;
+    return result;
 }
 
-
-NodeDataType
-MathOperationDataModel::
-dataType(PortType, PortIndex) const
+NodeDataType MathOperationDataModel::dataType(PortType, PortIndex) const
 {
-  return DecimalData().type();
+    return DecimalData().type();
 }
 
-
-std::shared_ptr<NodeData>
-MathOperationDataModel::
-outData(PortIndex)
+std::shared_ptr<NodeData> MathOperationDataModel::outData(PortIndex)
 {
-  return std::static_pointer_cast<NodeData>(_result);
+    return std::static_pointer_cast<NodeData>(_result);
 }
 
-
-void
-MathOperationDataModel::
-setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
+void MathOperationDataModel::setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
 {
-  auto numberData =
-    std::dynamic_pointer_cast<DecimalData>(data);
+    auto numberData = std::dynamic_pointer_cast<DecimalData>(data);
 
-  if (!data)
-  {
-    Q_EMIT dataInvalidated(0);
-  }
+    if (!data) {
+        Q_EMIT dataInvalidated(0);
+    }
 
-  if (portIndex == 0)
-  {
-    _number1 = numberData;
-  }
-  else
-  {
-    _number2 = numberData;
-  }
+    if (portIndex == 0) {
+        _number1 = numberData;
+    } else {
+        _number2 = numberData;
+    }
 
-  compute();
+    compute();
 }
-

--- a/examples/calculator/MathOperationDataModel.hpp
+++ b/examples/calculator/MathOperationDataModel.hpp
@@ -2,8 +2,8 @@
 
 #include <QtNodes/NodeDelegateModel>
 
-#include <QtCore/QObject>
 #include <QtCore/QJsonObject>
+#include <QtCore/QObject>
 #include <QtWidgets/QLabel>
 
 #include <iostream>
@@ -11,8 +11,8 @@
 class DecimalData;
 
 using QtNodes::NodeData;
-using QtNodes::NodeDelegateModel;
 using QtNodes::NodeDataType;
+using QtNodes::NodeDelegateModel;
 using QtNodes::PortIndex;
 using QtNodes::PortType;
 
@@ -20,39 +20,28 @@ using QtNodes::PortType;
 /// In this example it has no logic.
 class MathOperationDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-
-  ~MathOperationDataModel() = default;
+    ~MathOperationDataModel() = default;
 
 public:
+    unsigned int nPorts(PortType portType) const override;
 
-  unsigned int
-  nPorts(PortType portType) const override;
+    NodeDataType dataType(PortType portType, PortIndex portIndex) const override;
 
-  NodeDataType
-  dataType(PortType  portType,
-           PortIndex portIndex) const override;
+    std::shared_ptr<NodeData> outData(PortIndex port) override;
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex port) override;
+    void setInData(std::shared_ptr<NodeData> data, PortIndex portIndex) override;
 
-  void
-  setInData(std::shared_ptr<NodeData> data, PortIndex portIndex) override;
-
-  QWidget*
-  embeddedWidget() override { return nullptr; }
+    QWidget *embeddedWidget() override { return nullptr; }
 
 protected:
-
-  virtual void
-  compute() = 0;
+    virtual void compute() = 0;
 
 protected:
+    std::weak_ptr<DecimalData> _number1;
+    std::weak_ptr<DecimalData> _number2;
 
-  std::weak_ptr<DecimalData> _number1;
-  std::weak_ptr<DecimalData> _number2;
-
-  std::shared_ptr<DecimalData> _result;
+    std::shared_ptr<DecimalData> _result;
 };

--- a/examples/calculator/MultiplicationModel.hpp
+++ b/examples/calculator/MultiplicationModel.hpp
@@ -14,46 +14,31 @@
 class MultiplicationModel : public MathOperationDataModel
 {
 public:
-
-  virtual
-  ~MultiplicationModel() {}
+    virtual ~MultiplicationModel() {}
 
 public:
+    QString caption() const override { return QStringLiteral("Multiplication"); }
 
-  QString
-  caption() const override
-  { return QStringLiteral("Multiplication"); }
-
-  QString
-  name() const override
-  { return QStringLiteral("Multiplication"); }
+    QString name() const override { return QStringLiteral("Multiplication"); }
 
 private:
-
-  void
-  compute() override
-  {
-    PortIndex const outPortIndex = 0;
-
-    auto n1 = _number1.lock();
-    auto n2 = _number2.lock();
-
-    if (n1 && n2)
+    void compute() override
     {
-      //modelValidationState = NodeValidationState::Valid;
-      //modelValidationError = QString();
-      _result = std::make_shared<DecimalData>(n1->number() *
-                                              n2->number());
+        PortIndex const outPortIndex = 0;
+
+        auto n1 = _number1.lock();
+        auto n2 = _number2.lock();
+
+        if (n1 && n2) {
+            //modelValidationState = NodeValidationState::Valid;
+            //modelValidationError = QString();
+            _result = std::make_shared<DecimalData>(n1->number() * n2->number());
+        } else {
+            //modelValidationState = NodeValidationState::Warning;
+            //modelValidationError = QStringLiteral("Missing or incorrect inputs");
+            _result.reset();
+        }
+
+        Q_EMIT dataUpdated(outPortIndex);
     }
-    else
-    {
-      //modelValidationState = NodeValidationState::Warning;
-      //modelValidationError = QStringLiteral("Missing or incorrect inputs");
-      _result.reset();
-    }
-
-    Q_EMIT dataUpdated(outPortIndex);
-  }
-
-
 };

--- a/examples/calculator/NumberDisplayDataModel.cpp
+++ b/examples/calculator/NumberDisplayDataModel.cpp
@@ -2,95 +2,70 @@
 
 #include <QtWidgets/QLabel>
 
-NumberDisplayDataModel::
-NumberDisplayDataModel()
-  : _label{nullptr}
+NumberDisplayDataModel::NumberDisplayDataModel()
+    : _label{nullptr}
+{}
+
+unsigned int NumberDisplayDataModel::nPorts(PortType portType) const
 {
-}
+    unsigned int result = 1;
 
-
-unsigned int
-NumberDisplayDataModel::
-nPorts(PortType portType) const
-{
-  unsigned int result = 1;
-
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      result = 1;
-      break;
+        result = 1;
+        break;
 
     case PortType::Out:
-      result = 0;
+        result = 0;
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-NodeDataType
-NumberDisplayDataModel::
-dataType(PortType, PortIndex) const
+NodeDataType NumberDisplayDataModel::dataType(PortType, PortIndex) const
 {
-  return DecimalData().type();
+    return DecimalData().type();
 }
 
-
-std::shared_ptr<NodeData>
-NumberDisplayDataModel::
-outData(PortIndex)
+std::shared_ptr<NodeData> NumberDisplayDataModel::outData(PortIndex)
 {
-  std::shared_ptr<NodeData> ptr;
-  return ptr;
+    std::shared_ptr<NodeData> ptr;
+    return ptr;
 }
 
-
-void
-NumberDisplayDataModel::
-setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
+void NumberDisplayDataModel::setInData(std::shared_ptr<NodeData> data, PortIndex portIndex)
 {
-  _numberData = std::dynamic_pointer_cast<DecimalData>(data);
+    _numberData = std::dynamic_pointer_cast<DecimalData>(data);
 
-  if (!_label)
-    return;
+    if (!_label)
+        return;
 
-  if (_numberData)
-  {
-    _label->setText(_numberData->numberAsText());
-  }
-  else
-  {
-    _label->clear();
-  }
+    if (_numberData) {
+        _label->setText(_numberData->numberAsText());
+    } else {
+        _label->clear();
+    }
 
-  _label->adjustSize();
+    _label->adjustSize();
 }
 
-
-QWidget*
-NumberDisplayDataModel::
-embeddedWidget()
+QWidget *NumberDisplayDataModel::embeddedWidget()
 {
-  if (!_label)
-  {
-    _label = new QLabel();
-    _label->setMargin(3);
-  }
+    if (!_label) {
+        _label = new QLabel();
+        _label->setMargin(3);
+    }
 
-  return _label; 
+    return _label;
 }
 
-
-double 
-NumberDisplayDataModel::
-number() const
+double NumberDisplayDataModel::number() const
 {
-  if (_numberData)
-    return _numberData->number();
+    if (_numberData)
+        return _numberData->number();
 
-  return 0.0;
+    return 0.0;
 }

--- a/examples/calculator/NumberDisplayDataModel.hpp
+++ b/examples/calculator/NumberDisplayDataModel.hpp
@@ -8,12 +8,11 @@
 
 #include "DecimalData.hpp"
 
-
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 class QLabel;
 
@@ -21,51 +20,35 @@ class QLabel;
 /// In this example it has no logic.
 class NumberDisplayDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  NumberDisplayDataModel();
+    NumberDisplayDataModel();
 
-  ~NumberDisplayDataModel() = default;
-
-public:
-
-  QString
-  caption() const override
-  { return QStringLiteral("Result"); }
-
-  bool
-  captionVisible() const override
-  { return false; }
-
-  QString
-  name() const override
-  { return QStringLiteral("Result"); }
+    ~NumberDisplayDataModel() = default;
 
 public:
+    QString caption() const override { return QStringLiteral("Result"); }
 
-  unsigned int
-  nPorts(PortType portType) const override;
+    bool captionVisible() const override { return false; }
 
-  NodeDataType
-  dataType(PortType  portType,
-           PortIndex portIndex) const override;
+    QString name() const override { return QStringLiteral("Result"); }
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex port) override;
+public:
+    unsigned int nPorts(PortType portType) const override;
 
-  void
-  setInData(std::shared_ptr<NodeData> data,
-            PortIndex                 portIndex) override;
+    NodeDataType dataType(PortType portType, PortIndex portIndex) const override;
 
-  QWidget *
-  embeddedWidget() override;
+    std::shared_ptr<NodeData> outData(PortIndex port) override;
 
-  double number() const;
+    void setInData(std::shared_ptr<NodeData> data, PortIndex portIndex) override;
 
+    QWidget *embeddedWidget() override;
+
+    double number() const;
 
 private:
-  std::shared_ptr<DecimalData> _numberData;
+    std::shared_ptr<DecimalData> _numberData;
 
-  QLabel* _label;
+    QLabel *_label;
 };

--- a/examples/calculator/NumberSourceDataModel.cpp
+++ b/examples/calculator/NumberSourceDataModel.cpp
@@ -6,140 +6,105 @@
 #include <QtGui/QDoubleValidator>
 #include <QtWidgets/QLineEdit>
 
+NumberSourceDataModel::NumberSourceDataModel()
+    : _lineEdit{nullptr}
+    , _number(std::make_shared<DecimalData>(0.0))
+{}
 
-NumberSourceDataModel::
-NumberSourceDataModel()
-  : _lineEdit{nullptr}
-  , _number(std::make_shared<DecimalData>(0.0))
+QJsonObject NumberSourceDataModel::save() const
 {
+    QJsonObject modelJson = NodeDelegateModel::save();
+
+    modelJson["number"] = QString::number(_number->number());
+
+    return modelJson;
 }
 
-
-QJsonObject
-NumberSourceDataModel::
-save() const
+void NumberSourceDataModel::load(QJsonObject const &p)
 {
-  QJsonObject modelJson = NodeDelegateModel::save();
+    QJsonValue v = p["number"];
 
-  modelJson["number"] = QString::number(_number->number());
+    if (!v.isUndefined()) {
+        QString strNum = v.toString();
 
-  return modelJson;
-}
+        bool ok;
+        double d = strNum.toDouble(&ok);
+        if (ok) {
+            _number = std::make_shared<DecimalData>(d);
 
-
-void
-NumberSourceDataModel::
-load(QJsonObject const& p)
-{
-  QJsonValue v = p["number"];
-
-  if (!v.isUndefined())
-  {
-    QString strNum = v.toString();
-
-    bool ok;
-    double d = strNum.toDouble(&ok);
-    if (ok)
-    {
-      _number = std::make_shared<DecimalData>(d);
-
-      if (_lineEdit)
-        _lineEdit->setText(strNum);
+            if (_lineEdit)
+                _lineEdit->setText(strNum);
+        }
     }
-  }
 }
 
-
-unsigned int
-NumberSourceDataModel::
-nPorts(PortType portType) const
+unsigned int NumberSourceDataModel::nPorts(PortType portType) const
 {
-  unsigned int result = 1;
+    unsigned int result = 1;
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      result = 0;
-      break;
+        result = 0;
+        break;
 
     case PortType::Out:
-      result = 1;
+        result = 1;
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-void
-NumberSourceDataModel::
-onTextEdited(QString const& str)
+void NumberSourceDataModel::onTextEdited(QString const &str)
 {
-  bool ok = false;
+    bool ok = false;
 
-  double number = str.toDouble(&ok);
+    double number = str.toDouble(&ok);
 
-  if (ok)
-  {
-    _number = std::make_shared<DecimalData>(number);
+    if (ok) {
+        _number = std::make_shared<DecimalData>(number);
+
+        Q_EMIT dataUpdated(0);
+
+    } else {
+        Q_EMIT dataInvalidated(0);
+    }
+}
+
+NodeDataType NumberSourceDataModel::dataType(PortType, PortIndex) const
+{
+    return DecimalData().type();
+}
+
+std::shared_ptr<NodeData> NumberSourceDataModel::outData(PortIndex)
+{
+    return _number;
+}
+
+QWidget *NumberSourceDataModel::embeddedWidget()
+{
+    if (!_lineEdit) {
+        _lineEdit = new QLineEdit();
+
+        _lineEdit->setValidator(new QDoubleValidator());
+        _lineEdit->setMaximumSize(_lineEdit->sizeHint());
+
+        connect(_lineEdit, &QLineEdit::textChanged, this, &NumberSourceDataModel::onTextEdited);
+
+        _lineEdit->setText(QString::number(_number->number()));
+    }
+
+    return _lineEdit;
+}
+
+void NumberSourceDataModel::setNumber(double n)
+{
+    _number = std::make_shared<DecimalData>(n);
 
     Q_EMIT dataUpdated(0);
 
-  }
-  else
-  {
-    Q_EMIT dataInvalidated(0);
-  }
-}
-
-
-NodeDataType
-NumberSourceDataModel::
-dataType(PortType, PortIndex) const
-{
-  return DecimalData().type();
-}
-
-
-std::shared_ptr<NodeData>
-NumberSourceDataModel::
-outData(PortIndex)
-{
-  return _number;
-}
-
-
-QWidget *
-NumberSourceDataModel::
-embeddedWidget()
-{
-  if (!_lineEdit)
-  {
-    _lineEdit = new QLineEdit();
-
-    _lineEdit->setValidator(new QDoubleValidator());
-    _lineEdit->setMaximumSize(_lineEdit->sizeHint());
-
-    connect(_lineEdit, &QLineEdit::textChanged,
-            this, &NumberSourceDataModel::onTextEdited);
-
-    _lineEdit->setText(QString::number(_number->number()));
-  }
-
-  return _lineEdit;
-}
-
-
-void 
-NumberSourceDataModel::
-setNumber(double n)
-{
-  _number = std::make_shared<DecimalData>(n);
-
-  Q_EMIT dataUpdated(0);
-
-  if(_lineEdit)
-    _lineEdit->setText(QString::number(_number->number()));
+    if (_lineEdit)
+        _lineEdit->setText(QString::number(_number->number()));
 }

--- a/examples/calculator/NumberSourceDataModel.hpp
+++ b/examples/calculator/NumberSourceDataModel.hpp
@@ -8,11 +8,11 @@
 
 class DecimalData;
 
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 class QLineEdit;
 
@@ -20,65 +20,45 @@ class QLineEdit;
 /// In this example it has no logic.
 class NumberSourceDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  NumberSourceDataModel();
+    NumberSourceDataModel();
 
-  virtual
-  ~NumberSourceDataModel() {}
-
-public:
-
-  QString
-  caption() const override
-  { return QStringLiteral("Number Source"); }
-
-  bool
-  captionVisible() const override
-  { return false; }
-
-  QString
-  name() const override
-  { return QStringLiteral("NumberSource"); }
+    virtual ~NumberSourceDataModel() {}
 
 public:
+    QString caption() const override { return QStringLiteral("Number Source"); }
 
-  QJsonObject
-  save() const override;
+    bool captionVisible() const override { return false; }
 
-  void
-  load(QJsonObject const& p) override;
-
-public:
-
-  unsigned int
-  nPorts(PortType portType) const override;
-
-  NodeDataType
-  dataType(PortType portType, PortIndex portIndex) const override;
-
-  std::shared_ptr<NodeData>
-  outData(PortIndex port) override;
-
-  void
-  setInData(std::shared_ptr<NodeData>, PortIndex) override
-  {}
-
-  QWidget *
-  embeddedWidget() override;
+    QString name() const override { return QStringLiteral("NumberSource"); }
 
 public:
-  void setNumber(double number);
+    QJsonObject save() const override;
+
+    void load(QJsonObject const &p) override;
+
+public:
+    unsigned int nPorts(PortType portType) const override;
+
+    NodeDataType dataType(PortType portType, PortIndex portIndex) const override;
+
+    std::shared_ptr<NodeData> outData(PortIndex port) override;
+
+    void setInData(std::shared_ptr<NodeData>, PortIndex) override {}
+
+    QWidget *embeddedWidget() override;
+
+public:
+    void setNumber(double number);
 
 private Q_SLOTS:
 
-  void
-  onTextEdited(QString const& string);
+    void onTextEdited(QString const &string);
 
 private:
+    std::shared_ptr<DecimalData> _number;
 
-  std::shared_ptr<DecimalData> _number;
-
-  QLineEdit* _lineEdit;
+    QLineEdit *_lineEdit;
 };

--- a/examples/calculator/SubtractionModel.hpp
+++ b/examples/calculator/SubtractionModel.hpp
@@ -14,73 +14,54 @@
 class SubtractionModel : public MathOperationDataModel
 {
 public:
-
-  virtual
-  ~SubtractionModel() {}
+    virtual ~SubtractionModel() {}
 
 public:
+    QString caption() const override { return QStringLiteral("Subtraction"); }
 
-  QString
-  caption() const override
-  { return QStringLiteral("Subtraction"); }
-
-  virtual bool
-  portCaptionVisible(PortType portType, PortIndex portIndex) const override
-  {
-    Q_UNUSED(portType); Q_UNUSED(portIndex);
-    return true;
-  }
-
-
-  virtual QString
-  portCaption(PortType portType, PortIndex portIndex) const override
-  {
-    switch (portType)
+    virtual bool portCaptionVisible(PortType portType, PortIndex portIndex) const override
     {
-      case PortType::In:
-        if (portIndex == 0)
-          return QStringLiteral("Minuend");
-        else if (portIndex == 1)
-          return QStringLiteral("Subtrahend");
-
-        break;
-
-      case PortType::Out:
-        return QStringLiteral("Result");
-
-      default:
-        break;
+        Q_UNUSED(portType);
+        Q_UNUSED(portIndex);
+        return true;
     }
-    return QString();
-  }
 
+    virtual QString portCaption(PortType portType, PortIndex portIndex) const override
+    {
+        switch (portType) {
+        case PortType::In:
+            if (portIndex == 0)
+                return QStringLiteral("Minuend");
+            else if (portIndex == 1)
+                return QStringLiteral("Subtrahend");
 
-  QString
-  name() const override
-  { return QStringLiteral("Subtraction"); }
+            break;
+
+        case PortType::Out:
+            return QStringLiteral("Result");
+
+        default:
+            break;
+        }
+        return QString();
+    }
+
+    QString name() const override { return QStringLiteral("Subtraction"); }
 
 private:
-
-  void
-  compute() override
-  {
-    PortIndex const outPortIndex = 0;
-
-    auto n1 = _number1.lock();
-    auto n2 = _number2.lock();
-
-    if (n1 && n2)
+    void compute() override
     {
-      _result = std::make_shared<DecimalData>(n1->number() -
-                                              n2->number());
+        PortIndex const outPortIndex = 0;
+
+        auto n1 = _number1.lock();
+        auto n2 = _number2.lock();
+
+        if (n1 && n2) {
+            _result = std::make_shared<DecimalData>(n1->number() - n2->number());
+        } else {
+            _result.reset();
+        }
+
+        Q_EMIT dataUpdated(outPortIndex);
     }
-    else
-    {
-      _result.reset();
-    }
-
-    Q_EMIT dataUpdated(outPortIndex);
-  }
-
-
 };

--- a/examples/calculator/headless_main.cpp
+++ b/examples/calculator/headless_main.cpp
@@ -8,31 +8,27 @@
 #include <QtNodes/DataFlowGraphModel>
 #include <QtNodes/NodeDelegateModelRegistry>
 
-
-using QtNodes::NodeId;
 using QtNodes::DataFlowGraphModel;
 using QtNodes::NodeDelegateModelRegistry;
+using QtNodes::NodeId;
 
-
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
-  ret->registerModel<NumberSourceDataModel>("Sources");
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    ret->registerModel<NumberSourceDataModel>("Sources");
 
-  ret->registerModel<NumberDisplayDataModel>("Displays");
+    ret->registerModel<NumberDisplayDataModel>("Displays");
 
-  ret->registerModel<AdditionModel>("Operators");
+    ret->registerModel<AdditionModel>("Operators");
 
-  ret->registerModel<SubtractionModel>("Operators");
+    ret->registerModel<SubtractionModel>("Operators");
 
-  ret->registerModel<MultiplicationModel>("Operators");
+    ret->registerModel<MultiplicationModel>("Operators");
 
-  ret->registerModel<DivisionModel>("Operators");
+    ret->registerModel<DivisionModel>("Operators");
 
-  return ret;
+    return ret;
 }
-
 
 /**
  * This scene JSON was saved by the normal `calculator` example.
@@ -47,7 +43,7 @@ registerDataModels()
  *                     \  O[____________]
  */
 static QString addingNumbersScene(
-R"(
+    R"(
     {
         "nodes": [
             {
@@ -105,41 +101,37 @@ R"(
     }
 )");
 
-
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
+    std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
 
-  // Here we create a graph model without attaching to any view or scene.
-  DataFlowGraphModel dataFlowGraphModel(registry);
+    // Here we create a graph model without attaching to any view or scene.
+    DataFlowGraphModel dataFlowGraphModel(registry);
 
-  // Alternatively you can create the graph by yourself with the functions
-  // `DataFlowGraphModel::addNode` and `DataFlowGraphModel::addConnection` and
-  // use the obtained `NodeId` to fetch the `NodeDelegateModel`s
-  QJsonDocument sceneJson = QJsonDocument::fromJson(addingNumbersScene.toUtf8());
+    // Alternatively you can create the graph by yourself with the functions
+    // `DataFlowGraphModel::addNode` and `DataFlowGraphModel::addConnection` and
+    // use the obtained `NodeId` to fetch the `NodeDelegateModel`s
+    QJsonDocument sceneJson = QJsonDocument::fromJson(addingNumbersScene.toUtf8());
 
-  dataFlowGraphModel.load(sceneJson.object());
+    dataFlowGraphModel.load(sceneJson.object());
 
-  qInfo() << "Data Flow graph was created from a json-serialized graph";
+    qInfo() << "Data Flow graph was created from a json-serialized graph";
 
-  NodeId const nodeSource = 0;
-  NodeId const nodeResult = 2;
+    NodeId const nodeSource = 0;
+    NodeId const nodeResult = 2;
 
+    qInfo() << "========================================";
+    qInfo() << "Entering the number " << 33.3 << "to the input node";
+    dataFlowGraphModel.delegateModel<NumberSourceDataModel>(nodeSource)->setNumber(33.3);
 
-  qInfo() << "========================================";
-  qInfo() << "Entering the number " << 33.3 << "to the input node";
-  dataFlowGraphModel.delegateModel<NumberSourceDataModel>(nodeSource)->setNumber(33.3);
+    qInfo() << "Result of the addiion operation: "
+            << dataFlowGraphModel.delegateModel<NumberDisplayDataModel>(nodeResult)->number();
 
-  qInfo() << "Result of the addiion operation: "
-          << dataFlowGraphModel.delegateModel<NumberDisplayDataModel>(nodeResult)->number();
+    qInfo() << "========================================";
+    qInfo() << "Entering the number " << -5. << "to the input node";
+    dataFlowGraphModel.delegateModel<NumberSourceDataModel>(nodeSource)->setNumber(-5);
 
-  qInfo() << "========================================";
-  qInfo() << "Entering the number " << -5. << "to the input node";
-  dataFlowGraphModel.delegateModel<NumberSourceDataModel>(nodeSource)->setNumber(-5);
-
-  qInfo() << "Result of the addiion operation: "
-          << dataFlowGraphModel.delegateModel<NumberDisplayDataModel>(nodeResult)->number();
-  return 0;
+    qInfo() << "Result of the addiion operation: "
+            << dataFlowGraphModel.delegateModel<NumberDisplayDataModel>(nodeResult)->number();
+    return 0;
 }
-

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -1,14 +1,14 @@
 #include <QtNodes/ConnectionStyle>
 #include <QtNodes/DataFlowGraphModel>
 #include <QtNodes/DataFlowGraphicsScene>
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/GraphicsView>
 #include <QtNodes/NodeData>
+#include <QtNodes/NodeDelegateModelRegistry>
 
+#include <QtGui/QScreen>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenuBar>
 #include <QtWidgets/QVBoxLayout>
-#include <QtGui/QScreen>
 
 #include <QtGui/QScreen>
 
@@ -20,38 +20,33 @@
 #include "SubtractionModel.hpp"
 
 using QtNodes::ConnectionStyle;
-using QtNodes::DataFlowGraphModel;
 using QtNodes::DataFlowGraphicsScene;
-using QtNodes::NodeDelegateModelRegistry;
+using QtNodes::DataFlowGraphModel;
 using QtNodes::GraphicsView;
+using QtNodes::NodeDelegateModelRegistry;
 
-
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
-  ret->registerModel<NumberSourceDataModel>("Sources");
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    ret->registerModel<NumberSourceDataModel>("Sources");
 
-  ret->registerModel<NumberDisplayDataModel>("Displays");
+    ret->registerModel<NumberDisplayDataModel>("Displays");
 
-  ret->registerModel<AdditionModel>("Operators");
+    ret->registerModel<AdditionModel>("Operators");
 
-  ret->registerModel<SubtractionModel>("Operators");
+    ret->registerModel<SubtractionModel>("Operators");
 
-  ret->registerModel<MultiplicationModel>("Operators");
+    ret->registerModel<MultiplicationModel>("Operators");
 
-  ret->registerModel<DivisionModel>("Operators");
+    ret->registerModel<DivisionModel>("Operators");
 
-  return ret;
+    return ret;
 }
 
-
-static
-void
-setStyle()
+static void setStyle()
 {
-  ConnectionStyle::setConnectionStyle(
-    R"(
+    ConnectionStyle::setConnectionStyle(
+        R"(
   {
     "ConnectionStyle": {
       "ConstructionColor": "gray",
@@ -70,51 +65,45 @@ setStyle()
   )");
 }
 
-
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  setStyle();
+    setStyle();
 
-  std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
+    std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
 
-  QWidget mainWidget;
+    QWidget mainWidget;
 
-  auto menuBar = new QMenuBar();
-  QMenu* menu = menuBar->addMenu("File");
-  auto saveAction = menu->addAction("Save Scene");
-  auto loadAction = menu->addAction("Load Scene");
+    auto menuBar = new QMenuBar();
+    QMenu *menu = menuBar->addMenu("File");
+    auto saveAction = menu->addAction("Save Scene");
+    auto loadAction = menu->addAction("Load Scene");
 
-  QVBoxLayout* l = new QVBoxLayout(&mainWidget);
+    QVBoxLayout *l = new QVBoxLayout(&mainWidget);
 
-  DataFlowGraphModel dataFlowGraphModel(registry);
+    DataFlowGraphModel dataFlowGraphModel(registry);
 
-  l->addWidget(menuBar);
-  auto scene = new DataFlowGraphicsScene(dataFlowGraphModel,
-                                         &mainWidget);
+    l->addWidget(menuBar);
+    auto scene = new DataFlowGraphicsScene(dataFlowGraphModel, &mainWidget);
 
-  auto view = new GraphicsView(scene);
-  l->addWidget(view);
-  l->setContentsMargins(0, 0, 0, 0);
-  l->setSpacing(0);
+    auto view = new GraphicsView(scene);
+    l->addWidget(view);
+    l->setContentsMargins(0, 0, 0, 0);
+    l->setSpacing(0);
 
-  QObject::connect(saveAction, &QAction::triggered,
-                   scene, &DataFlowGraphicsScene::save);
+    QObject::connect(saveAction, &QAction::triggered, scene, &DataFlowGraphicsScene::save);
 
-  QObject::connect(loadAction, &QAction::triggered,
-                   scene, &DataFlowGraphicsScene::load);
+    QObject::connect(loadAction, &QAction::triggered, scene, &DataFlowGraphicsScene::load);
 
-  QObject::connect(scene, &DataFlowGraphicsScene::sceneLoaded,
-                   view, &GraphicsView::centerScene);
+    QObject::connect(scene, &DataFlowGraphicsScene::sceneLoaded, view, &GraphicsView::centerScene);
 
-  mainWidget.setWindowTitle("Data Flow: simplest calculator");
-  mainWidget.resize(800, 600);
-  // Center window.
-  mainWidget.move(QApplication::primaryScreen()->availableGeometry().center() - mainWidget.rect().center());
-  mainWidget.showNormal();
+    mainWidget.setWindowTitle("Data Flow: simplest calculator");
+    mainWidget.resize(800, 600);
+    // Center window.
+    mainWidget.move(QApplication::primaryScreen()->availableGeometry().center()
+                    - mainWidget.rect().center());
+    mainWidget.showNormal();
 
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/connection_colors/main.cpp
+++ b/examples/connection_colors/main.cpp
@@ -3,26 +3,25 @@
 #include <QtNodes/ConnectionStyle>
 #include <QtNodes/DataFlowGraphModel>
 #include <QtNodes/DataFlowGraphicsScene>
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/GraphicsView>
 #include <QtNodes/NodeData>
+#include <QtNodes/NodeDelegateModelRegistry>
 
 #include "models.hpp"
 
-using QtNodes::NodeDelegateModelRegistry;
-using QtNodes::DataFlowGraphModel;
-using QtNodes::DataFlowGraphicsScene;
-using QtNodes::GraphicsView;
 using QtNodes::ConnectionStyle;
+using QtNodes::DataFlowGraphicsScene;
+using QtNodes::DataFlowGraphModel;
+using QtNodes::GraphicsView;
+using QtNodes::NodeDelegateModelRegistry;
 
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
 
-  ret->registerModel<NaiveDataModel>();
+    ret->registerModel<NaiveDataModel>();
 
-  /*
+    /*
      We could have more models registered.
      All of them become items in the context meny of the scene.
 
@@ -31,16 +30,13 @@ registerDataModels()
 
    */
 
-  return ret;
+    return ret;
 }
 
-
-static
-void
-setStyle()
+static void setStyle()
 {
-  ConnectionStyle::setConnectionStyle(
-    R"(
+    ConnectionStyle::setConnectionStyle(
+        R"(
   {
     "ConnectionStyle": {
       "UseDataDefinedColors": true
@@ -49,27 +45,24 @@ setStyle()
   )");
 }
 
-
 //------------------------------------------------------------------------------
 
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  setStyle();
+    setStyle();
 
-  std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
-  DataFlowGraphModel dataFlowGraphModel(registry);
+    std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
+    DataFlowGraphModel dataFlowGraphModel(registry);
 
-  DataFlowGraphicsScene scene(dataFlowGraphModel);
+    DataFlowGraphicsScene scene(dataFlowGraphModel);
 
-  GraphicsView view(&scene);
+    GraphicsView view(&scene);
 
-  view.setWindowTitle("Node-based flow editor");
-  view.resize(800, 600);
-  view.show();
+    view.setWindowTitle("Node-based flow editor");
+    view.resize(800, 600);
+    view.show();
 
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/connection_colors/models.hpp
+++ b/examples/connection_colors/models.hpp
@@ -10,34 +10,21 @@
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
-using QtNodes::PortType;
 using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 /// The class can potentially incapsulate any user data which
 /// need to be transferred within the Node Editor graph
 class MyNodeData : public NodeData
 {
 public:
-  NodeDataType
-  type() const override
-  {
-    return NodeDataType {"MyNodeData",
-                         "My Node Data"};
-  }
-
+    NodeDataType type() const override { return NodeDataType{"MyNodeData", "My Node Data"}; }
 };
-
 
 class SimpleNodeData : public NodeData
 {
 public:
-  NodeDataType
-  type() const override
-  {
-    return NodeDataType {"SimpleData",
-                         "Simple Data"};
-  }
-
+    NodeDataType type() const override { return NodeDataType{"SimpleData", "Simple Data"}; }
 };
 
 //------------------------------------------------------------------------------
@@ -46,101 +33,76 @@ public:
 /// In this example it has no logic.
 class NaiveDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-
-  virtual
-  ~NaiveDataModel() {}
+    virtual ~NaiveDataModel() {}
 
 public:
+    QString caption() const override { return QString("Naive Data Model"); }
 
-  QString
-  caption() const override
-  {
-    return QString("Naive Data Model");
-  }
-
-
-  QString
-  name() const override
-  { return QString("NaiveDataModel"); }
+    QString name() const override { return QString("NaiveDataModel"); }
 
 public:
-
-  unsigned int
-  nPorts(PortType const portType) const override
-  {
-    unsigned int result = 1;
-
-    switch (portType)
+    unsigned int nPorts(PortType const portType) const override
     {
-      case PortType::In:
-        result = 2;
-        break;
+        unsigned int result = 1;
 
-      case PortType::Out:
-        result = 2;
-        break;
-      case PortType::None:
-        break;
+        switch (portType) {
+        case PortType::In:
+            result = 2;
+            break;
+
+        case PortType::Out:
+            result = 2;
+            break;
+        case PortType::None:
+            break;
+        }
+
+        return result;
     }
 
-    return result;
-  }
-
-
-  NodeDataType
-  dataType(PortType const  portType,
-           PortIndex const portIndex) const override
-  {
-    switch (portType)
+    NodeDataType dataType(PortType const portType, PortIndex const portIndex) const override
     {
-      case PortType::In:
-        switch (portIndex)
-        {
-          case 0:
-            return MyNodeData().type();
-          case 1:
-            return SimpleNodeData().type();
-        }
-        break;
+        switch (portType) {
+        case PortType::In:
+            switch (portIndex) {
+            case 0:
+                return MyNodeData().type();
+            case 1:
+                return SimpleNodeData().type();
+            }
+            break;
 
-      case PortType::Out:
-        switch (portIndex)
-        {
-          case 0:
-            return MyNodeData().type();
-          case 1:
-            return SimpleNodeData().type();
-        }
-        break;
+        case PortType::Out:
+            switch (portIndex) {
+            case 0:
+                return MyNodeData().type();
+            case 1:
+                return SimpleNodeData().type();
+            }
+            break;
 
-      case PortType::None:
-        break;
+        case PortType::None:
+            break;
+        }
+        // FIXME: control may reach end of non-void function [-Wreturn-type]
+        return NodeDataType();
     }
-    // FIXME: control may reach end of non-void function [-Wreturn-type]
-    return NodeDataType();
-  }
 
+    std::shared_ptr<NodeData> outData(PortIndex const port) override
+    {
+        if (port < 1)
+            return std::make_shared<MyNodeData>();
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex const port) override
-  {
-    if (port < 1)
-      return std::make_shared<MyNodeData>();
+        return std::make_shared<SimpleNodeData>();
+    }
 
-    return std::make_shared<SimpleNodeData>();
-  }
+    void setInData(std::shared_ptr<NodeData>, PortIndex const) override
+    {
+        //
+    }
 
-
-  void
-  setInData(std::shared_ptr<NodeData>, PortIndex const) override
-  {
-    //
-  }
-
-
-  QWidget*
-  embeddedWidget() override { return nullptr; }
+    QWidget *embeddedWidget() override { return nullptr; }
 };

--- a/examples/dynamic_ports/DynamicPortsModel.cpp
+++ b/examples/dynamic_ports/DynamicPortsModel.cpp
@@ -8,508 +8,403 @@
 
 #include <iterator>
 
-
-DynamicPortsModel::
-DynamicPortsModel()
-  : _nextNodeId{0}
+DynamicPortsModel::DynamicPortsModel()
+    : _nextNodeId{0}
 {}
 
-
-DynamicPortsModel::
-~DynamicPortsModel()
+DynamicPortsModel::~DynamicPortsModel()
 {
-  //
+    //
 }
 
-
-std::unordered_set<NodeId>
-DynamicPortsModel::
-allNodeIds() const
+std::unordered_set<NodeId> DynamicPortsModel::allNodeIds() const
 {
-  return _nodeIds;
+    return _nodeIds;
 }
 
-
-std::unordered_set<ConnectionId>
-DynamicPortsModel::
-allConnectionIds(NodeId const nodeId) const
+std::unordered_set<ConnectionId> DynamicPortsModel::allConnectionIds(NodeId const nodeId) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&nodeId](ConnectionId const & cid)
-               {
-                  return cid.inNodeId == nodeId ||
-                         cid.outNodeId == nodeId;
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&nodeId](ConnectionId const &cid) {
+                     return cid.inNodeId == nodeId || cid.outNodeId == nodeId;
+                 });
 
-  return result;
+    return result;
 }
 
-
-std::unordered_set<ConnectionId>
-DynamicPortsModel::
-connections(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex) const
+std::unordered_set<ConnectionId> DynamicPortsModel::connections(NodeId nodeId,
+                                                                PortType portType,
+                                                                PortIndex portIndex) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&portType, &portIndex, &nodeId](ConnectionId const & cid)
-               {
-                  return (getNodeId(portType, cid) == nodeId &&
-                          getPortIndex(portType, cid) == portIndex);
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&portType, &portIndex, &nodeId](ConnectionId const &cid) {
+                     return (getNodeId(portType, cid) == nodeId
+                             && getPortIndex(portType, cid) == portIndex);
+                 });
 
-  return result;
+    return result;
 }
 
-
-bool
-DynamicPortsModel::
-connectionExists(ConnectionId const connectionId) const
+bool DynamicPortsModel::connectionExists(ConnectionId const connectionId) const
 {
-  return (_connectivity.find(connectionId) != _connectivity.end());
+    return (_connectivity.find(connectionId) != _connectivity.end());
 }
 
-
-NodeId
-DynamicPortsModel::
-addNode(QString const nodeType)
+NodeId DynamicPortsModel::addNode(QString const nodeType)
 {
-  NodeId newId = newNodeId();
+    NodeId newId = newNodeId();
 
-  // Create new node.
-  _nodeIds.insert(newId);
+    // Create new node.
+    _nodeIds.insert(newId);
 
-  Q_EMIT nodeCreated(newId);
+    Q_EMIT nodeCreated(newId);
 
-  return newId;
+    return newId;
 }
 
-
-bool
-DynamicPortsModel::
-connectionPossible(ConnectionId const connectionId) const
+bool DynamicPortsModel::connectionPossible(ConnectionId const connectionId) const
 {
-  return !connectionExists(connectionId);
+    return !connectionExists(connectionId);
 }
 
-
-void
-DynamicPortsModel::
-addConnection(ConnectionId const connectionId)
+void DynamicPortsModel::addConnection(ConnectionId const connectionId)
 {
-  _connectivity.insert(connectionId);
+    _connectivity.insert(connectionId);
 
-  Q_EMIT connectionCreated(connectionId);
+    Q_EMIT connectionCreated(connectionId);
 }
 
-
-bool
-DynamicPortsModel::
-nodeExists(NodeId const nodeId) const
+bool DynamicPortsModel::nodeExists(NodeId const nodeId) const
 {
-  return (_nodeIds.find(nodeId) != _nodeIds.end());
+    return (_nodeIds.find(nodeId) != _nodeIds.end());
 }
 
-
-PortAddRemoveWidget*
-DynamicPortsModel::
-widget(NodeId nodeId) const
+PortAddRemoveWidget *DynamicPortsModel::widget(NodeId nodeId) const
 {
-  auto it = _nodeWidgets.find(nodeId);
-  if (it == _nodeWidgets.end())
-  {
-    _nodeWidgets[nodeId] =
-      new PortAddRemoveWidget(0, 0, nodeId,
-                              *const_cast<DynamicPortsModel*>(this));
-  }
+    auto it = _nodeWidgets.find(nodeId);
+    if (it == _nodeWidgets.end()) {
+        _nodeWidgets[nodeId] = new PortAddRemoveWidget(0,
+                                                       0,
+                                                       nodeId,
+                                                       *const_cast<DynamicPortsModel *>(this));
+    }
 
-  return _nodeWidgets[nodeId];
+    return _nodeWidgets[nodeId];
 }
 
-
-QVariant
-DynamicPortsModel::
-nodeData(NodeId nodeId, NodeRole role) const
+QVariant DynamicPortsModel::nodeData(NodeId nodeId, NodeRole role) const
 {
-  Q_UNUSED(nodeId);
+    Q_UNUSED(nodeId);
 
-  QVariant result;
+    QVariant result;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      result = QString("Default Node Type");
-      break;
+        result = QString("Default Node Type");
+        break;
 
     case NodeRole::Position:
-      result = _nodeGeometryData[nodeId].pos;
-      break;
+        result = _nodeGeometryData[nodeId].pos;
+        break;
 
     case NodeRole::Size:
-      result = _nodeGeometryData[nodeId].size;
-      break;
+        result = _nodeGeometryData[nodeId].size;
+        break;
 
     case NodeRole::CaptionVisible:
-      result = true;
-      break;
+        result = true;
+        break;
 
     case NodeRole::Caption:
-      result = QString("Node");
-      break;
+        result = QString("Node");
+        break;
 
-    case NodeRole::Style:
-    {
-      auto style = StyleCollection::nodeStyle();
-      result = style.toJson().toVariantMap();
-    }
-    break;
+    case NodeRole::Style: {
+        auto style = StyleCollection::nodeStyle();
+        result = style.toJson().toVariantMap();
+    } break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      result = _nodePortCounts[nodeId].in;
-      break;
+        result = _nodePortCounts[nodeId].in;
+        break;
 
     case NodeRole::OutPortCount:
-      result = _nodePortCounts[nodeId].out;
-      break;
+        result = _nodePortCounts[nodeId].out;
+        break;
 
-    case NodeRole::Widget:
-    {
-      result = QVariant::fromValue(widget(nodeId));
-      break;
+    case NodeRole::Widget: {
+        result = QVariant::fromValue(widget(nodeId));
+        break;
     }
-  }
+    }
 
-  return result;
+    return result;
 }
 
-
-bool
-DynamicPortsModel::
-setNodeData(NodeId   nodeId,
-            NodeRole role,
-            QVariant value)
+bool DynamicPortsModel::setNodeData(NodeId nodeId, NodeRole role, QVariant value)
 {
-  bool result = false;
+    bool result = false;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      break;
-    case NodeRole::Position:
-    {
-      _nodeGeometryData[nodeId].pos = value.value<QPointF>();
+        break;
+    case NodeRole::Position: {
+        _nodeGeometryData[nodeId].pos = value.value<QPointF>();
 
-      Q_EMIT nodePositionUpdated(nodeId);
+        Q_EMIT nodePositionUpdated(nodeId);
 
-      result = true;
-    }
-    break;
+        result = true;
+    } break;
 
-    case NodeRole::Size:
-    {
-
-      _nodeGeometryData[nodeId].size = value.value<QSize>();
-      result = true;
-    }
-    break;
+    case NodeRole::Size: {
+        _nodeGeometryData[nodeId].size = value.value<QSize>();
+        result = true;
+    } break;
 
     case NodeRole::CaptionVisible:
-      break;
+        break;
 
     case NodeRole::Caption:
-      break;
+        break;
 
     case NodeRole::Style:
-      break;
+        break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      _nodePortCounts[nodeId].in = value.toUInt();
-      widget(nodeId)->populateButtons(PortType::In, value.toUInt());
-      break;
+        _nodePortCounts[nodeId].in = value.toUInt();
+        widget(nodeId)->populateButtons(PortType::In, value.toUInt());
+        break;
 
     case NodeRole::OutPortCount:
-      _nodePortCounts[nodeId].out = value.toUInt();
-      widget(nodeId)->populateButtons(PortType::Out, value.toUInt());
-      break;
+        _nodePortCounts[nodeId].out = value.toUInt();
+        widget(nodeId)->populateButtons(PortType::Out, value.toUInt());
+        break;
 
     case NodeRole::Widget:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-QVariant
-DynamicPortsModel::
-portData(NodeId    nodeId,
-         PortType  portType,
-         PortIndex portIndex,
-         PortRole  role) const
+QVariant DynamicPortsModel::portData(NodeId nodeId,
+                                     PortType portType,
+                                     PortIndex portIndex,
+                                     PortRole role) const
 {
-  switch (role)
-  {
+    switch (role) {
     case PortRole::Data:
-      return QVariant();
-      break;
+        return QVariant();
+        break;
 
     case PortRole::DataType:
-      return QVariant();
-      break;
+        return QVariant();
+        break;
 
     case PortRole::ConnectionPolicyRole:
-      return QVariant::fromValue(ConnectionPolicy::One);
-      break;
+        return QVariant::fromValue(ConnectionPolicy::One);
+        break;
 
     case PortRole::CaptionVisible:
-      return true;
-      break;
+        return true;
+        break;
 
     case PortRole::Caption:
-      if (portType == PortType::In)
-        return QString::fromUtf8("Port In");
-      else
-        return QString::fromUtf8("Port Out");
+        if (portType == PortType::In)
+            return QString::fromUtf8("Port In");
+        else
+            return QString::fromUtf8("Port Out");
 
-      break;
-  }
+        break;
+    }
 
-  return QVariant();
+    return QVariant();
 }
 
-
-bool
-DynamicPortsModel::
-setPortData(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex,
-            QVariant const& value,
-            PortRole  role)
+bool DynamicPortsModel::setPortData(
+    NodeId nodeId, PortType portType, PortIndex portIndex, QVariant const &value, PortRole role)
 {
-  Q_UNUSED(nodeId);
-  Q_UNUSED(portType);
-  Q_UNUSED(portIndex);
-  Q_UNUSED(value);
-  Q_UNUSED(role);
+    Q_UNUSED(nodeId);
+    Q_UNUSED(portType);
+    Q_UNUSED(portIndex);
+    Q_UNUSED(value);
+    Q_UNUSED(role);
 
-  return false;
+    return false;
 }
 
-
-bool
-DynamicPortsModel::
-deleteConnection(ConnectionId const connectionId)
+bool DynamicPortsModel::deleteConnection(ConnectionId const connectionId)
 {
-  bool disconnected = false;
+    bool disconnected = false;
 
-  auto it = _connectivity.find(connectionId);
+    auto it = _connectivity.find(connectionId);
 
-  if (it != _connectivity.end())
-  {
-    disconnected = true;
+    if (it != _connectivity.end()) {
+        disconnected = true;
 
-    _connectivity.erase(it);
-  };
+        _connectivity.erase(it);
+    };
 
-  if (disconnected)
-    Q_EMIT connectionDeleted(connectionId);
+    if (disconnected)
+        Q_EMIT connectionDeleted(connectionId);
 
-  return disconnected;
+    return disconnected;
 }
 
-
-bool
-DynamicPortsModel::
-deleteNode(NodeId const nodeId)
+bool DynamicPortsModel::deleteNode(NodeId const nodeId)
 {
-  // Delete connections to this node first.
-  auto connectionIds = allConnectionIds(nodeId);
-  for (auto & cId : connectionIds)
-  {
-    deleteConnection(cId);
-  }
+    // Delete connections to this node first.
+    auto connectionIds = allConnectionIds(nodeId);
+    for (auto &cId : connectionIds) {
+        deleteConnection(cId);
+    }
 
-  _nodeIds.erase(nodeId);
-  _nodeGeometryData.erase(nodeId);
-  _nodePortCounts.erase(nodeId);
-  _nodeWidgets.erase(nodeId);
+    _nodeIds.erase(nodeId);
+    _nodeGeometryData.erase(nodeId);
+    _nodePortCounts.erase(nodeId);
+    _nodeWidgets.erase(nodeId);
 
-  Q_EMIT nodeDeleted(nodeId);
+    Q_EMIT nodeDeleted(nodeId);
 
-  return true;
+    return true;
 }
 
-
-QJsonObject
-DynamicPortsModel::
-saveNode(NodeId const nodeId) const
+QJsonObject DynamicPortsModel::saveNode(NodeId const nodeId) const
 {
-  QJsonObject nodeJson;
+    QJsonObject nodeJson;
 
-  nodeJson["id"] = static_cast<qint64>(nodeId);
+    nodeJson["id"] = static_cast<qint64>(nodeId);
 
-  {
-    QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
+    {
+        QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
 
-    QJsonObject posJson;
-    posJson["x"] = pos.x();
-    posJson["y"] = pos.y();
-    nodeJson["position"] = posJson;
+        QJsonObject posJson;
+        posJson["x"] = pos.x();
+        posJson["y"] = pos.y();
+        nodeJson["position"] = posJson;
 
-    nodeJson["inPortCount"] = QString::number(_nodePortCounts[nodeId].in);
-    nodeJson["outPortCount"] = QString::number(_nodePortCounts[nodeId].out);
-  }
+        nodeJson["inPortCount"] = QString::number(_nodePortCounts[nodeId].in);
+        nodeJson["outPortCount"] = QString::number(_nodePortCounts[nodeId].out);
+    }
 
-  return nodeJson;
+    return nodeJson;
 }
 
-
-QJsonObject
-DynamicPortsModel::
-save() const
+QJsonObject DynamicPortsModel::save() const
 {
-  QJsonObject sceneJson;
+    QJsonObject sceneJson;
 
-  QJsonArray nodesJsonArray;
-  for (auto const nodeId : allNodeIds())
-  {
-    nodesJsonArray.append(saveNode(nodeId));
-  }
-  sceneJson["nodes"] = nodesJsonArray;
+    QJsonArray nodesJsonArray;
+    for (auto const nodeId : allNodeIds()) {
+        nodesJsonArray.append(saveNode(nodeId));
+    }
+    sceneJson["nodes"] = nodesJsonArray;
 
+    QJsonArray connJsonArray;
+    for (auto const &cid : _connectivity) {
+        connJsonArray.append(QtNodes::toJson(cid));
+    }
+    sceneJson["connections"] = connJsonArray;
 
-  QJsonArray connJsonArray;
-  for (auto const & cid : _connectivity)
-  {
-    connJsonArray.append(QtNodes::toJson(cid));
-  }
-  sceneJson["connections"] = connJsonArray;
-
-  return sceneJson;
+    return sceneJson;
 }
 
-
-void
-DynamicPortsModel::
-loadNode(QJsonObject const & nodeJson)
+void DynamicPortsModel::loadNode(QJsonObject const &nodeJson)
 {
-  NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInt());
+    NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInt());
 
-  _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
+    _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
 
-  // Create new node.
-  _nodeIds.insert(restoredNodeId);
+    // Create new node.
+    _nodeIds.insert(restoredNodeId);
 
-  setNodeData(restoredNodeId,
-              NodeRole::InPortCount,
-              nodeJson["inPortCount"].toString().toUInt());
-
-  setNodeData(restoredNodeId,
-              NodeRole::OutPortCount,
-              nodeJson["outPortCount"].toString().toUInt());
-
-  {
-    QJsonObject posJson = nodeJson["position"].toObject();
-    QPointF const pos(posJson["x"].toDouble(),
-                      posJson["y"].toDouble());
+    setNodeData(restoredNodeId, NodeRole::InPortCount, nodeJson["inPortCount"].toString().toUInt());
 
     setNodeData(restoredNodeId,
-                NodeRole::Position,
-                pos);
+                NodeRole::OutPortCount,
+                nodeJson["outPortCount"].toString().toUInt());
 
-  }
+    {
+        QJsonObject posJson = nodeJson["position"].toObject();
+        QPointF const pos(posJson["x"].toDouble(), posJson["y"].toDouble());
 
-  Q_EMIT nodeCreated(restoredNodeId);
+        setNodeData(restoredNodeId, NodeRole::Position, pos);
+    }
+
+    Q_EMIT nodeCreated(restoredNodeId);
 }
 
-
-void
-DynamicPortsModel::
-load(QJsonObject const &jsonDocument)
+void DynamicPortsModel::load(QJsonObject const &jsonDocument)
 {
-  QJsonArray nodesJsonArray = jsonDocument["nodes"].toArray();
+    QJsonArray nodesJsonArray = jsonDocument["nodes"].toArray();
 
-  for (QJsonValueRef nodeJson : nodesJsonArray)
-  {
-    loadNode(nodeJson.toObject());
-  }
+    for (QJsonValueRef nodeJson : nodesJsonArray) {
+        loadNode(nodeJson.toObject());
+    }
 
-  QJsonArray connectionJsonArray = jsonDocument["connections"].toArray();
+    QJsonArray connectionJsonArray = jsonDocument["connections"].toArray();
 
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
+    for (QJsonValueRef connection : connectionJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-    ConnectionId connId = QtNodes::fromJson(connJson);
+        ConnectionId connId = QtNodes::fromJson(connJson);
 
-    // Restore the connection
-    addConnection(connId);
-  }
+        // Restore the connection
+        addConnection(connId);
+    }
 }
 
-
-void
-DynamicPortsModel::
-addPort(NodeId nodeId,
-        PortType portType,
-        PortIndex portIndex)
+void DynamicPortsModel::addPort(NodeId nodeId, PortType portType, PortIndex portIndex)
 {
-  // STAGE 1.
-  // Compute new addresses for the existing connections that are shifted and
-  // placed after the new ones
-  PortIndex first = portIndex;
-  PortIndex last = first;
-  portsAboutToBeInserted(nodeId, portType, first, last);
+    // STAGE 1.
+    // Compute new addresses for the existing connections that are shifted and
+    // placed after the new ones
+    PortIndex first = portIndex;
+    PortIndex last = first;
+    portsAboutToBeInserted(nodeId, portType, first, last);
 
+    // STAGE 2. Change the number of connections in your model
+    if (portType == PortType::In)
+        _nodePortCounts[nodeId].in++;
+    else
+        _nodePortCounts[nodeId].out++;
 
-  // STAGE 2. Change the number of connections in your model
-  if (portType == PortType::In)
-    _nodePortCounts[nodeId].in++;
-  else
-    _nodePortCounts[nodeId].out++;
+    // STAGE 3. Re-create previouly existed and now shifted connections
+    portsInserted();
 
-
-  // STAGE 3. Re-create previouly existed and now shifted connections
-  portsInserted();
-
-  Q_EMIT nodeUpdated(nodeId);
+    Q_EMIT nodeUpdated(nodeId);
 }
 
-
-void
-DynamicPortsModel::
-removePort(NodeId nodeId,
-           PortType portType,
-           PortIndex portIndex)
+void DynamicPortsModel::removePort(NodeId nodeId, PortType portType, PortIndex portIndex)
 {
-  // STAGE 1.
-  // Compute new addresses for the existing connections that are shifted upwards
-  // instead of the deleted ports.
-  PortIndex first = portIndex;
-  PortIndex last = first;
-  portsAboutToBeDeleted(nodeId, portType, first, last);
+    // STAGE 1.
+    // Compute new addresses for the existing connections that are shifted upwards
+    // instead of the deleted ports.
+    PortIndex first = portIndex;
+    PortIndex last = first;
+    portsAboutToBeDeleted(nodeId, portType, first, last);
 
-  // STAGE 2. Change the number of connections in your model
-  if (portType == PortType::In)
-    _nodePortCounts[nodeId].in--;
-  else
-    _nodePortCounts[nodeId].out--;
+    // STAGE 2. Change the number of connections in your model
+    if (portType == PortType::In)
+        _nodePortCounts[nodeId].in--;
+    else
+        _nodePortCounts[nodeId].out--;
 
-  portsDeleted();
+    portsDeleted();
 
-  Q_EMIT nodeUpdated(nodeId);
+    Q_EMIT nodeUpdated(nodeId);
 }

--- a/examples/dynamic_ports/DynamicPortsModel.hpp
+++ b/examples/dynamic_ports/DynamicPortsModel.hpp
@@ -1,21 +1,20 @@
 #pragma once
 
+#include <QtCore/QJsonObject>
 #include <QtCore/QPointF>
 #include <QtCore/QSize>
-#include <QtCore/QJsonObject>
 
 #include <QtNodes/AbstractGraphModel>
 #include <QtNodes/StyleCollection>
 
-
-using ConnectionId     = QtNodes::ConnectionId;
+using ConnectionId = QtNodes::ConnectionId;
 using ConnectionPolicy = QtNodes::ConnectionPolicy;
-using NodeFlag        = QtNodes::NodeFlag;
-using NodeId          = QtNodes::NodeId;
-using NodeRole        = QtNodes::NodeRole;
-using PortIndex       = QtNodes::PortIndex;
-using PortRole        = QtNodes::PortRole;
-using PortType        = QtNodes::PortType;
+using NodeFlag = QtNodes::NodeFlag;
+using NodeId = QtNodes::NodeId;
+using NodeRole = QtNodes::NodeRole;
+using PortIndex = QtNodes::PortIndex;
+using PortRole = QtNodes::PortRole;
+using PortType = QtNodes::PortType;
 using StyleCollection = QtNodes::StyleCollection;
 using QtNodes::InvalidNodeId;
 
@@ -27,128 +26,101 @@ class PortAddRemoveWidget;
  */
 class DynamicPortsModel : public QtNodes::AbstractGraphModel
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  struct NodeGeometryData
-  {
-    QSize size;
-    QPointF pos;
-  };
+    struct NodeGeometryData
+    {
+        QSize size;
+        QPointF pos;
+    };
 
 public:
-  DynamicPortsModel();
+    DynamicPortsModel();
 
-  ~DynamicPortsModel() override;
+    ~DynamicPortsModel() override;
 
-  std::unordered_set<NodeId>
-  allNodeIds() const override;
+    std::unordered_set<NodeId> allNodeIds() const override;
 
-  std::unordered_set<ConnectionId>
-  allConnectionIds(NodeId const nodeId) const override;
+    std::unordered_set<ConnectionId> allConnectionIds(NodeId const nodeId) const override;
 
-  std::unordered_set<ConnectionId>
-  connections(NodeId    nodeId,
-              PortType  portType,
-              PortIndex portIndex) const override;
+    std::unordered_set<ConnectionId> connections(NodeId nodeId,
+                                                 PortType portType,
+                                                 PortIndex portIndex) const override;
 
-  bool
-  connectionExists(ConnectionId const connectionId) const override;
+    bool connectionExists(ConnectionId const connectionId) const override;
 
-  NodeId
-  addNode(QString const nodeType = QString()) override;
+    NodeId addNode(QString const nodeType = QString()) override;
 
-  /**
+    /**
    * Connection is possible when graph contains no connectivity data
    * in both directions `Out -> In` and `In -> Out`.
    */
-  bool
-  connectionPossible(ConnectionId const connectionId) const override;
+    bool connectionPossible(ConnectionId const connectionId) const override;
 
-  void
-  addConnection(ConnectionId const connectionId) override;
+    void addConnection(ConnectionId const connectionId) override;
 
-  bool
-  nodeExists(NodeId const nodeId) const override;
+    bool nodeExists(NodeId const nodeId) const override;
 
-  QVariant
-  nodeData(NodeId nodeId, NodeRole role) const override;
+    QVariant nodeData(NodeId nodeId, NodeRole role) const override;
 
-  bool
-  setNodeData(NodeId   nodeId,
-              NodeRole role,
-              QVariant value) override;
+    bool setNodeData(NodeId nodeId, NodeRole role, QVariant value) override;
 
-  QVariant
-  portData(NodeId    nodeId,
-           PortType  portType,
-           PortIndex portIndex,
-           PortRole  role) const override;
+    QVariant portData(NodeId nodeId,
+                      PortType portType,
+                      PortIndex portIndex,
+                      PortRole role) const override;
 
-  bool
-  setPortData(NodeId    nodeId,
-              PortType  portType,
-              PortIndex portIndex,
-              QVariant const& value,
-              PortRole        role = PortRole::Data) override;
+    bool setPortData(NodeId nodeId,
+                     PortType portType,
+                     PortIndex portIndex,
+                     QVariant const &value,
+                     PortRole role = PortRole::Data) override;
 
-  bool
-  deleteConnection(ConnectionId const connectionId) override;
+    bool deleteConnection(ConnectionId const connectionId) override;
 
-  bool
-  deleteNode(NodeId const nodeId) override;
+    bool deleteNode(NodeId const nodeId) override;
 
-  QJsonObject
-  saveNode(NodeId const) const override;
+    QJsonObject saveNode(NodeId const) const override;
 
-  QJsonObject
-  save() const;
+    QJsonObject save() const;
 
-  /// @brief Creates a new node based on the informatoin in `nodeJson`.
-  /**
+    /// @brief Creates a new node based on the informatoin in `nodeJson`.
+    /**
    * @param nodeJson conains a `NodeId`, node's position, internal node
    * information.
    */
-  void
-  loadNode(QJsonObject const & nodeJson) override;
+    void loadNode(QJsonObject const &nodeJson) override;
 
-  void
-  load(QJsonObject const &jsonDocument);
+    void load(QJsonObject const &jsonDocument);
 
-  void
-  addPort(NodeId nodeId,
-          PortType portType,
-          PortIndex portIndex);
+    void addPort(NodeId nodeId, PortType portType, PortIndex portIndex);
 
-  void
-  removePort(NodeId nodeId,
-             PortType portType,
-             PortIndex first);
+    void removePort(NodeId nodeId, PortType portType, PortIndex first);
 
-  NodeId newNodeId() override { return _nextNodeId++; }
+    NodeId newNodeId() override { return _nextNodeId++; }
 
 private:
-  std::unordered_set<NodeId> _nodeIds;
+    std::unordered_set<NodeId> _nodeIds;
 
-  /// [Important] This is a user defined data structure backing your model.
-  /// In your case it could be anything else representing a graph, for example, a
-  /// table. Or a collection of structs with pointers to each other. Or an
-  /// abstract syntax tree, you name it.
-  std::unordered_set<ConnectionId> _connectivity;
+    /// [Important] This is a user defined data structure backing your model.
+    /// In your case it could be anything else representing a graph, for example, a
+    /// table. Or a collection of structs with pointers to each other. Or an
+    /// abstract syntax tree, you name it.
+    std::unordered_set<ConnectionId> _connectivity;
 
-  mutable std::unordered_map<NodeId, NodeGeometryData>
-    _nodeGeometryData;
+    mutable std::unordered_map<NodeId, NodeGeometryData> _nodeGeometryData;
 
-  struct NodePortCount
-  {
-    unsigned int in = 0;
-    unsigned int out = 0;
-  };
+    struct NodePortCount
+    {
+        unsigned int in = 0;
+        unsigned int out = 0;
+    };
 
-  PortAddRemoveWidget* widget(NodeId) const;
+    PortAddRemoveWidget *widget(NodeId) const;
 
-  mutable std::unordered_map<NodeId, NodePortCount> _nodePortCounts;
-  mutable std::unordered_map<NodeId, PortAddRemoveWidget*> _nodeWidgets;
+    mutable std::unordered_map<NodeId, NodePortCount> _nodePortCounts;
+    mutable std::unordered_map<NodeId, PortAddRemoveWidget *> _nodeWidgets;
 
-  /// A convenience variable needed for generating unique node ids.
-  unsigned int _nextNodeId;
+    /// A convenience variable needed for generating unique node ids.
+    unsigned int _nextNodeId;
 };

--- a/examples/dynamic_ports/PortAddRemoveWidget.cpp
+++ b/examples/dynamic_ports/PortAddRemoveWidget.cpp
@@ -2,219 +2,169 @@
 
 #include "DynamicPortsModel.hpp"
 
-
-PortAddRemoveWidget::
-PortAddRemoveWidget(unsigned int nInPorts,
-                    unsigned int nOutPorts,
-                    NodeId nodeId,
-                    DynamicPortsModel & model,
-                    QWidget * parent)
-  : QWidget(parent)
-  , _nodeId(nodeId)
-  , _model(model)
+PortAddRemoveWidget::PortAddRemoveWidget(unsigned int nInPorts,
+                                         unsigned int nOutPorts,
+                                         NodeId nodeId,
+                                         DynamicPortsModel &model,
+                                         QWidget *parent)
+    : QWidget(parent)
+    , _nodeId(nodeId)
+    , _model(model)
 {
-  setSizePolicy(QSizePolicy::Policy::Minimum,
-                QSizePolicy::Policy::Minimum);
+    setSizePolicy(QSizePolicy::Policy::Minimum, QSizePolicy::Policy::Minimum);
 
-  QHBoxLayout* hl = new QHBoxLayout(this);
-  hl->setContentsMargins(0, 0, 0, 0);
-  hl->setSpacing(0);
+    QHBoxLayout *hl = new QHBoxLayout(this);
+    hl->setContentsMargins(0, 0, 0, 0);
+    hl->setSpacing(0);
 
-  _left = new QVBoxLayout();
-  _left->setSpacing(0);
-  _left->setContentsMargins(0, 0, 0, 0);
-  _left->addStretch();
+    _left = new QVBoxLayout();
+    _left->setSpacing(0);
+    _left->setContentsMargins(0, 0, 0, 0);
+    _left->addStretch();
 
-  _right = new QVBoxLayout();
-  _right->setSpacing(0);
-  _right->setContentsMargins(0, 0, 0, 0);
-  _right->addStretch();
+    _right = new QVBoxLayout();
+    _right->setSpacing(0);
+    _right->setContentsMargins(0, 0, 0, 0);
+    _right->addStretch();
 
-  hl->addLayout(_left);
-  hl->addSpacing(50);
-  hl->addLayout(_right);
+    hl->addLayout(_left);
+    hl->addSpacing(50);
+    hl->addLayout(_right);
 }
 
-
-PortAddRemoveWidget::
-~PortAddRemoveWidget()
+PortAddRemoveWidget::~PortAddRemoveWidget()
 {
-  //
+    //
 }
 
-void
-PortAddRemoveWidget::
-populateButtons(PortType portType,
-                unsigned int nPorts)
+void PortAddRemoveWidget::populateButtons(PortType portType, unsigned int nPorts)
 {
-  QVBoxLayout* vl =
-    (portType == PortType::In) ?  _left : _right;
+    QVBoxLayout *vl = (portType == PortType::In) ? _left : _right;
 
-  // we use [-1} in the expression `vl->count() - 1` because
-  // one element - a spacer - is alvays present in this layout.
+    // we use [-1} in the expression `vl->count() - 1` because
+    // one element - a spacer - is alvays present in this layout.
 
-  if (vl->count()-1 < nPorts)
-    while (vl->count()-1 < nPorts)
-    {
-      addButtonGroupToLayout(vl, 0);
-    }
-
-  if (vl->count()-1 > nPorts)
-  {
-    while (vl->count()-1 > nPorts)
-    {
-      removeButtonGroupFromLayout(vl, 0);
-    }
-  }
-}
-
-
-QHBoxLayout* 
-PortAddRemoveWidget::
-addButtonGroupToLayout(QVBoxLayout * vbl,
-                       unsigned int portIndex)
-{
-  auto l = new QHBoxLayout();
-  l->setContentsMargins(0, 0, 0, 0);
-
-  auto button = new QPushButton("+");
-  button->setFixedHeight(25);
-  l->addWidget(button);
-  connect(button,
-          &QPushButton::clicked,
-          this,
-          &PortAddRemoveWidget::onPlusClicked);
-
-  button = new QPushButton("-"); 
-  button->setFixedHeight(25);
-  l->addWidget(button);
-  connect(button,
-          &QPushButton::clicked,
-          this,
-          &PortAddRemoveWidget::onMinusClicked);
-
-  vbl->insertLayout(portIndex, l);
-
-  return l;
-}
-
-
-void
-PortAddRemoveWidget::
-removeButtonGroupFromLayout(QVBoxLayout * vbl,
-                            unsigned int portIndex)
-{
-  // Last item in the layout is always a spacer
-  if (vbl->count() > 1)
-  {
-    auto item = vbl->itemAt(portIndex);
-
-    // Delete [+] and [-] QPushButton widgets
-    item->layout()->itemAt(0)->widget()->deleteLater();
-    item->layout()->itemAt(1)->widget()->deleteLater();
-
-    vbl->removeItem(item);
-
-    delete item;
-  }
-}
-
-
-void 
-PortAddRemoveWidget::
-onPlusClicked()
-{
-  // index of the plus button in the QHBoxLayout
-  int const plusButtonIndex = 0;
-
-  PortType portType;
-  PortIndex portIndex;
-
-  // All existing "plus" buttons trigger the same slot. We need to find out which
-  // button has been actually clicked.
-  std::tie(portType, portIndex) =
-    findWhichPortWasClicked(QObject::sender(), plusButtonIndex);
-
-  // We add new "plus-minus" button group to the chosen layout.
-  addButtonGroupToLayout((portType == PortType::In) ?
-                         _left :
-                         _right,
-                         portIndex + 1);
-
-  // Trigger changes in the model
-  _model.addPort(_nodeId, portType, portIndex + 1);
-
-  adjustSize();
-}
-
-
-void
-PortAddRemoveWidget::
-onMinusClicked()
-{
-  // index of the minus button in the QHBoxLayout
-  int const minusButtonIndex = 1;
-
-  PortType portType;
-  PortIndex portIndex;
-
-  std::tie(portType, portIndex) =
-    findWhichPortWasClicked(QObject::sender(), minusButtonIndex);
-
-  removeButtonGroupFromLayout((portType == PortType::In) ?
-                              _left :
-                              _right,
-                              portIndex);
-
-  // Trigger changes in the model
-  _model.removePort(_nodeId, portType, portIndex);
-
-  adjustSize();
-}
-
-
-std::pair<PortType, PortIndex>
-PortAddRemoveWidget::
-findWhichPortWasClicked(QObject* sender, int const buttonIndex)
-{
-  PortType portType = PortType::None;
-  PortIndex portIndex = QtNodes::InvalidPortIndex;
-
-  auto checkOneSide =
-    [&portType, &portIndex, &sender, &buttonIndex](QVBoxLayout * sideLayout)
-    {
-      for(int i = 0; i < sideLayout->count(); ++i)
-      {
-        auto layoutItem = sideLayout->itemAt(i);
-        auto hLayout = dynamic_cast<QHBoxLayout*>(layoutItem);
-
-        if (!hLayout) continue;
-
-        auto widget = static_cast<QWidgetItem*>(hLayout->itemAt(buttonIndex))->widget();
-
-        if (sender == widget)
-        {
-          portIndex = i;
-          break;
+    if (vl->count() - 1 < nPorts)
+        while (vl->count() - 1 < nPorts) {
+            addButtonGroupToLayout(vl, 0);
         }
-      }
+
+    if (vl->count() - 1 > nPorts) {
+        while (vl->count() - 1 > nPorts) {
+            removeButtonGroupFromLayout(vl, 0);
+        }
+    }
+}
+
+QHBoxLayout *PortAddRemoveWidget::addButtonGroupToLayout(QVBoxLayout *vbl, unsigned int portIndex)
+{
+    auto l = new QHBoxLayout();
+    l->setContentsMargins(0, 0, 0, 0);
+
+    auto button = new QPushButton("+");
+    button->setFixedHeight(25);
+    l->addWidget(button);
+    connect(button, &QPushButton::clicked, this, &PortAddRemoveWidget::onPlusClicked);
+
+    button = new QPushButton("-");
+    button->setFixedHeight(25);
+    l->addWidget(button);
+    connect(button, &QPushButton::clicked, this, &PortAddRemoveWidget::onMinusClicked);
+
+    vbl->insertLayout(portIndex, l);
+
+    return l;
+}
+
+void PortAddRemoveWidget::removeButtonGroupFromLayout(QVBoxLayout *vbl, unsigned int portIndex)
+{
+    // Last item in the layout is always a spacer
+    if (vbl->count() > 1) {
+        auto item = vbl->itemAt(portIndex);
+
+        // Delete [+] and [-] QPushButton widgets
+        item->layout()->itemAt(0)->widget()->deleteLater();
+        item->layout()->itemAt(1)->widget()->deleteLater();
+
+        vbl->removeItem(item);
+
+        delete item;
+    }
+}
+
+void PortAddRemoveWidget::onPlusClicked()
+{
+    // index of the plus button in the QHBoxLayout
+    int const plusButtonIndex = 0;
+
+    PortType portType;
+    PortIndex portIndex;
+
+    // All existing "plus" buttons trigger the same slot. We need to find out which
+    // button has been actually clicked.
+    std::tie(portType, portIndex) = findWhichPortWasClicked(QObject::sender(), plusButtonIndex);
+
+    // We add new "plus-minus" button group to the chosen layout.
+    addButtonGroupToLayout((portType == PortType::In) ? _left : _right, portIndex + 1);
+
+    // Trigger changes in the model
+    _model.addPort(_nodeId, portType, portIndex + 1);
+
+    adjustSize();
+}
+
+void PortAddRemoveWidget::onMinusClicked()
+{
+    // index of the minus button in the QHBoxLayout
+    int const minusButtonIndex = 1;
+
+    PortType portType;
+    PortIndex portIndex;
+
+    std::tie(portType, portIndex) = findWhichPortWasClicked(QObject::sender(), minusButtonIndex);
+
+    removeButtonGroupFromLayout((portType == PortType::In) ? _left : _right, portIndex);
+
+    // Trigger changes in the model
+    _model.removePort(_nodeId, portType, portIndex);
+
+    adjustSize();
+}
+
+std::pair<PortType, PortIndex> PortAddRemoveWidget::findWhichPortWasClicked(QObject *sender,
+                                                                            int const buttonIndex)
+{
+    PortType portType = PortType::None;
+    PortIndex portIndex = QtNodes::InvalidPortIndex;
+
+    auto checkOneSide = [&portType, &portIndex, &sender, &buttonIndex](QVBoxLayout *sideLayout) {
+        for (int i = 0; i < sideLayout->count(); ++i) {
+            auto layoutItem = sideLayout->itemAt(i);
+            auto hLayout = dynamic_cast<QHBoxLayout *>(layoutItem);
+
+            if (!hLayout)
+                continue;
+
+            auto widget = static_cast<QWidgetItem *>(hLayout->itemAt(buttonIndex))->widget();
+
+            if (sender == widget) {
+                portIndex = i;
+                break;
+            }
+        }
     };
 
-  checkOneSide(_left);
+    checkOneSide(_left);
 
-  if (portIndex != QtNodes::InvalidPortIndex)
-  {
-    portType = PortType::In;
-  }
-  else
-  {
-    checkOneSide(_right);
+    if (portIndex != QtNodes::InvalidPortIndex) {
+        portType = PortType::In;
+    } else {
+        checkOneSide(_right);
 
-    if (portIndex != QtNodes::InvalidPortIndex)
-    {
-      portType = PortType::Out;
+        if (portIndex != QtNodes::InvalidPortIndex) {
+            portType = PortType::Out;
+        }
     }
-  }
 
-  return std::make_pair(portType, portIndex);
+    return std::make_pair(portType, portIndex);
 }

--- a/examples/dynamic_ports/PortAddRemoveWidget.hpp
+++ b/examples/dynamic_ports/PortAddRemoveWidget.hpp
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <QWidget>
 #include <QPushButton>
+#include <QWidget>
 
 #include <QtNodes/Definitions>
 
-#include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QVBoxLayout>
 
-
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeId;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 class DynamicPortsModel;
-
 
 /**
  *                PortAddRemoveWidget
@@ -42,54 +40,49 @@ class DynamicPortsModel;
  */
 class PortAddRemoveWidget : public QWidget
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  PortAddRemoveWidget(unsigned int nInPorts,
-                      unsigned int nOutPorts,
-                      NodeId nodeId,
-                      DynamicPortsModel & model,
-                      QWidget * parent = nullptr);
+    PortAddRemoveWidget(unsigned int nInPorts,
+                        unsigned int nOutPorts,
+                        NodeId nodeId,
+                        DynamicPortsModel &model,
+                        QWidget *parent = nullptr);
 
-  ~PortAddRemoveWidget();
+    ~PortAddRemoveWidget();
 
-
-  /**
+    /**
    * Called from constructor, creates all button groups according to models'port
    * counts.
    */
-  void
-  populateButtons(PortType portType, unsigned int nPorts);
+    void populateButtons(PortType portType, unsigned int nPorts);
 
-  /**
+    /**
    * Adds a single `[+][-]` button group to a given layout.
    */
-  QHBoxLayout*
-  addButtonGroupToLayout(QVBoxLayout * vbl, unsigned int portIndex);
+    QHBoxLayout *addButtonGroupToLayout(QVBoxLayout *vbl, unsigned int portIndex);
 
-  /**
+    /**
    * Removes a single `[+][-]` button group from a given layout.
    */
-  void
-  removeButtonGroupFromLayout(QVBoxLayout * vbl, unsigned int portIndex);
+    void removeButtonGroupFromLayout(QVBoxLayout *vbl, unsigned int portIndex);
 
 private Q_SLOTS:
-  void onPlusClicked();
+    void onPlusClicked();
 
-  void onMinusClicked();
+    void onMinusClicked();
 
 private:
-  /**
+    /**
    * @param buttonIndex is the index of a button in the layout.
    * Plus button has the index 0.
    * Minus button has the index 1.
    */
-  std::pair<PortType, PortIndex>
-  findWhichPortWasClicked(QObject* sender, int const buttonIndex);
+    std::pair<PortType, PortIndex> findWhichPortWasClicked(QObject *sender, int const buttonIndex);
 
 private:
-  NodeId const _nodeId;
-  DynamicPortsModel & _model;
+    NodeId const _nodeId;
+    DynamicPortsModel &_model;
 
-  QVBoxLayout* _left;
-  QVBoxLayout* _right;
+    QVBoxLayout *_left;
+    QVBoxLayout *_right;
 };

--- a/examples/dynamic_ports/main.cpp
+++ b/examples/dynamic_ports/main.cpp
@@ -1,166 +1,137 @@
+#include <QtNodes/BasicGraphicsScene>
 #include <QtNodes/ConnectionStyle>
 #include <QtNodes/GraphicsView>
-#include <QtNodes/BasicGraphicsScene>
 #include <QtNodes/StyleCollection>
 
+#include <QAction>
+#include <QFileDialog>
+#include <QScreen>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenuBar>
 #include <QtWidgets/QVBoxLayout>
-#include <QAction>
-#include <QScreen>
-#include <QFileDialog>
 
 #include "DynamicPortsModel.hpp"
 
-
+using QtNodes::BasicGraphicsScene;
 using QtNodes::ConnectionStyle;
 using QtNodes::GraphicsView;
-using QtNodes::BasicGraphicsScene;
 using QtNodes::NodeRole;
 using QtNodes::StyleCollection;
 
-
-
-void
-initializeModel(DynamicPortsModel & graphModel)
+void initializeModel(DynamicPortsModel &graphModel)
 {
-  NodeId id1 = graphModel.addNode();
-  graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
-  graphModel.setNodeData(id1, NodeRole::InPortCount, 1);
-  graphModel.setNodeData(id1, NodeRole::OutPortCount, 1);
+    NodeId id1 = graphModel.addNode();
+    graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
+    graphModel.setNodeData(id1, NodeRole::InPortCount, 1);
+    graphModel.setNodeData(id1, NodeRole::OutPortCount, 1);
 
-  NodeId id2 = graphModel.addNode();
-  graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
+    NodeId id2 = graphModel.addNode();
+    graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
 
-  graphModel.setNodeData(id2, NodeRole::InPortCount, 1);
-  graphModel.setNodeData(id2, NodeRole::OutPortCount, 1);
+    graphModel.setNodeData(id2, NodeRole::InPortCount, 1);
+    graphModel.setNodeData(id2, NodeRole::OutPortCount, 1);
 
-  graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
+    graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
 }
 
-
-QMenuBar*
-createSaveRestoreMenu(DynamicPortsModel & graphModel,
-                      BasicGraphicsScene * scene,
-                      GraphicsView & view)
+QMenuBar *createSaveRestoreMenu(DynamicPortsModel &graphModel,
+                                BasicGraphicsScene *scene,
+                                GraphicsView &view)
 {
-  auto menuBar = new QMenuBar();
-  QMenu* menu = menuBar->addMenu("File");
-  auto saveAction = menu->addAction("Save Scene");
-  auto loadAction = menu->addAction("Load Scene");
+    auto menuBar = new QMenuBar();
+    QMenu *menu = menuBar->addMenu("File");
+    auto saveAction = menu->addAction("Save Scene");
+    auto loadAction = menu->addAction("Load Scene");
 
-  QObject::connect(saveAction, &QAction::triggered,
-                   scene,
-                   [&graphModel]
-                   {
-                     QString fileName =
-                       QFileDialog::getSaveFileName(nullptr,
-                                                    "Open Flow Scene",
-                                                    QDir::homePath(),
-                                                    "Flow Scene Files (*.flow)");
+    QObject::connect(saveAction, &QAction::triggered, scene, [&graphModel] {
+        QString fileName = QFileDialog::getSaveFileName(nullptr,
+                                                        "Open Flow Scene",
+                                                        QDir::homePath(),
+                                                        "Flow Scene Files (*.flow)");
 
-                     if (!fileName.isEmpty())
-                     {
-                       if (!fileName.endsWith("flow", Qt::CaseInsensitive))
-                         fileName += ".flow";
+        if (!fileName.isEmpty()) {
+            if (!fileName.endsWith("flow", Qt::CaseInsensitive))
+                fileName += ".flow";
 
-                       QFile file(fileName);
-                       if (file.open(QIODevice::WriteOnly))
-                       {
-                         file.write(QJsonDocument(graphModel.save()).toJson());
-                       }
-                     }
-                   });
+            QFile file(fileName);
+            if (file.open(QIODevice::WriteOnly)) {
+                file.write(QJsonDocument(graphModel.save()).toJson());
+            }
+        }
+    });
 
-  QObject::connect(loadAction, &QAction::triggered,
-                   scene,
-                   [&graphModel, &view, scene]
-                   {
-                      QString fileName =
-                        QFileDialog::getOpenFileName(nullptr,
-                                                     "Open Flow Scene",
-                                                     QDir::homePath(),
-                                                     "Flow Scene Files (*.flow)");
-                      if (!QFileInfo::exists(fileName))
-                        return;
+    QObject::connect(loadAction, &QAction::triggered, scene, [&graphModel, &view, scene] {
+        QString fileName = QFileDialog::getOpenFileName(nullptr,
+                                                        "Open Flow Scene",
+                                                        QDir::homePath(),
+                                                        "Flow Scene Files (*.flow)");
+        if (!QFileInfo::exists(fileName))
+            return;
 
-                      QFile file(fileName);
+        QFile file(fileName);
 
-                      if (!file.open(QIODevice::ReadOnly))
-                        return;
+        if (!file.open(QIODevice::ReadOnly))
+            return;
 
-                      scene->clearScene();
+        scene->clearScene();
 
-                      QByteArray const wholeFile = file.readAll();
+        QByteArray const wholeFile = file.readAll();
 
-                      graphModel.load(QJsonDocument::fromJson(wholeFile).object());
+        graphModel.load(QJsonDocument::fromJson(wholeFile).object());
 
-                      view.centerScene();
-                   });
+        view.centerScene();
+    });
 
-  return menuBar;
+    return menuBar;
 }
 
-
-QAction*
-createNodeAction(DynamicPortsModel & graphModel,
-                 GraphicsView & view)
+QAction *createNodeAction(DynamicPortsModel &graphModel, GraphicsView &view)
 {
-  auto action = new QAction(QStringLiteral("Create Node"), &view);
-  QObject::connect(action, &QAction::triggered,
-                   [&]()
-                   {
-                     // Mouse position in scene coordinates.
-                     QPointF posView =
-                       view.mapToScene(view.mapFromGlobal(QCursor::pos()));
+    auto action = new QAction(QStringLiteral("Create Node"), &view);
+    QObject::connect(action, &QAction::triggered, [&]() {
+        // Mouse position in scene coordinates.
+        QPointF posView = view.mapToScene(view.mapFromGlobal(QCursor::pos()));
 
+        NodeId const newId = graphModel.addNode();
+        graphModel.setNodeData(newId, NodeRole::Position, posView);
+    });
 
-                     NodeId const newId = graphModel.addNode();
-                     graphModel.setNodeData(newId,
-                                            NodeRole::Position,
-                                            posView);
-                   });
-
-  return action;
+    return action;
 }
 
-
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  DynamicPortsModel graphModel;
+    DynamicPortsModel graphModel;
 
-  // Initialize and connect two nodes.
-  initializeModel(graphModel);
+    // Initialize and connect two nodes.
+    initializeModel(graphModel);
 
-  // Main app window holding menu and a scene view.
-  QWidget window;
-  window.setWindowTitle("Dynamic Nodes Example");
-  window.resize(800, 600);
+    // Main app window holding menu and a scene view.
+    QWidget window;
+    window.setWindowTitle("Dynamic Nodes Example");
+    window.resize(800, 600);
 
-  auto scene = new BasicGraphicsScene(graphModel);
+    auto scene = new BasicGraphicsScene(graphModel);
 
-  qWarning() << "MODEF FROM SCENE " << &(scene->graphModel());
+    qWarning() << "MODEF FROM SCENE " << &(scene->graphModel());
 
-  GraphicsView view(scene);
-  // Setup context menu for creating new nodes.
-  view.setContextMenuPolicy(Qt::ActionsContextMenu);
-  view.insertAction(view.actions().front(), createNodeAction(graphModel, view));
+    GraphicsView view(scene);
+    // Setup context menu for creating new nodes.
+    view.setContextMenuPolicy(Qt::ActionsContextMenu);
+    view.insertAction(view.actions().front(), createNodeAction(graphModel, view));
 
+    // Pack all elements into layout.
+    QVBoxLayout *l = new QVBoxLayout(&window);
+    l->setContentsMargins(0, 0, 0, 0);
+    l->setSpacing(0);
+    l->addWidget(createSaveRestoreMenu(graphModel, scene, view));
+    l->addWidget(&view);
 
-  // Pack all elements into layout.
-  QVBoxLayout* l = new QVBoxLayout(&window);
-  l->setContentsMargins(0, 0, 0, 0);
-  l->setSpacing(0);
-  l->addWidget(createSaveRestoreMenu(graphModel, scene, view));
-  l->addWidget(&view);
+    // Center window
+    window.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
+    window.showNormal();
 
-
-  // Center window
-  window.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
-  window.showNormal();
-
-  return app.exec();
+    return app.exec();
 }

--- a/examples/lock_nodes_and_connections/DataFlowModel.hpp
+++ b/examples/lock_nodes_and_connections/DataFlowModel.hpp
@@ -1,6 +1,5 @@
 #include <QtNodes/DataFlowGraphModel>
 
-
 using QtNodes::ConnectionId;
 using QtNodes::DataFlowGraphModel;
 using QtNodes::NodeDelegateModelRegistry;
@@ -11,49 +10,39 @@ using QtNodes::NodeId;
 class DataFlowModel : public DataFlowGraphModel
 {
 public:
-  DataFlowModel(std::shared_ptr<NodeDelegateModelRegistry> registry)
-    : DataFlowGraphModel(std::move(registry))
-    , _detachPossible{true}
-    , _nodesLocked{false}
-  {}
+    DataFlowModel(std::shared_ptr<NodeDelegateModelRegistry> registry)
+        : DataFlowGraphModel(std::move(registry))
+        , _detachPossible{true}
+        , _nodesLocked{false}
+    {}
 
-  bool detachPossible(ConnectionId const) const override
-  {
-    return _detachPossible;
-  }
+    bool detachPossible(ConnectionId const) const override { return _detachPossible; }
 
-  void setDetachPossible(bool d = true)
-  {
-    _detachPossible = d;
-  }
+    void setDetachPossible(bool d = true) { _detachPossible = d; }
 
+    //----
 
-  //----
-
-  NodeFlags
-  nodeFlags(NodeId nodeId) const override
-  {
-    auto basicFlags = DataFlowGraphModel::nodeFlags(nodeId);
-
-    if (_nodesLocked)
-      basicFlags |= NodeFlag::Locked;
-
-    return basicFlags;
-  }
-
-
-  void setNodesLocked(bool b = true)
-  {
-    _nodesLocked = b;
-
-    for (NodeId nodeId : allNodeIds())
+    NodeFlags nodeFlags(NodeId nodeId) const override
     {
-      Q_EMIT nodeFlagsUpdated(nodeId);
+        auto basicFlags = DataFlowGraphModel::nodeFlags(nodeId);
+
+        if (_nodesLocked)
+            basicFlags |= NodeFlag::Locked;
+
+        return basicFlags;
     }
-  }
+
+    void setNodesLocked(bool b = true)
+    {
+        _nodesLocked = b;
+
+        for (NodeId nodeId : allNodeIds()) {
+            Q_EMIT nodeFlagsUpdated(nodeId);
+        }
+    }
 
 private:
-  bool _detachPossible;
+    bool _detachPossible;
 
-  bool _nodesLocked;
+    bool _nodesLocked;
 };

--- a/examples/lock_nodes_and_connections/DelegateNodeModel.hpp
+++ b/examples/lock_nodes_and_connections/DelegateNodeModel.hpp
@@ -10,62 +10,40 @@
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
-using QtNodes::PortType;
 using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 class SimpleNodeData : public NodeData
 {
 public:
-  NodeDataType
-  type() const override
-  {
-    return NodeDataType {"SimpleData",
-                         "Simple Data"};
-  }
+    NodeDataType type() const override { return NodeDataType{"SimpleData", "Simple Data"}; }
 };
-
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
 class SimpleDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  QString
-  caption() const override
-  {
-    return QString("Simple Data Model");
-  }
+    QString caption() const override { return QString("Simple Data Model"); }
 
-  QString
-  name() const override
-  { return QString("SimpleDataModel"); }
+    QString name() const override { return QString("SimpleDataModel"); }
 
 public:
-  unsigned int
-  nPorts(PortType const portType) const override
-  {
-    return 2;
-  }
+    unsigned int nPorts(PortType const portType) const override { return 2; }
 
-  NodeDataType
-  dataType(PortType const  portType,
-           PortIndex const portIndex) const override
-  {
-    return SimpleNodeData().type();
-  }
+    NodeDataType dataType(PortType const portType, PortIndex const portIndex) const override
+    {
+        return SimpleNodeData().type();
+    }
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex const port) override
-  {
-    return std::make_shared<SimpleNodeData>();
-  }
+    std::shared_ptr<NodeData> outData(PortIndex const port) override
+    {
+        return std::make_shared<SimpleNodeData>();
+    }
 
-  void
-  setInData(std::shared_ptr<NodeData>, PortIndex const) override
-  {}
+    void setInData(std::shared_ptr<NodeData>, PortIndex const) override {}
 
-  QWidget*
-  embeddedWidget() override { return nullptr; }
+    QWidget *embeddedWidget() override { return nullptr; }
 };

--- a/examples/lock_nodes_and_connections/main.cpp
+++ b/examples/lock_nodes_and_connections/main.cpp
@@ -1,100 +1,86 @@
-#include <QtNodes/GraphicsView>
 #include <QtNodes/DataFlowGraphicsScene>
+#include <QtNodes/GraphicsView>
 #include <QtNodes/NodeDelegateModelRegistry>
 
-#include <QtWidgets/QApplication>
-#include <QtWidgets/QGroupBox>
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QCheckBox>
 #include <QAction>
 #include <QScreen>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QGroupBox>
+#include <QtWidgets/QHBoxLayout>
 
 #include "DataFlowModel.hpp"
 #include "DelegateNodeModel.hpp"
-
 
 using QtNodes::DataFlowGraphicsScene;
 using QtNodes::GraphicsView;
 using QtNodes::NodeDelegateModelRegistry;
 using QtNodes::NodeRole;
 
-
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
 
-  ret->registerModel<SimpleDataModel>();
+    ret->registerModel<SimpleDataModel>();
 
-  return ret;
+    return ret;
 }
 
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  DataFlowModel graphModel(registerDataModels());
+    DataFlowModel graphModel(registerDataModels());
 
-  // Initialize and connect two nodes.
-  {
-    NodeId id1 = graphModel.addNode(SimpleNodeData().type().id);
-    graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
+    // Initialize and connect two nodes.
+    {
+        NodeId id1 = graphModel.addNode(SimpleNodeData().type().id);
+        graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
 
-    NodeId id2 = graphModel.addNode(SimpleNodeData().type().id);
-    graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
+        NodeId id2 = graphModel.addNode(SimpleNodeData().type().id);
+        graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
 
-    graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
-  }
+        graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
+    }
 
-  auto scene = new DataFlowGraphicsScene(graphModel);
+    auto scene = new DataFlowGraphicsScene(graphModel);
 
-  QWidget window;
+    QWidget window;
 
-  QHBoxLayout * l = new QHBoxLayout(&window);
+    QHBoxLayout *l = new QHBoxLayout(&window);
 
-  GraphicsView view(scene);
+    GraphicsView view(scene);
 
-  l->addWidget(&view);
+    l->addWidget(&view);
 
+    QGroupBox *groupBox = new QGroupBox("Options");
 
+    QCheckBox *cb1 = new QCheckBox("Nodes are locked");
+    QCheckBox *cb2 = new QCheckBox("Connections detachable");
+    cb2->setChecked(true);
 
-  QGroupBox *groupBox = new QGroupBox("Options");
+    QVBoxLayout *vbl = new QVBoxLayout;
+    vbl->addWidget(cb1);
+    vbl->addWidget(cb2);
+    vbl->addStretch();
+    groupBox->setLayout(vbl);
 
-  QCheckBox *cb1 = new QCheckBox("Nodes are locked");
-  QCheckBox *cb2 = new QCheckBox("Connections detachable");
-  cb2->setChecked(true);
+    QObject::connect(cb1, &QCheckBox::stateChanged, [&graphModel](int state) {
+        graphModel.setNodesLocked(state == Qt::Checked);
+    });
 
-  QVBoxLayout * vbl = new QVBoxLayout;
-  vbl->addWidget(cb1);
-  vbl->addWidget(cb2);
-  vbl->addStretch();
-  groupBox->setLayout(vbl);
+    QObject::connect(cb2, &QCheckBox::stateChanged, [&graphModel](int state) {
+        graphModel.setDetachPossible(state == Qt::Checked);
+    });
 
-  QObject::connect(cb1,
-                   &QCheckBox::stateChanged,
-                   [&graphModel](int state)
-                   {
-                     graphModel.setNodesLocked(state == Qt::Checked);
-                   });
+    l->addWidget(groupBox);
 
-  QObject::connect(cb2,
-                   &QCheckBox::stateChanged,
-                   [&graphModel](int state)
-                   {
-                     graphModel.setDetachPossible(state == Qt::Checked);
-                   });
+    window.setWindowTitle("Locked Nodes and Connections");
+    window.resize(800, 600);
 
-  l->addWidget(groupBox);
+    // Center window.
+    window.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
+    window.showNormal();
 
-
-  window.setWindowTitle("Locked Nodes and Connections");
-  window.resize(800, 600);
-
-  // Center window.
-  window.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
-  window.showNormal();
-
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/resizable_images/ImageLoaderModel.cpp
+++ b/examples/resizable_images/ImageLoaderModel.cpp
@@ -1,99 +1,79 @@
 #include "ImageLoaderModel.hpp"
 
-#include <QtCore/QEvent>
 #include <QtCore/QDir>
+#include <QtCore/QEvent>
 
 #include <QtWidgets/QFileDialog>
 
-ImageLoaderModel::
-ImageLoaderModel()
-  : _label(new QLabel("Double click to load image"))
+ImageLoaderModel::ImageLoaderModel()
+    : _label(new QLabel("Double click to load image"))
 {
-  _label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
+    _label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
 
-  QFont f = _label->font();
-  f.setBold(true);
-  f.setItalic(true);
+    QFont f = _label->font();
+    f.setBold(true);
+    f.setItalic(true);
 
-  _label->setFont(f);
+    _label->setFont(f);
 
-  _label->setFixedSize(200, 200);
+    _label->setFixedSize(200, 200);
 
-  _label->installEventFilter(this);
+    _label->installEventFilter(this);
 }
 
-
-unsigned int
-ImageLoaderModel::
-nPorts(PortType portType) const
+unsigned int ImageLoaderModel::nPorts(PortType portType) const
 {
-  unsigned int result = 1;
+    unsigned int result = 1;
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      result = 0;
-      break;
+        result = 0;
+        break;
 
     case PortType::Out:
-      result = 1;
+        result = 1;
 
     default:
-      break;
-  }
-
-  return result;
-}
-
-
-bool
-ImageLoaderModel::
-eventFilter(QObject *object, QEvent *event)
-{
-  if (object == _label)
-  {
-    int w = _label->width();
-    int h = _label->height();
-
-    if (event->type() == QEvent::MouseButtonPress)
-    {
-
-      QString fileName =
-        QFileDialog::getOpenFileName(nullptr,
-                                     tr("Open Image"),
-                                     QDir::homePath(),
-                                     tr("Image Files (*.png *.jpg *.bmp)"));
-
-      _pixmap = QPixmap(fileName);
-
-      _label->setPixmap(_pixmap.scaled(w, h, Qt::KeepAspectRatio));
-
-      Q_EMIT dataUpdated(0);
-
-      return true;
+        break;
     }
-    else if (event->type() == QEvent::Resize)
-    {
-      if (!_pixmap.isNull())
-        _label->setPixmap(_pixmap.scaled(w, h, Qt::KeepAspectRatio));
+
+    return result;
+}
+
+bool ImageLoaderModel::eventFilter(QObject *object, QEvent *event)
+{
+    if (object == _label) {
+        int w = _label->width();
+        int h = _label->height();
+
+        if (event->type() == QEvent::MouseButtonPress) {
+            QString fileName = QFileDialog::getOpenFileName(nullptr,
+                                                            tr("Open Image"),
+                                                            QDir::homePath(),
+                                                            tr("Image Files (*.png *.jpg *.bmp)"));
+
+            _pixmap = QPixmap(fileName);
+
+            _label->setPixmap(_pixmap.scaled(w, h, Qt::KeepAspectRatio));
+
+            Q_EMIT dataUpdated(0);
+
+            return true;
+        } else if (event->type() == QEvent::Resize) {
+            if (!_pixmap.isNull())
+                _label->setPixmap(_pixmap.scaled(w, h, Qt::KeepAspectRatio));
+        }
     }
-  }
 
-  return false;
+    return false;
 }
 
-
-NodeDataType
-ImageLoaderModel::
-dataType(PortType const, PortIndex const) const
+NodeDataType ImageLoaderModel::dataType(PortType const, PortIndex const) const
 {
-  return PixmapData().type();
+    return PixmapData().type();
 }
 
-
-std::shared_ptr<NodeData>
-ImageLoaderModel::
-outData(PortIndex)
+std::shared_ptr<NodeData> ImageLoaderModel::outData(PortIndex)
 {
-  return std::make_shared<PixmapData>(_pixmap);
+    return std::make_shared<PixmapData>(_pixmap);
 }

--- a/examples/resizable_images/ImageLoaderModel.hpp
+++ b/examples/resizable_images/ImageLoaderModel.hpp
@@ -5,69 +5,53 @@
 #include <QtCore/QObject>
 #include <QtWidgets/QLabel>
 
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/NodeDelegateModel>
+#include <QtNodes/NodeDelegateModelRegistry>
 
 #include "PixmapData.hpp"
 
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
 class ImageLoaderModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  ImageLoaderModel();
+    ImageLoaderModel();
 
-  ~ImageLoaderModel() = default;
-
-public:
-
-  QString
-  caption() const override { return QString("Image Source"); }
-
-  QString
-  name() const override { return QString("ImageLoaderModel"); }
+    ~ImageLoaderModel() = default;
 
 public:
+    QString caption() const override { return QString("Image Source"); }
 
-  virtual QString
-  modelName() const { return QString("Source Image"); }
+    QString name() const override { return QString("ImageLoaderModel"); }
 
-  unsigned int
-  nPorts(PortType const portType) const override;
+public:
+    virtual QString modelName() const { return QString("Source Image"); }
 
-  NodeDataType
-  dataType(PortType const  portType,
-           PortIndex const portIndex) const override;
+    unsigned int nPorts(PortType const portType) const override;
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex const port) override;
+    NodeDataType dataType(PortType const portType, PortIndex const portIndex) const override;
 
-  void
-  setInData(std::shared_ptr<NodeData>,
-            PortIndex const portIndex) override {}
+    std::shared_ptr<NodeData> outData(PortIndex const port) override;
 
-  QWidget*
-  embeddedWidget() override { return _label; }
+    void setInData(std::shared_ptr<NodeData>, PortIndex const portIndex) override {}
 
-  bool
-  resizable() const override { return true; }
+    QWidget *embeddedWidget() override { return _label; }
+
+    bool resizable() const override { return true; }
 
 protected:
-
-  bool
-  eventFilter(QObject* object, QEvent* event) override;
+    bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
+    QLabel *_label;
 
-  QLabel* _label;
-
-  QPixmap _pixmap;
+    QPixmap _pixmap;
 };

--- a/examples/resizable_images/ImageShowModel.cpp
+++ b/examples/resizable_images/ImageShowModel.cpp
@@ -4,111 +4,86 @@
 
 #include <QtNodes/NodeDelegateModelRegistry>
 
-#include <QtCore/QEvent>
 #include <QtCore/QDir>
+#include <QtCore/QEvent>
 #include <QtWidgets/QFileDialog>
 
-
-ImageShowModel::
-ImageShowModel()
-  : _label(new QLabel("Image will appear here"))
+ImageShowModel::ImageShowModel()
+    : _label(new QLabel("Image will appear here"))
 {
-  _label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
+    _label->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
 
-  QFont f = _label->font();
-  f.setBold(true);
-  f.setItalic(true);
+    QFont f = _label->font();
+    f.setBold(true);
+    f.setItalic(true);
 
-  _label->setFont(f);
+    _label->setFont(f);
 
-  _label->setFixedSize(200, 200);
+    _label->setFixedSize(200, 200);
 
-  _label->installEventFilter(this);
+    _label->installEventFilter(this);
 }
 
-
-unsigned int
-ImageShowModel::
-nPorts(PortType portType) const
+unsigned int ImageShowModel::nPorts(PortType portType) const
 {
-  unsigned int result = 1;
+    unsigned int result = 1;
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      result = 1;
-      break;
+        result = 1;
+        break;
 
     case PortType::Out:
-      result = 1;
+        result = 1;
 
     default:
-      break;
-  }
-
-  return result;
-}
-
-
-bool
-ImageShowModel::
-eventFilter(QObject* object, QEvent* event)
-{
-  if (object == _label)
-  {
-    int w = _label->width();
-    int h = _label->height();
-
-    if (event->type() == QEvent::Resize)
-    {
-      auto d = std::dynamic_pointer_cast<PixmapData>(_nodeData);
-      if (d)
-      {
-        _label->setPixmap(d->pixmap().scaled(w, h, Qt::KeepAspectRatio));
-      }
+        break;
     }
-  }
 
-  return false;
+    return result;
 }
 
-
-NodeDataType
-ImageShowModel::
-dataType(PortType const, PortIndex const) const
+bool ImageShowModel::eventFilter(QObject *object, QEvent *event)
 {
-  return PixmapData().type();
+    if (object == _label) {
+        int w = _label->width();
+        int h = _label->height();
+
+        if (event->type() == QEvent::Resize) {
+            auto d = std::dynamic_pointer_cast<PixmapData>(_nodeData);
+            if (d) {
+                _label->setPixmap(d->pixmap().scaled(w, h, Qt::KeepAspectRatio));
+            }
+        }
+    }
+
+    return false;
 }
 
-
-std::shared_ptr<NodeData>
-ImageShowModel::
-outData(PortIndex)
+NodeDataType ImageShowModel::dataType(PortType const, PortIndex const) const
 {
-  return _nodeData;
+    return PixmapData().type();
 }
 
-
-void
-ImageShowModel::
-setInData(std::shared_ptr<NodeData> nodeData, PortIndex const)
+std::shared_ptr<NodeData> ImageShowModel::outData(PortIndex)
 {
-  _nodeData = nodeData;
-
-  if (_nodeData)
-  {
-    auto d = std::dynamic_pointer_cast<PixmapData>(_nodeData);
-
-    int w = _label->width();
-    int h = _label->height();
-
-    _label->setPixmap(d->pixmap().scaled(w, h, Qt::KeepAspectRatio));
-  }
-  else
-  {
-    _label->setPixmap(QPixmap());
-  }
-
-  Q_EMIT dataUpdated(0);
+    return _nodeData;
 }
 
+void ImageShowModel::setInData(std::shared_ptr<NodeData> nodeData, PortIndex const)
+{
+    _nodeData = nodeData;
+
+    if (_nodeData) {
+        auto d = std::dynamic_pointer_cast<PixmapData>(_nodeData);
+
+        int w = _label->width();
+        int h = _label->height();
+
+        _label->setPixmap(d->pixmap().scaled(w, h, Qt::KeepAspectRatio));
+    } else {
+        _label->setPixmap(QPixmap());
+    }
+
+    Q_EMIT dataUpdated(0);
+}

--- a/examples/resizable_images/ImageShowModel.hpp
+++ b/examples/resizable_images/ImageShowModel.hpp
@@ -5,70 +5,51 @@
 #include <QtCore/QObject>
 #include <QtWidgets/QLabel>
 
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/NodeDelegateModel>
+#include <QtNodes/NodeDelegateModelRegistry>
 
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 /// The model dictates the number of inputs and outputs for the Node.
 /// In this example it has no logic.
 class ImageShowModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  ImageShowModel();
+    ImageShowModel();
 
-  ~ImageShowModel() = default;
-
-public:
-
-  QString
-  caption() const override
-  { return QString("Image Display"); }
-
-  QString
-  name() const override
-  { return QString("ImageShowModel"); }
+    ~ImageShowModel() = default;
 
 public:
+    QString caption() const override { return QString("Image Display"); }
 
-  virtual QString
-  modelName() const
-  { return QString("Resulting Image"); }
+    QString name() const override { return QString("ImageShowModel"); }
 
-  unsigned int
-  nPorts(PortType const portType) const override;
+public:
+    virtual QString modelName() const { return QString("Resulting Image"); }
 
-  NodeDataType
-  dataType(PortType const  portType,
-           PortIndex const portIndex) const override;
+    unsigned int nPorts(PortType const portType) const override;
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex const port) override;
+    NodeDataType dataType(PortType const portType, PortIndex const portIndex) const override;
 
-  void
-  setInData(std::shared_ptr<NodeData> nodeData,
-            PortIndex const           port) override;
+    std::shared_ptr<NodeData> outData(PortIndex const port) override;
 
-  QWidget*
-  embeddedWidget() override { return _label; }
+    void setInData(std::shared_ptr<NodeData> nodeData, PortIndex const port) override;
 
-  bool
-  resizable() const override { return true; }
+    QWidget *embeddedWidget() override { return _label; }
+
+    bool resizable() const override { return true; }
 
 protected:
-
-  bool
-  eventFilter(QObject* object, QEvent* event) override;
+    bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
+    QLabel *_label;
 
-  QLabel* _label;
-
-  std::shared_ptr<NodeData> _nodeData;
+    std::shared_ptr<NodeData> _nodeData;
 };

--- a/examples/resizable_images/PixmapData.hpp
+++ b/examples/resizable_images/PixmapData.hpp
@@ -12,24 +12,20 @@ using QtNodes::NodeDataType;
 class PixmapData : public NodeData
 {
 public:
+    PixmapData() {}
 
-  PixmapData() {}
+    PixmapData(QPixmap const &pixmap)
+        : _pixmap(pixmap)
+    {}
 
-  PixmapData(QPixmap const &pixmap)
-    : _pixmap(pixmap)
-  {}
+    NodeDataType type() const override
+    {
+        //       id      name
+        return {"pixmap", "P"};
+    }
 
-  NodeDataType
-  type() const override
-  {
-    //       id      name
-    return {"pixmap", "P"};
-  }
-
-  QPixmap
-  pixmap() const { return _pixmap; }
+    QPixmap pixmap() const { return _pixmap; }
 
 private:
-
-  QPixmap _pixmap;
+    QPixmap _pixmap;
 };

--- a/examples/resizable_images/main.cpp
+++ b/examples/resizable_images/main.cpp
@@ -1,53 +1,48 @@
 #include <QtNodes/DataFlowGraphModel>
 #include <QtNodes/DataFlowGraphicsScene>
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/GraphicsView>
 #include <QtNodes/NodeData>
+#include <QtNodes/NodeDelegateModelRegistry>
 
-#include <QtWidgets/QApplication>
 #include <QtGui/QScreen>
+#include <QtWidgets/QApplication>
 
-#include "ImageShowModel.hpp"
 #include "ImageLoaderModel.hpp"
+#include "ImageShowModel.hpp"
 
 using QtNodes::ConnectionStyle;
-using QtNodes::DataFlowGraphModel;
 using QtNodes::DataFlowGraphicsScene;
-using QtNodes::NodeDelegateModelRegistry;
+using QtNodes::DataFlowGraphModel;
 using QtNodes::GraphicsView;
+using QtNodes::NodeDelegateModelRegistry;
 
-
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
-  ret->registerModel<ImageShowModel>();
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    ret->registerModel<ImageShowModel>();
 
-  ret->registerModel<ImageLoaderModel>();
+    ret->registerModel<ImageLoaderModel>();
 
-  return ret;
+    return ret;
 }
 
-
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
+    std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
 
-  DataFlowGraphModel dataFlowGraphModel(registry);
+    DataFlowGraphModel dataFlowGraphModel(registry);
 
-  DataFlowGraphicsScene scene(dataFlowGraphModel);
+    DataFlowGraphicsScene scene(dataFlowGraphModel);
 
-  GraphicsView view(&scene);
+    GraphicsView view(&scene);
 
-  view.setWindowTitle("Data Flow: Resizable Images");
-  view.resize(800, 600);
-  // Center window.
-  view.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
-  view.show();
+    view.setWindowTitle("Data Flow: Resizable Images");
+    view.resize(800, 600);
+    // Center window.
+    view.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
+    view.show();
 
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/simple_graph_model/SimpleGraphModel.cpp
+++ b/examples/simple_graph_model/SimpleGraphModel.cpp
@@ -1,369 +1,294 @@
 #include "SimpleGraphModel.hpp"
 
-
-SimpleGraphModel::
-SimpleGraphModel()
-  : _nextNodeId{0}
+SimpleGraphModel::SimpleGraphModel()
+    : _nextNodeId{0}
 {}
 
-
-SimpleGraphModel::
-~SimpleGraphModel()
+SimpleGraphModel::~SimpleGraphModel()
 {
-  //
+    //
 }
 
-
-std::unordered_set<NodeId>
-SimpleGraphModel::
-allNodeIds() const
+std::unordered_set<NodeId> SimpleGraphModel::allNodeIds() const
 {
-  return _nodeIds;
+    return _nodeIds;
 }
 
-
-std::unordered_set<ConnectionId>
-SimpleGraphModel::
-allConnectionIds(NodeId const nodeId) const
+std::unordered_set<ConnectionId> SimpleGraphModel::allConnectionIds(NodeId const nodeId) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&nodeId](ConnectionId const & cid)
-               {
-                  return cid.inNodeId == nodeId ||
-                         cid.outNodeId == nodeId;
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&nodeId](ConnectionId const &cid) {
+                     return cid.inNodeId == nodeId || cid.outNodeId == nodeId;
+                 });
 
-  return result;
+    return result;
 }
 
-
-std::unordered_set<ConnectionId>
-SimpleGraphModel::
-connections(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex) const
+std::unordered_set<ConnectionId> SimpleGraphModel::connections(NodeId nodeId,
+                                                               PortType portType,
+                                                               PortIndex portIndex) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&portType, &portIndex, &nodeId](ConnectionId const & cid)
-               {
-                  return (getNodeId(portType, cid) == nodeId &&
-                          getPortIndex(portType, cid) == portIndex);
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&portType, &portIndex, &nodeId](ConnectionId const &cid) {
+                     return (getNodeId(portType, cid) == nodeId
+                             && getPortIndex(portType, cid) == portIndex);
+                 });
 
-  return result;
+    return result;
 }
 
-
-bool
-SimpleGraphModel::
-connectionExists(ConnectionId const connectionId) const
+bool SimpleGraphModel::connectionExists(ConnectionId const connectionId) const
 {
-  return (_connectivity.find(connectionId) != _connectivity.end());
+    return (_connectivity.find(connectionId) != _connectivity.end());
 }
 
-
-NodeId
-SimpleGraphModel::
-addNode(QString const nodeType)
+NodeId SimpleGraphModel::addNode(QString const nodeType)
 {
-  NodeId newId = newNodeId();
-  // Create new node.
-  _nodeIds.insert(newId);
+    NodeId newId = newNodeId();
+    // Create new node.
+    _nodeIds.insert(newId);
 
-  Q_EMIT nodeCreated(newId);
+    Q_EMIT nodeCreated(newId);
 
-  return newId;
+    return newId;
 }
 
-
-bool
-SimpleGraphModel::
-connectionPossible(ConnectionId const connectionId) const
+bool SimpleGraphModel::connectionPossible(ConnectionId const connectionId) const
 {
-  return _connectivity.find(connectionId) == _connectivity.end();
+    return _connectivity.find(connectionId) == _connectivity.end();
 }
 
-
-void
-SimpleGraphModel::
-addConnection(ConnectionId const connectionId)
+void SimpleGraphModel::addConnection(ConnectionId const connectionId)
 {
-  _connectivity.insert(connectionId);
+    _connectivity.insert(connectionId);
 
-  Q_EMIT connectionCreated(connectionId);
+    Q_EMIT connectionCreated(connectionId);
 }
 
-
-bool
-SimpleGraphModel::
-nodeExists(NodeId const nodeId) const
+bool SimpleGraphModel::nodeExists(NodeId const nodeId) const
 {
-  return (_nodeIds.find(nodeId) != _nodeIds.end());
+    return (_nodeIds.find(nodeId) != _nodeIds.end());
 }
 
-
-QVariant
-SimpleGraphModel::
-nodeData(NodeId nodeId, NodeRole role) const
+QVariant SimpleGraphModel::nodeData(NodeId nodeId, NodeRole role) const
 {
-  Q_UNUSED(nodeId);
+    Q_UNUSED(nodeId);
 
-  QVariant result;
+    QVariant result;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      result = QString("Default Node Type");
-      break;
+        result = QString("Default Node Type");
+        break;
 
     case NodeRole::Position:
-      result = _nodeGeometryData[nodeId].pos;
-      break;
+        result = _nodeGeometryData[nodeId].pos;
+        break;
 
     case NodeRole::Size:
-      result = _nodeGeometryData[nodeId].size;
-      break;
+        result = _nodeGeometryData[nodeId].size;
+        break;
 
     case NodeRole::CaptionVisible:
-      result = true;
-      break;
+        result = true;
+        break;
 
     case NodeRole::Caption:
-      result = QString("Node");
-      break;
+        result = QString("Node");
+        break;
 
-    case NodeRole::Style:
-    {
-      auto style = StyleCollection::nodeStyle();
-      result = style.toJson().toVariantMap();
-    }
-    break;
+    case NodeRole::Style: {
+        auto style = StyleCollection::nodeStyle();
+        result = style.toJson().toVariantMap();
+    } break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      result = 1u;
-      break;
+        result = 1u;
+        break;
 
     case NodeRole::OutPortCount:
-      result = 1u;
-      break;
+        result = 1u;
+        break;
 
     case NodeRole::Widget:
-      result = QVariant();
-      break;
-  }
+        result = QVariant();
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-bool
-SimpleGraphModel::
-setNodeData(NodeId   nodeId,
-            NodeRole role,
-            QVariant value)
+bool SimpleGraphModel::setNodeData(NodeId nodeId, NodeRole role, QVariant value)
 {
-  bool result = false;
+    bool result = false;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      break;
-    case NodeRole::Position:
-    {
-      _nodeGeometryData[nodeId].pos = value.value<QPointF>();
+        break;
+    case NodeRole::Position: {
+        _nodeGeometryData[nodeId].pos = value.value<QPointF>();
 
-      Q_EMIT nodePositionUpdated(nodeId);
+        Q_EMIT nodePositionUpdated(nodeId);
 
-      result = true;
-    }
-    break;
+        result = true;
+    } break;
 
-    case NodeRole::Size:
-    {
-
-      _nodeGeometryData[nodeId].size = value.value<QSize>();
-      result = true;
-    }
-    break;
+    case NodeRole::Size: {
+        _nodeGeometryData[nodeId].size = value.value<QSize>();
+        result = true;
+    } break;
 
     case NodeRole::CaptionVisible:
-      break;
+        break;
 
     case NodeRole::Caption:
-      break;
+        break;
 
     case NodeRole::Style:
-      break;
+        break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      break;
+        break;
 
     case NodeRole::OutPortCount:
-      break;
+        break;
 
     case NodeRole::Widget:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-QVariant
-SimpleGraphModel::
-portData(NodeId    nodeId,
-         PortType  portType,
-         PortIndex portIndex,
-         PortRole  role) const
+QVariant SimpleGraphModel::portData(NodeId nodeId,
+                                    PortType portType,
+                                    PortIndex portIndex,
+                                    PortRole role) const
 {
-  switch (role)
-  {
+    switch (role) {
     case PortRole::Data:
-      return QVariant();
-      break;
+        return QVariant();
+        break;
 
     case PortRole::DataType:
-      return QVariant();
-      break;
+        return QVariant();
+        break;
 
     case PortRole::ConnectionPolicyRole:
-      return QVariant::fromValue(ConnectionPolicy::One);
-      break;
+        return QVariant::fromValue(ConnectionPolicy::One);
+        break;
 
     case PortRole::CaptionVisible:
-      return true;
-      break;
+        return true;
+        break;
 
     case PortRole::Caption:
-      if (portType == PortType::In)
-        return QString::fromUtf8("Port In");
-      else
-        return QString::fromUtf8("Port Out");
+        if (portType == PortType::In)
+            return QString::fromUtf8("Port In");
+        else
+            return QString::fromUtf8("Port Out");
 
-      break;
-  }
+        break;
+    }
 
-  return QVariant();
+    return QVariant();
 }
 
-
-bool
-SimpleGraphModel::
-setPortData(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex,
-            QVariant const& value,
-            PortRole  role)
+bool SimpleGraphModel::setPortData(
+    NodeId nodeId, PortType portType, PortIndex portIndex, QVariant const &value, PortRole role)
 {
-  Q_UNUSED(nodeId);
-  Q_UNUSED(portType);
-  Q_UNUSED(portIndex);
-  Q_UNUSED(value);
-  Q_UNUSED(role);
+    Q_UNUSED(nodeId);
+    Q_UNUSED(portType);
+    Q_UNUSED(portIndex);
+    Q_UNUSED(value);
+    Q_UNUSED(role);
 
-  return false;
+    return false;
 }
 
-
-bool
-SimpleGraphModel::
-deleteConnection(ConnectionId const connectionId)
+bool SimpleGraphModel::deleteConnection(ConnectionId const connectionId)
 {
-  bool disconnected = false;
+    bool disconnected = false;
 
-  auto it = _connectivity.find(connectionId);
+    auto it = _connectivity.find(connectionId);
 
-  if (it != _connectivity.end())
-  {
-    disconnected = true;
+    if (it != _connectivity.end()) {
+        disconnected = true;
 
-    _connectivity.erase(it);
-  }
+        _connectivity.erase(it);
+    }
 
-  if (disconnected)
-    Q_EMIT connectionDeleted(connectionId);
+    if (disconnected)
+        Q_EMIT connectionDeleted(connectionId);
 
-  return disconnected;
+    return disconnected;
 }
 
-
-bool
-SimpleGraphModel::
-deleteNode(NodeId const nodeId)
+bool SimpleGraphModel::deleteNode(NodeId const nodeId)
 {
-  // Delete connections to this node first.
-  auto connectionIds = allConnectionIds(nodeId);
+    // Delete connections to this node first.
+    auto connectionIds = allConnectionIds(nodeId);
 
-  for (auto & cId : connectionIds)
-  {
-    deleteConnection(cId);
-  }
+    for (auto &cId : connectionIds) {
+        deleteConnection(cId);
+    }
 
-  _nodeIds.erase(nodeId);
-  _nodeGeometryData.erase(nodeId);
+    _nodeIds.erase(nodeId);
+    _nodeGeometryData.erase(nodeId);
 
-  Q_EMIT nodeDeleted(nodeId);
+    Q_EMIT nodeDeleted(nodeId);
 
-  return true;
+    return true;
 }
 
-
-QJsonObject
-SimpleGraphModel::
-saveNode(NodeId const nodeId) const
+QJsonObject SimpleGraphModel::saveNode(NodeId const nodeId) const
 {
-  QJsonObject nodeJson;
+    QJsonObject nodeJson;
 
-  nodeJson["id"] = static_cast<qint64>(nodeId);
+    nodeJson["id"] = static_cast<qint64>(nodeId);
 
-  {
-    QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
+    {
+        QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
 
-    QJsonObject posJson;
-    posJson["x"] = pos.x();
-    posJson["y"] = pos.y();
-    nodeJson["position"] = posJson;
-  }
+        QJsonObject posJson;
+        posJson["x"] = pos.x();
+        posJson["y"] = pos.y();
+        nodeJson["position"] = posJson;
+    }
 
-  return nodeJson;
+    return nodeJson;
 }
 
-
-void
-SimpleGraphModel::
-loadNode(QJsonObject const & nodeJson)
+void SimpleGraphModel::loadNode(QJsonObject const &nodeJson)
 {
-  NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInt());
+    NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInt());
 
-  // Next NodeId must be larger that any id existing in the graph
-  _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
+    // Next NodeId must be larger that any id existing in the graph
+    _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
 
-  // Create new node.
-  _nodeIds.insert(restoredNodeId);
+    // Create new node.
+    _nodeIds.insert(restoredNodeId);
 
-  Q_EMIT nodeCreated(restoredNodeId);
+    Q_EMIT nodeCreated(restoredNodeId);
 
-  {
-    QJsonObject posJson = nodeJson["position"].toObject();
-    QPointF const pos(posJson["x"].toDouble(),
-                      posJson["y"].toDouble());
+    {
+        QJsonObject posJson = nodeJson["position"].toObject();
+        QPointF const pos(posJson["x"].toDouble(), posJson["y"].toDouble());
 
-    setNodeData(restoredNodeId,
-                NodeRole::Position,
-                pos);
-  }
+        setNodeData(restoredNodeId, NodeRole::Position, pos);
+    }
 }

--- a/examples/simple_graph_model/SimpleGraphModel.hpp
+++ b/examples/simple_graph_model/SimpleGraphModel.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
+#include <QtCore/QJsonObject>
 #include <QtCore/QPointF>
 #include <QtCore/QSize>
-#include <QtCore/QJsonObject>
 
 #include <QtNodes/AbstractGraphModel>
-#include <QtNodes/StyleCollection>
 #include <QtNodes/ConnectionIdUtils>
+#include <QtNodes/StyleCollection>
 
-
-using ConnectionId     = QtNodes::ConnectionId;
+using ConnectionId = QtNodes::ConnectionId;
 using ConnectionPolicy = QtNodes::ConnectionPolicy;
-using NodeFlag        = QtNodes::NodeFlag;
-using NodeId          = QtNodes::NodeId;
-using NodeRole        = QtNodes::NodeRole;
-using PortIndex       = QtNodes::PortIndex;
-using PortRole        = QtNodes::PortRole;
-using PortType        = QtNodes::PortType;
+using NodeFlag = QtNodes::NodeFlag;
+using NodeId = QtNodes::NodeId;
+using NodeRole = QtNodes::NodeRole;
+using PortIndex = QtNodes::PortIndex;
+using PortRole = QtNodes::PortRole;
+using PortType = QtNodes::PortType;
 using StyleCollection = QtNodes::StyleCollection;
 using QtNodes::InvalidNodeId;
 
@@ -26,104 +25,85 @@ using QtNodes::InvalidNodeId;
  */
 class SimpleGraphModel : public QtNodes::AbstractGraphModel
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  struct NodeGeometryData
-  {
-    QSize size;
-    QPointF pos;
-  };
+    struct NodeGeometryData
+    {
+        QSize size;
+        QPointF pos;
+    };
 
 public:
-  SimpleGraphModel();
+    SimpleGraphModel();
 
-  ~SimpleGraphModel() override;
+    ~SimpleGraphModel() override;
 
-  std::unordered_set<NodeId>
-  allNodeIds() const override;
+    std::unordered_set<NodeId> allNodeIds() const override;
 
-  std::unordered_set<ConnectionId>
-  allConnectionIds(NodeId const nodeId) const override;
+    std::unordered_set<ConnectionId> allConnectionIds(NodeId const nodeId) const override;
 
-  std::unordered_set<ConnectionId>
-  connections(NodeId    nodeId,
-              PortType  portType,
-              PortIndex portIndex) const override;
+    std::unordered_set<ConnectionId> connections(NodeId nodeId,
+                                                 PortType portType,
+                                                 PortIndex portIndex) const override;
 
-  bool
-  connectionExists(ConnectionId const connectionId) const override;
+    bool connectionExists(ConnectionId const connectionId) const override;
 
-  NodeId
-  addNode(QString const nodeType = QString()) override;
+    NodeId addNode(QString const nodeType = QString()) override;
 
-  /**
+    /**
    * Connection is possible when graph contains no connectivity data
    * in both directions `Out -> In` and `In -> Out`.
    */
-  bool
-  connectionPossible(ConnectionId const connectionId) const override;
+    bool connectionPossible(ConnectionId const connectionId) const override;
 
-  void
-  addConnection(ConnectionId const connectionId) override;
+    void addConnection(ConnectionId const connectionId) override;
 
-  bool
-  nodeExists(NodeId const nodeId) const override;
+    bool nodeExists(NodeId const nodeId) const override;
 
-  QVariant
-  nodeData(NodeId nodeId, NodeRole role) const override;
+    QVariant nodeData(NodeId nodeId, NodeRole role) const override;
 
-  bool
-  setNodeData(NodeId   nodeId,
-              NodeRole role,
-              QVariant value) override;
+    bool setNodeData(NodeId nodeId, NodeRole role, QVariant value) override;
 
-  QVariant
-  portData(NodeId    nodeId,
-           PortType  portType,
-           PortIndex portIndex,
-           PortRole  role) const override;
+    QVariant portData(NodeId nodeId,
+                      PortType portType,
+                      PortIndex portIndex,
+                      PortRole role) const override;
 
-  bool
-  setPortData(NodeId    nodeId,
-              PortType  portType,
-              PortIndex portIndex,
-              QVariant const& value,
-              PortRole        role = PortRole::Data) override;
+    bool setPortData(NodeId nodeId,
+                     PortType portType,
+                     PortIndex portIndex,
+                     QVariant const &value,
+                     PortRole role = PortRole::Data) override;
 
-  bool
-  deleteConnection(ConnectionId const connectionId) override;
+    bool deleteConnection(ConnectionId const connectionId) override;
 
-  bool
-  deleteNode(NodeId const nodeId) override;
+    bool deleteNode(NodeId const nodeId) override;
 
-  QJsonObject
-  saveNode(NodeId const) const override;
+    QJsonObject saveNode(NodeId const) const override;
 
-  /// @brief Creates a new node based on the informatoin in `nodeJson`.
-  /**
+    /// @brief Creates a new node based on the informatoin in `nodeJson`.
+    /**
    * @param nodeJson conains a `NodeId`, node's position, internal node
    * information.
    */
-  void
-  loadNode(QJsonObject const & nodeJson) override;
+    void loadNode(QJsonObject const &nodeJson) override;
 
-  NodeId newNodeId() override { return _nextNodeId++; }
+    NodeId newNodeId() override { return _nextNodeId++; }
 
 private:
-  std::unordered_set<NodeId> _nodeIds;
+    std::unordered_set<NodeId> _nodeIds;
 
-  /// [Important] This is a user defined data structure backing your model.
-  /// In your case it could be anything else representing a graph, for example, a
-  /// table. Or a collection of structs with pointers to each other. Or an
-  /// abstract syntax tree, you name it.
-  ///
-  /// This data structure contains the graph connectivity information in both
-  /// directions, i.e. from Node1 to Node2 and from Node2 to Node1.
-  std::unordered_set<ConnectionId> _connectivity;
+    /// [Important] This is a user defined data structure backing your model.
+    /// In your case it could be anything else representing a graph, for example, a
+    /// table. Or a collection of structs with pointers to each other. Or an
+    /// abstract syntax tree, you name it.
+    ///
+    /// This data structure contains the graph connectivity information in both
+    /// directions, i.e. from Node1 to Node2 and from Node2 to Node1.
+    std::unordered_set<ConnectionId> _connectivity;
 
-  mutable std::unordered_map<NodeId, NodeGeometryData>
-    _nodeGeometryData;
+    mutable std::unordered_map<NodeId, NodeGeometryData> _nodeGeometryData;
 
-  /// A convenience variable needed for generating unique node ids.
-  unsigned int _nextNodeId;
+    /// A convenience variable needed for generating unique node ids.
+    unsigned int _nextNodeId;
 };

--- a/examples/simple_graph_model/main.cpp
+++ b/examples/simple_graph_model/main.cpp
@@ -1,69 +1,59 @@
+#include <QtNodes/BasicGraphicsScene>
 #include <QtNodes/ConnectionStyle>
 #include <QtNodes/GraphicsView>
-#include <QtNodes/BasicGraphicsScene>
 #include <QtNodes/StyleCollection>
 
-#include <QtWidgets/QApplication>
 #include <QAction>
 #include <QScreen>
+#include <QtWidgets/QApplication>
 
 #include "SimpleGraphModel.hpp"
 
-
+using QtNodes::BasicGraphicsScene;
 using QtNodes::ConnectionStyle;
 using QtNodes::GraphicsView;
-using QtNodes::BasicGraphicsScene;
 using QtNodes::NodeRole;
 using QtNodes::StyleCollection;
 
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  SimpleGraphModel graphModel;
+    SimpleGraphModel graphModel;
 
-  // Initialize and connect two nodes.
-  {
-    NodeId id1 = graphModel.addNode();
-    graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
+    // Initialize and connect two nodes.
+    {
+        NodeId id1 = graphModel.addNode();
+        graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
 
-    NodeId id2 = graphModel.addNode();
-    graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
+        NodeId id2 = graphModel.addNode();
+        graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
 
-    graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
-  }
+        graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
+    }
 
-  auto scene = new BasicGraphicsScene(graphModel);
+    auto scene = new BasicGraphicsScene(graphModel);
 
-  GraphicsView view(scene);
+    GraphicsView view(scene);
 
-  // Setup context menu for creating new nodes.
-  view.setContextMenuPolicy(Qt::ActionsContextMenu);
-  QAction createNodeAction(QStringLiteral("Create Node"), &view);
-  QObject::connect(&createNodeAction, &QAction::triggered,
-                   [&]()
-                   {
-                     // Mouse position in scene coordinates.
-                     QPointF posView =
-                       view.mapToScene(view.mapFromGlobal(QCursor::pos()));
+    // Setup context menu for creating new nodes.
+    view.setContextMenuPolicy(Qt::ActionsContextMenu);
+    QAction createNodeAction(QStringLiteral("Create Node"), &view);
+    QObject::connect(&createNodeAction, &QAction::triggered, [&]() {
+        // Mouse position in scene coordinates.
+        QPointF posView = view.mapToScene(view.mapFromGlobal(QCursor::pos()));
 
+        NodeId const newId = graphModel.addNode();
+        graphModel.setNodeData(newId, NodeRole::Position, posView);
+    });
+    view.insertAction(view.actions().front(), &createNodeAction);
 
-                     NodeId const newId = graphModel.addNode();
-                     graphModel.setNodeData(newId,
-                                            NodeRole::Position,
-                                            posView);
-                   });
-  view.insertAction(view.actions().front(), &createNodeAction);
+    view.setWindowTitle("Simple Node Graph");
+    view.resize(800, 600);
 
+    // Center window.
+    view.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
+    view.showNormal();
 
-  view.setWindowTitle("Simple Node Graph");
-  view.resize(800, 600);
-
-  // Center window.
-  view.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
-  view.showNormal();
-
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/styles/main.cpp
+++ b/examples/styles/main.cpp
@@ -3,39 +3,35 @@
 #include <QtNodes/ConnectionStyle>
 #include <QtNodes/DataFlowGraphModel>
 #include <QtNodes/DataFlowGraphicsScene>
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/GraphicsView>
 #include <QtNodes/GraphicsViewStyle>
 #include <QtNodes/NodeData>
+#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/NodeStyle>
 
 #include <QtWidgets/QApplication>
 
 using QtNodes::ConnectionStyle;
-using QtNodes::DataFlowGraphModel;
 using QtNodes::DataFlowGraphicsScene;
-using QtNodes::NodeDelegateModelRegistry;
+using QtNodes::DataFlowGraphModel;
 using QtNodes::GraphicsView;
 using QtNodes::GraphicsViewStyle;
+using QtNodes::NodeDelegateModelRegistry;
 using QtNodes::NodeStyle;
 
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
 
-  ret->registerModel<MyDataModel>();
+    ret->registerModel<MyDataModel>();
 
-  return ret;
+    return ret;
 }
 
-
-static
-void
-setStyle()
+static void setStyle()
 {
-  GraphicsViewStyle::setStyle(
-    R"(
+    GraphicsViewStyle::setStyle(
+        R"(
   {
     "GraphicsViewStyle": {
       "BackgroundColor": [255, 255, 240],
@@ -45,8 +41,8 @@ setStyle()
   }
   )");
 
-  NodeStyle::setNodeStyle(
-    R"(
+    NodeStyle::setNodeStyle(
+        R"(
   {
     "NodeStyle": {
       "NormalBoundaryColor": "darkgray",
@@ -67,8 +63,8 @@ setStyle()
   }
   )");
 
-  ConnectionStyle::setConnectionStyle(
-    R"(
+    ConnectionStyle::setConnectionStyle(
+        R"(
   {
     "ConnectionStyle": {
       "ConstructionColor": "gray",
@@ -87,25 +83,22 @@ setStyle()
   )");
 }
 
-
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  setStyle();
+    setStyle();
 
-  std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
-  DataFlowGraphModel dataFlowGraphModel(registry);
+    std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
+    DataFlowGraphModel dataFlowGraphModel(registry);
 
-  DataFlowGraphicsScene scene(dataFlowGraphModel);
+    DataFlowGraphicsScene scene(dataFlowGraphModel);
 
-  GraphicsView view(&scene);
+    GraphicsView view(&scene);
 
-  view.setWindowTitle("Style example");
-  view.resize(800, 600);
-  view.show();
+    view.setWindowTitle("Style example");
+    view.resize(800, 600);
+    view.show();
 
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/styles/models.hpp
+++ b/examples/styles/models.hpp
@@ -7,21 +7,18 @@
 
 #include <memory>
 
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDataType;
 using QtNodes::NodeDelegateModel;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 /// The class can potentially incapsulate any user data which need to
 /// be transferred within the Node Editor graph
 class MyNodeData : public NodeData
 {
 public:
-
-  NodeDataType
-  type() const override
-  { return NodeDataType {"MyNodeData", "My Node Data"}; }
+    NodeDataType type() const override { return NodeDataType{"MyNodeData", "My Node Data"}; }
 };
 
 //------------------------------------------------------------------------------
@@ -30,67 +27,36 @@ public:
 /// In this example it has no logic.
 class MyDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-
-  ~MyDataModel() = default;
-
-public:
-
-  QString
-  caption() const override
-  {
-    return QString("My Data Model");
-  }
-
-
-  QString
-  name() const override
-  {
-    return QString("MyDataModel");
-  }
-
+    ~MyDataModel() = default;
 
 public:
+    QString caption() const override { return QString("My Data Model"); }
 
-  QJsonObject
-  save() const override
-  {
-    QJsonObject modelJson;
-
-    modelJson["name"] = name();
-
-    return modelJson;
-  }
-
+    QString name() const override { return QString("MyDataModel"); }
 
 public:
+    QJsonObject save() const override
+    {
+        QJsonObject modelJson;
 
-  unsigned int
-  nPorts(PortType const) const override
-  {
-    return 3;
-  }
+        modelJson["name"] = name();
 
+        return modelJson;
+    }
 
-  NodeDataType
-  dataType(PortType const, PortIndex const) const override
-  {
-    return MyNodeData().type();
-  }
+public:
+    unsigned int nPorts(PortType const) const override { return 3; }
 
+    NodeDataType dataType(PortType const, PortIndex const) const override
+    {
+        return MyNodeData().type();
+    }
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex) override
-  {
-    return std::make_shared<MyNodeData>();
-  }
+    std::shared_ptr<NodeData> outData(PortIndex) override { return std::make_shared<MyNodeData>(); }
 
+    void setInData(std::shared_ptr<NodeData>, PortIndex const) override {}
 
-  void
-  setInData(std::shared_ptr<NodeData>, PortIndex const) override
-  {}
-
-  QWidget*
-  embeddedWidget() override { return nullptr; }
+    QWidget *embeddedWidget() override { return nullptr; }
 };

--- a/examples/text/TextData.hpp
+++ b/examples/text/TextData.hpp
@@ -10,19 +10,16 @@ using QtNodes::NodeDataType;
 class TextData : public NodeData
 {
 public:
+    TextData() {}
 
-  TextData() {}
+    TextData(QString const &text)
+        : _text(text)
+    {}
 
-  TextData(QString const &text)
-    : _text(text)
-  {}
+    NodeDataType type() const override { return NodeDataType{"text", "Text"}; }
 
-  NodeDataType type() const override
-  { return NodeDataType {"text", "Text"}; }
-
-  QString text() const { return _text; }
+    QString text() const { return _text; }
 
 private:
-
-  QString _text;
+    QString _text;
 };

--- a/examples/text/TextDisplayDataModel.cpp
+++ b/examples/text/TextDisplayDataModel.cpp
@@ -1,69 +1,51 @@
 #include "TextDisplayDataModel.hpp"
 
-TextDisplayDataModel::
-TextDisplayDataModel()
-  : _label(new QLabel("Resulting Text"))
+TextDisplayDataModel::TextDisplayDataModel()
+    : _label(new QLabel("Resulting Text"))
 {
-  _label->setMargin(3);
+    _label->setMargin(3);
 }
 
-
-unsigned int
-TextDisplayDataModel::
-nPorts(PortType portType) const
+unsigned int TextDisplayDataModel::nPorts(PortType portType) const
 {
-  unsigned int result = 1;
+    unsigned int result = 1;
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      result = 1;
-      break;
+        result = 1;
+        break;
 
     case PortType::Out:
-      result = 0;
+        result = 0;
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-NodeDataType
-TextDisplayDataModel::
-dataType(PortType, PortIndex) const
+NodeDataType TextDisplayDataModel::dataType(PortType, PortIndex) const
 {
-  return TextData().type();
+    return TextData().type();
 }
 
-
-std::shared_ptr<NodeData>
-TextDisplayDataModel::
-outData(PortIndex)
+std::shared_ptr<NodeData> TextDisplayDataModel::outData(PortIndex)
 {
-  std::shared_ptr<NodeData> ptr;
-  return ptr;
+    std::shared_ptr<NodeData> ptr;
+    return ptr;
 }
 
-
-void
-TextDisplayDataModel::
-setInData(std::shared_ptr<NodeData> data, PortIndex const)
+void TextDisplayDataModel::setInData(std::shared_ptr<NodeData> data, PortIndex const)
 {
-  auto textData = std::dynamic_pointer_cast<TextData>(data);
+    auto textData = std::dynamic_pointer_cast<TextData>(data);
 
-  if (textData)
-  {
-    _inputText = textData->text();
-  }
-  else
-  {
-    _inputText = "";
-  }
+    if (textData) {
+        _inputText = textData->text();
+    } else {
+        _inputText = "";
+    }
 
-  _label->setText(_inputText);
-  _label->adjustSize();
+    _label->setText(_inputText);
+    _label->adjustSize();
 }
-

--- a/examples/text/TextDisplayDataModel.hpp
+++ b/examples/text/TextDisplayDataModel.hpp
@@ -20,50 +20,34 @@ using QtNodes::PortType;
 /// In this example it has no logic.
 class TextDisplayDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  TextDisplayDataModel();
+    TextDisplayDataModel();
 
-  virtual
-  ~TextDisplayDataModel() {}
-
-public:
-
-  QString
-  caption() const override
-  { return QString("Text Display"); }
-
-  bool
-  captionVisible() const override { return false; }
-
-  static QString
-  Name()
-  { return QString("TextDisplayDataModel"); }
-
-  QString
-  name() const override
-  { return TextDisplayDataModel::Name(); }
+    virtual ~TextDisplayDataModel() {}
 
 public:
+    QString caption() const override { return QString("Text Display"); }
 
-  unsigned int
-  nPorts(PortType portType) const override;
+    bool captionVisible() const override { return false; }
 
-  NodeDataType
-  dataType(PortType portType, PortIndex portIndex) const override;
+    static QString Name() { return QString("TextDisplayDataModel"); }
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex const port) override;
+    QString name() const override { return TextDisplayDataModel::Name(); }
 
-  void
-  setInData(std::shared_ptr<NodeData> data, 
-            PortIndex const portIndex) override;
+public:
+    unsigned int nPorts(PortType portType) const override;
 
-  QWidget*
-  embeddedWidget() override { return _label; }
+    NodeDataType dataType(PortType portType, PortIndex portIndex) const override;
+
+    std::shared_ptr<NodeData> outData(PortIndex const port) override;
+
+    void setInData(std::shared_ptr<NodeData> data, PortIndex const portIndex) override;
+
+    QWidget *embeddedWidget() override { return _label; }
 
 private:
-  QLabel * _label;
-  QString _inputText;
+    QLabel *_label;
+    QString _inputText;
 };

--- a/examples/text/TextSourceDataModel.cpp
+++ b/examples/text/TextSourceDataModel.cpp
@@ -2,77 +2,56 @@
 
 #include <QtWidgets/QLineEdit>
 
-TextSourceDataModel::
-TextSourceDataModel()
-  : _lineEdit{nullptr}
+TextSourceDataModel::TextSourceDataModel()
+    : _lineEdit{nullptr}
 {
-  //
+    //
 }
 
-
-unsigned int
-TextSourceDataModel::
-nPorts(PortType portType) const
+unsigned int TextSourceDataModel::nPorts(PortType portType) const
 {
-  unsigned int result = 1;
+    unsigned int result = 1;
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      result = 0;
-      break;
+        result = 0;
+        break;
 
     case PortType::Out:
-      result = 1;
+        result = 1;
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-void
-TextSourceDataModel::
-onTextEdited(QString const & string)
+void TextSourceDataModel::onTextEdited(QString const &string)
 {
-  Q_UNUSED(string);
+    Q_UNUSED(string);
 
-  Q_EMIT dataUpdated(0);
+    Q_EMIT dataUpdated(0);
 }
 
-
-NodeDataType
-TextSourceDataModel::
-dataType(PortType, PortIndex) const
+NodeDataType TextSourceDataModel::dataType(PortType, PortIndex) const
 {
-  return TextData().type();
+    return TextData().type();
 }
 
-
-std::shared_ptr<NodeData>
-TextSourceDataModel::
-outData(PortIndex const portIndex)
+std::shared_ptr<NodeData> TextSourceDataModel::outData(PortIndex const portIndex)
 {
-  Q_UNUSED(portIndex);
-  return std::make_shared<TextData>(_lineEdit->text());
+    Q_UNUSED(portIndex);
+    return std::make_shared<TextData>(_lineEdit->text());
 }
 
-
-QWidget *
-TextSourceDataModel::
-embeddedWidget()
+QWidget *TextSourceDataModel::embeddedWidget()
 {
-  if (!_lineEdit)
-  {
-    _lineEdit = new QLineEdit("Default Text"),
+    if (!_lineEdit) {
+        _lineEdit = new QLineEdit("Default Text"),
 
-    connect(_lineEdit, &QLineEdit::textEdited,
-            this, &TextSourceDataModel::onTextEdited);
+        connect(_lineEdit, &QLineEdit::textEdited, this, &TextSourceDataModel::onTextEdited);
+    }
 
-  }
-
-  return _lineEdit;
+    return _lineEdit;
 }
-

--- a/examples/text/TextSourceDataModel.hpp
+++ b/examples/text/TextSourceDataModel.hpp
@@ -8,10 +8,10 @@
 
 #include <iostream>
 
-using QtNodes::PortType;
-using QtNodes::PortIndex;
 using QtNodes::NodeData;
 using QtNodes::NodeDelegateModel;
+using QtNodes::PortIndex;
+using QtNodes::PortType;
 
 class QLineEdit;
 
@@ -19,48 +19,35 @@ class QLineEdit;
 /// In this example it has no logic.
 class TextSourceDataModel : public NodeDelegateModel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  TextSourceDataModel();
+    TextSourceDataModel();
 
 public:
-  QString
-  caption() const override
-  { return QString("Text Source"); }
+    QString caption() const override { return QString("Text Source"); }
 
-  bool
-  captionVisible() const override { return false; }
+    bool captionVisible() const override { return false; }
 
-  static QString
-  Name()
-  { return QString("TextSourceDataModel"); }
+    static QString Name() { return QString("TextSourceDataModel"); }
 
-  QString
-  name() const override
-  { return TextSourceDataModel::Name(); }
+    QString name() const override { return TextSourceDataModel::Name(); }
 
 public:
-  unsigned int
-  nPorts(PortType portType) const override;
+    unsigned int nPorts(PortType portType) const override;
 
-  NodeDataType
-  dataType(PortType portType, PortIndex portIndex) const override;
+    NodeDataType dataType(PortType portType, PortIndex portIndex) const override;
 
-  std::shared_ptr<NodeData>
-  outData(PortIndex const portIndex) override;
+    std::shared_ptr<NodeData> outData(PortIndex const portIndex) override;
 
-  void
-  setInData(std::shared_ptr<NodeData>, PortIndex const) override { }
+    void setInData(std::shared_ptr<NodeData>, PortIndex const) override {}
 
-  QWidget *
-  embeddedWidget() override;
+    QWidget *embeddedWidget() override;
 
 private Q_SLOTS:
 
-  void
-  onTextEdited(QString const & string);
+    void onTextEdited(QString const &string);
 
 private:
-  QLineEdit * _lineEdit;
+    QLineEdit *_lineEdit;
 };

--- a/examples/text/main.cpp
+++ b/examples/text/main.cpp
@@ -1,47 +1,43 @@
 #include <QtNodes/DataFlowGraphModel>
 #include <QtNodes/DataFlowGraphicsScene>
-#include <QtNodes/NodeDelegateModelRegistry>
 #include <QtNodes/GraphicsView>
 #include <QtNodes/NodeData>
+#include <QtNodes/NodeDelegateModelRegistry>
 
 #include <QtWidgets/QApplication>
 
-#include "TextSourceDataModel.hpp"
 #include "TextDisplayDataModel.hpp"
+#include "TextSourceDataModel.hpp"
 
-using QtNodes::DataFlowGraphModel;
 using QtNodes::DataFlowGraphicsScene;
-using QtNodes::NodeDelegateModelRegistry;
+using QtNodes::DataFlowGraphModel;
 using QtNodes::GraphicsView;
+using QtNodes::NodeDelegateModelRegistry;
 
-static std::shared_ptr<NodeDelegateModelRegistry>
-registerDataModels()
+static std::shared_ptr<NodeDelegateModelRegistry> registerDataModels()
 {
-  auto ret = std::make_shared<NodeDelegateModelRegistry>();
+    auto ret = std::make_shared<NodeDelegateModelRegistry>();
 
-  ret->registerModel<TextSourceDataModel>();
-  ret->registerModel<TextDisplayDataModel>();
+    ret->registerModel<TextSourceDataModel>();
+    ret->registerModel<TextDisplayDataModel>();
 
-  return ret;
+    return ret;
 }
 
-
-int
-main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
-  DataFlowGraphModel dataFlowGraphModel(registry);
+    std::shared_ptr<NodeDelegateModelRegistry> registry = registerDataModels();
+    DataFlowGraphModel dataFlowGraphModel(registry);
 
-  DataFlowGraphicsScene scene(dataFlowGraphModel);
+    DataFlowGraphicsScene scene(dataFlowGraphModel);
 
-  GraphicsView view(&scene);
+    GraphicsView view(&scene);
 
-  view.setWindowTitle("Node-based flow editor");
-  view.resize(800, 600);
-  view.show();
+    view.setWindowTitle("Node-based flow editor");
+    view.resize(800, 600);
+    view.show();
 
-  return app.exec();
+    return app.exec();
 }
-

--- a/examples/vertical_layout/SimpleGraphModel.cpp
+++ b/examples/vertical_layout/SimpleGraphModel.cpp
@@ -1,368 +1,293 @@
 #include "SimpleGraphModel.hpp"
 
-
-SimpleGraphModel::
-SimpleGraphModel()
-  : _nextNodeId{0}
+SimpleGraphModel::SimpleGraphModel()
+    : _nextNodeId{0}
 {}
 
-
-SimpleGraphModel::
-~SimpleGraphModel()
+SimpleGraphModel::~SimpleGraphModel()
 {
-  //
+    //
 }
 
-
-std::unordered_set<NodeId>
-SimpleGraphModel::
-allNodeIds() const
+std::unordered_set<NodeId> SimpleGraphModel::allNodeIds() const
 {
-  return _nodeIds;
+    return _nodeIds;
 }
 
-
-std::unordered_set<ConnectionId>
-SimpleGraphModel::
-allConnectionIds(NodeId const nodeId) const
+std::unordered_set<ConnectionId> SimpleGraphModel::allConnectionIds(NodeId const nodeId) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&nodeId](ConnectionId const & cid)
-               {
-                  return cid.inNodeId == nodeId ||
-                         cid.outNodeId == nodeId;
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&nodeId](ConnectionId const &cid) {
+                     return cid.inNodeId == nodeId || cid.outNodeId == nodeId;
+                 });
 
-  return result;
+    return result;
 }
 
-
-std::unordered_set<ConnectionId>
-SimpleGraphModel::
-connections(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex) const
+std::unordered_set<ConnectionId> SimpleGraphModel::connections(NodeId nodeId,
+                                                               PortType portType,
+                                                               PortIndex portIndex) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&portType, &portIndex, &nodeId](ConnectionId const & cid)
-               {
-                  return (getNodeId(portType, cid) == nodeId &&
-                          getPortIndex(portType, cid) == portIndex);
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&portType, &portIndex, &nodeId](ConnectionId const &cid) {
+                     return (getNodeId(portType, cid) == nodeId
+                             && getPortIndex(portType, cid) == portIndex);
+                 });
 
-  return result;
+    return result;
 }
 
-
-bool
-SimpleGraphModel::
-connectionExists(ConnectionId const connectionId) const
+bool SimpleGraphModel::connectionExists(ConnectionId const connectionId) const
 {
-  return (_connectivity.find(connectionId) != _connectivity.end());
+    return (_connectivity.find(connectionId) != _connectivity.end());
 }
 
-
-NodeId
-SimpleGraphModel::
-addNode(QString const nodeType)
+NodeId SimpleGraphModel::addNode(QString const nodeType)
 {
-  NodeId newId = _nextNodeId++;
-  // Create new node.
-  _nodeIds.insert(newId);
+    NodeId newId = _nextNodeId++;
+    // Create new node.
+    _nodeIds.insert(newId);
 
-  Q_EMIT nodeCreated(newId);
+    Q_EMIT nodeCreated(newId);
 
-  return newId;
+    return newId;
 }
 
-
-bool
-SimpleGraphModel::
-connectionPossible(ConnectionId const connectionId) const
+bool SimpleGraphModel::connectionPossible(ConnectionId const connectionId) const
 {
-  return _connectivity.find(connectionId) == _connectivity.end();
+    return _connectivity.find(connectionId) == _connectivity.end();
 }
 
-
-void
-SimpleGraphModel::
-addConnection(ConnectionId const connectionId)
+void SimpleGraphModel::addConnection(ConnectionId const connectionId)
 {
-  _connectivity.insert(connectionId);
+    _connectivity.insert(connectionId);
 
-  Q_EMIT connectionCreated(connectionId);
+    Q_EMIT connectionCreated(connectionId);
 }
 
-
-bool
-SimpleGraphModel::
-nodeExists(NodeId const nodeId) const
+bool SimpleGraphModel::nodeExists(NodeId const nodeId) const
 {
-  return (_nodeIds.find(nodeId) != _nodeIds.end());
+    return (_nodeIds.find(nodeId) != _nodeIds.end());
 }
 
-
-QVariant
-SimpleGraphModel::
-nodeData(NodeId nodeId, NodeRole role) const
+QVariant SimpleGraphModel::nodeData(NodeId nodeId, NodeRole role) const
 {
-  Q_UNUSED(nodeId);
+    Q_UNUSED(nodeId);
 
-  QVariant result;
+    QVariant result;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      result = QString("Default Node Type");
-      break;
+        result = QString("Default Node Type");
+        break;
 
     case NodeRole::Position:
-      result = _nodeGeometryData[nodeId].pos;
-      break;
+        result = _nodeGeometryData[nodeId].pos;
+        break;
 
     case NodeRole::Size:
-      result = _nodeGeometryData[nodeId].size;
-      break;
+        result = _nodeGeometryData[nodeId].size;
+        break;
 
     case NodeRole::CaptionVisible:
-      result = true;
-      break;
+        result = true;
+        break;
 
     case NodeRole::Caption:
-      result = QString("Node");
-      break;
+        result = QString("Node");
+        break;
 
-    case NodeRole::Style:
-    {
-      auto style = StyleCollection::nodeStyle();
-      result = style.toJson().toVariantMap();
-    }
-    break;
+    case NodeRole::Style: {
+        auto style = StyleCollection::nodeStyle();
+        result = style.toJson().toVariantMap();
+    } break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      result = 5u;
-      break;
+        result = 5u;
+        break;
 
     case NodeRole::OutPortCount:
-      result = 3u;
-      break;
+        result = 3u;
+        break;
 
     case NodeRole::Widget:
-      result = QVariant();
-      break;
-  }
+        result = QVariant();
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-bool
-SimpleGraphModel::
-setNodeData(NodeId   nodeId,
-            NodeRole role,
-            QVariant value)
+bool SimpleGraphModel::setNodeData(NodeId nodeId, NodeRole role, QVariant value)
 {
-  bool result = false;
+    bool result = false;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      break;
-    case NodeRole::Position:
-    {
-      _nodeGeometryData[nodeId].pos = value.value<QPointF>();
+        break;
+    case NodeRole::Position: {
+        _nodeGeometryData[nodeId].pos = value.value<QPointF>();
 
-      Q_EMIT nodePositionUpdated(nodeId);
+        Q_EMIT nodePositionUpdated(nodeId);
 
-      result = true;
-    }
-    break;
+        result = true;
+    } break;
 
-    case NodeRole::Size:
-    {
-
-      _nodeGeometryData[nodeId].size = value.value<QSize>();
-      result = true;
-    }
-    break;
+    case NodeRole::Size: {
+        _nodeGeometryData[nodeId].size = value.value<QSize>();
+        result = true;
+    } break;
 
     case NodeRole::CaptionVisible:
-      break;
+        break;
 
     case NodeRole::Caption:
-      break;
+        break;
 
     case NodeRole::Style:
-      break;
+        break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      break;
+        break;
 
     case NodeRole::OutPortCount:
-      break;
+        break;
 
     case NodeRole::Widget:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-QVariant
-SimpleGraphModel::
-portData(NodeId    nodeId,
-         PortType  portType,
-         PortIndex portIndex,
-         PortRole  role) const
+QVariant SimpleGraphModel::portData(NodeId nodeId,
+                                    PortType portType,
+                                    PortIndex portIndex,
+                                    PortRole role) const
 {
-  switch (role)
-  {
+    switch (role) {
     case PortRole::Data:
-      return QVariant();
-      break;
+        return QVariant();
+        break;
 
     case PortRole::DataType:
-      return QVariant();
-      break;
+        return QVariant();
+        break;
 
     case PortRole::ConnectionPolicyRole:
-      return QVariant::fromValue(ConnectionPolicy::One);
-      break;
+        return QVariant::fromValue(ConnectionPolicy::One);
+        break;
 
     case PortRole::CaptionVisible:
-      return true;
-      break;
+        return true;
+        break;
 
     case PortRole::Caption:
-      if (portType == PortType::In)
-        return QString::fromUtf8("Port In");
-      else
-        return QString::fromUtf8("Port Out");
+        if (portType == PortType::In)
+            return QString::fromUtf8("Port In");
+        else
+            return QString::fromUtf8("Port Out");
 
-      break;
-  }
+        break;
+    }
 
-  return QVariant();
+    return QVariant();
 }
 
-
-bool
-SimpleGraphModel::
-setPortData(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex,
-            QVariant const& value,
-            PortRole  role)
+bool SimpleGraphModel::setPortData(
+    NodeId nodeId, PortType portType, PortIndex portIndex, QVariant const &value, PortRole role)
 {
-  Q_UNUSED(nodeId);
-  Q_UNUSED(portType);
-  Q_UNUSED(portIndex);
-  Q_UNUSED(value);
-  Q_UNUSED(role);
+    Q_UNUSED(nodeId);
+    Q_UNUSED(portType);
+    Q_UNUSED(portIndex);
+    Q_UNUSED(value);
+    Q_UNUSED(role);
 
-  return false;
+    return false;
 }
 
-
-bool
-SimpleGraphModel::
-deleteConnection(ConnectionId const connectionId)
+bool SimpleGraphModel::deleteConnection(ConnectionId const connectionId)
 {
-  bool disconnected = false;
+    bool disconnected = false;
 
-  auto it = _connectivity.find(connectionId);
+    auto it = _connectivity.find(connectionId);
 
-  if (it != _connectivity.end())
-  {
-    disconnected = true;
+    if (it != _connectivity.end()) {
+        disconnected = true;
 
-    _connectivity.erase(it);
-  }
+        _connectivity.erase(it);
+    }
 
-  if (disconnected)
-    Q_EMIT connectionDeleted(connectionId);
+    if (disconnected)
+        Q_EMIT connectionDeleted(connectionId);
 
-  return disconnected;
+    return disconnected;
 }
 
-
-bool
-SimpleGraphModel::
-deleteNode(NodeId const nodeId)
+bool SimpleGraphModel::deleteNode(NodeId const nodeId)
 {
-  // Delete connections to this node first.
-  auto connectionIds = allConnectionIds(nodeId);
-  for (auto & cId : connectionIds)
-  {
-    deleteConnection(cId);
-  }
+    // Delete connections to this node first.
+    auto connectionIds = allConnectionIds(nodeId);
+    for (auto &cId : connectionIds) {
+        deleteConnection(cId);
+    }
 
-  _nodeIds.erase(nodeId);
-  _nodeGeometryData.erase(nodeId);
+    _nodeIds.erase(nodeId);
+    _nodeGeometryData.erase(nodeId);
 
-  Q_EMIT nodeDeleted(nodeId);
+    Q_EMIT nodeDeleted(nodeId);
 
-  return true;
+    return true;
 }
 
-
-QJsonObject
-SimpleGraphModel::
-saveNode(NodeId const nodeId) const
+QJsonObject SimpleGraphModel::saveNode(NodeId const nodeId) const
 {
-  QJsonObject nodeJson;
+    QJsonObject nodeJson;
 
-  nodeJson["id"] = static_cast<qint64>(nodeId);
+    nodeJson["id"] = static_cast<qint64>(nodeId);
 
-  {
-    QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
+    {
+        QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
 
-    QJsonObject posJson;
-    posJson["x"] = pos.x();
-    posJson["y"] = pos.y();
-    nodeJson["position"] = posJson;
-  }
+        QJsonObject posJson;
+        posJson["x"] = pos.x();
+        posJson["y"] = pos.y();
+        nodeJson["position"] = posJson;
+    }
 
-  return nodeJson;
+    return nodeJson;
 }
 
-
-void
-SimpleGraphModel::
-loadNode(QJsonObject const & nodeJson)
+void SimpleGraphModel::loadNode(QJsonObject const &nodeJson)
 {
-  NodeId restoredNodeId = nodeJson["id"].toInt();
+    NodeId restoredNodeId = nodeJson["id"].toInt();
 
-  // Next NodeId must be larger that any id existing in the graph
-  _nextNodeId = std::max(restoredNodeId + 1, _nextNodeId);
+    // Next NodeId must be larger that any id existing in the graph
+    _nextNodeId = std::max(restoredNodeId + 1, _nextNodeId);
 
-  // Create new node.
-  _nodeIds.insert(restoredNodeId);
+    // Create new node.
+    _nodeIds.insert(restoredNodeId);
 
-  Q_EMIT nodeCreated(restoredNodeId);
+    Q_EMIT nodeCreated(restoredNodeId);
 
-  {
-    QJsonObject posJson = nodeJson["position"].toObject();
-    QPointF const pos(posJson["x"].toDouble(),
-                      posJson["y"].toDouble());
+    {
+        QJsonObject posJson = nodeJson["position"].toObject();
+        QPointF const pos(posJson["x"].toDouble(), posJson["y"].toDouble());
 
-    setNodeData(restoredNodeId,
-                NodeRole::Position,
-                pos);
-  }
+        setNodeData(restoredNodeId, NodeRole::Position, pos);
+    }
 }

--- a/examples/vertical_layout/SimpleGraphModel.hpp
+++ b/examples/vertical_layout/SimpleGraphModel.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
+#include <QtCore/QJsonObject>
 #include <QtCore/QPointF>
 #include <QtCore/QSize>
-#include <QtCore/QJsonObject>
 
 #include <QtNodes/AbstractGraphModel>
-#include <QtNodes/StyleCollection>
 #include <QtNodes/ConnectionIdUtils>
+#include <QtNodes/StyleCollection>
 
-
-using ConnectionId     = QtNodes::ConnectionId;
+using ConnectionId = QtNodes::ConnectionId;
 using ConnectionPolicy = QtNodes::ConnectionPolicy;
-using NodeFlag        = QtNodes::NodeFlag;
-using NodeId          = QtNodes::NodeId;
-using NodeRole        = QtNodes::NodeRole;
-using PortIndex       = QtNodes::PortIndex;
-using PortRole        = QtNodes::PortRole;
-using PortType        = QtNodes::PortType;
+using NodeFlag = QtNodes::NodeFlag;
+using NodeId = QtNodes::NodeId;
+using NodeRole = QtNodes::NodeRole;
+using PortIndex = QtNodes::PortIndex;
+using PortRole = QtNodes::PortRole;
+using PortType = QtNodes::PortType;
 using StyleCollection = QtNodes::StyleCollection;
 using QtNodes::InvalidNodeId;
 
@@ -26,106 +25,86 @@ using QtNodes::InvalidNodeId;
  */
 class SimpleGraphModel : public QtNodes::AbstractGraphModel
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  struct NodeGeometryData
-  {
-    QSize size;
-    QPointF pos;
-  };
+    struct NodeGeometryData
+    {
+        QSize size;
+        QPointF pos;
+    };
 
 public:
-  SimpleGraphModel();
+    SimpleGraphModel();
 
-  ~SimpleGraphModel() override;
+    ~SimpleGraphModel() override;
 
-  std::unordered_set<NodeId>
-  allNodeIds() const override;
+    std::unordered_set<NodeId> allNodeIds() const override;
 
-  std::unordered_set<ConnectionId>
-  allConnectionIds(NodeId const nodeId) const override;
+    std::unordered_set<ConnectionId> allConnectionIds(NodeId const nodeId) const override;
 
-  std::unordered_set<ConnectionId>
-  connections(NodeId    nodeId,
-              PortType  portType,
-              PortIndex portIndex) const override;
+    std::unordered_set<ConnectionId> connections(NodeId nodeId,
+                                                 PortType portType,
+                                                 PortIndex portIndex) const override;
 
-  bool
-  connectionExists(ConnectionId const connectionId) const override;
+    bool connectionExists(ConnectionId const connectionId) const override;
 
-  NodeId
-  addNode(QString const nodeType = QString()) override;
+    NodeId addNode(QString const nodeType = QString()) override;
 
-  /**
+    /**
    * Connection is possible when graph contains no connectivity data
    * in both directions `Out -> In` and `In -> Out`.
    */
-  bool
-  connectionPossible(ConnectionId const connectionId) const override;
+    bool connectionPossible(ConnectionId const connectionId) const override;
 
-  void
-  addConnection(ConnectionId const connectionId) override;
+    void addConnection(ConnectionId const connectionId) override;
 
-  bool
-  nodeExists(NodeId const nodeId) const override;
+    bool nodeExists(NodeId const nodeId) const override;
 
-  QVariant
-  nodeData(NodeId nodeId, NodeRole role) const override;
+    QVariant nodeData(NodeId nodeId, NodeRole role) const override;
 
-  bool
-  setNodeData(NodeId   nodeId,
-              NodeRole role,
-              QVariant value) override;
+    bool setNodeData(NodeId nodeId, NodeRole role, QVariant value) override;
 
-  QVariant
-  portData(NodeId    nodeId,
-           PortType  portType,
-           PortIndex portIndex,
-           PortRole  role) const override;
+    QVariant portData(NodeId nodeId,
+                      PortType portType,
+                      PortIndex portIndex,
+                      PortRole role) const override;
 
-  bool
-  setPortData(NodeId          nodeId,
-              PortType        portType,
-              PortIndex       portIndex,
-              QVariant const& value,
-              PortRole        role = PortRole::Data) override;
+    bool setPortData(NodeId nodeId,
+                     PortType portType,
+                     PortIndex portIndex,
+                     QVariant const &value,
+                     PortRole role = PortRole::Data) override;
 
-  bool
-  deleteConnection(ConnectionId const connectionId) override;
+    bool deleteConnection(ConnectionId const connectionId) override;
 
-  bool
-  deleteNode(NodeId const nodeId) override;
+    bool deleteNode(NodeId const nodeId) override;
 
-  QJsonObject
-  saveNode(NodeId const) const override;
+    QJsonObject saveNode(NodeId const) const override;
 
-  /// @brief Creates a new node based on the informatoin in `nodeJson`.
-  /**
+    /// @brief Creates a new node based on the informatoin in `nodeJson`.
+    /**
    * @param nodeJson conains a `NodeId`, node's position, internal node
    * information.
    */
-  void
-  loadNode(QJsonObject const & nodeJson) override;
+    void loadNode(QJsonObject const &nodeJson) override;
 
 private:
-  NodeId
-  newNodeId() override { return _nextNodeId++; }
+    NodeId newNodeId() override { return _nextNodeId++; }
 
 private:
-  std::unordered_set<NodeId> _nodeIds;
+    std::unordered_set<NodeId> _nodeIds;
 
-  /// [Important] This is a user defined data structure backing your model.
-  /// In your case it could be anything else representing a graph, for example, a
-  /// table. Or a collection of structs with pointers to each other. Or an
-  /// abstract syntax tree, you name it.
-  ///
-  /// This data structure contains the graph connectivity information in both
-  /// directions, i.e. from Node1 to Node2 and from Node2 to Node1.
-  std::unordered_set<ConnectionId> _connectivity;
+    /// [Important] This is a user defined data structure backing your model.
+    /// In your case it could be anything else representing a graph, for example, a
+    /// table. Or a collection of structs with pointers to each other. Or an
+    /// abstract syntax tree, you name it.
+    ///
+    /// This data structure contains the graph connectivity information in both
+    /// directions, i.e. from Node1 to Node2 and from Node2 to Node1.
+    std::unordered_set<ConnectionId> _connectivity;
 
-  mutable std::unordered_map<NodeId, NodeGeometryData>
-    _nodeGeometryData;
+    mutable std::unordered_map<NodeId, NodeGeometryData> _nodeGeometryData;
 
-  /// A convenience variable needed for generating unique node ids.
-  unsigned int _nextNodeId;
+    /// A convenience variable needed for generating unique node ids.
+    unsigned int _nextNodeId;
 };

--- a/examples/vertical_layout/main.cpp
+++ b/examples/vertical_layout/main.cpp
@@ -1,102 +1,88 @@
-#include <QtNodes/GraphicsView>
+#include <QAction>
+#include <QScreen>
 #include <QtNodes/BasicGraphicsScene>
+#include <QtNodes/GraphicsView>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QRadioButton>
-#include <QAction>
-#include <QScreen>
 
 #include "SimpleGraphModel.hpp"
 
-
-using QtNodes::GraphicsView;
 using QtNodes::BasicGraphicsScene;
+using QtNodes::GraphicsView;
 using QtNodes::NodeRole;
 
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-  SimpleGraphModel graphModel;
+    SimpleGraphModel graphModel;
 
-  // Initialize and connect two nodes.
-  {
-    NodeId id1 = graphModel.addNode();
-    graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
+    // Initialize and connect two nodes.
+    {
+        NodeId id1 = graphModel.addNode();
+        graphModel.setNodeData(id1, NodeRole::Position, QPointF(0, 0));
 
-    NodeId id2 = graphModel.addNode();
-    graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
+        NodeId id2 = graphModel.addNode();
+        graphModel.setNodeData(id2, NodeRole::Position, QPointF(300, 300));
 
-    graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
-  }
+        graphModel.addConnection(ConnectionId{id1, 0, id2, 0});
+    }
 
-  auto scene = new BasicGraphicsScene(graphModel);
+    auto scene = new BasicGraphicsScene(graphModel);
 
-  scene->setOrientation(Qt::Vertical);
+    scene->setOrientation(Qt::Vertical);
 
-  QWidget window;
+    QWidget window;
 
-  QHBoxLayout * l = new QHBoxLayout(&window);
+    QHBoxLayout *l = new QHBoxLayout(&window);
 
-  GraphicsView view(scene);
+    GraphicsView view(scene);
 
-  l->addWidget(&view);
+    l->addWidget(&view);
 
+    QGroupBox *groupBox = new QGroupBox("Orientation");
 
+    QRadioButton *radio1 = new QRadioButton("Vertical");
+    QRadioButton *radio2 = new QRadioButton("Horizontal");
 
-  QGroupBox *groupBox = new QGroupBox("Orientation");
+    QVBoxLayout *vbl = new QVBoxLayout;
+    vbl->addWidget(radio1);
+    vbl->addWidget(radio2);
+    vbl->addStretch();
+    groupBox->setLayout(vbl);
 
-  QRadioButton *radio1 = new QRadioButton("Vertical");
-  QRadioButton *radio2 = new QRadioButton("Horizontal");
+    QObject::connect(radio1, &QRadioButton::clicked, [&scene]() {
+        scene->setOrientation(Qt::Vertical);
+    });
 
-  QVBoxLayout * vbl = new QVBoxLayout;
-  vbl->addWidget(radio1);
-  vbl->addWidget(radio2);
-  vbl->addStretch();
-  groupBox->setLayout(vbl);
+    QObject::connect(radio2, &QRadioButton::clicked, [&scene]() {
+        scene->setOrientation(Qt::Horizontal);
+    });
 
-  QObject::connect(radio1,
-                   &QRadioButton::clicked,
-                   [&scene](){ scene->setOrientation(Qt::Vertical); });
+    radio1->setChecked(true);
 
-  QObject::connect(radio2,
-                   &QRadioButton::clicked,
-                   [&scene](){ scene->setOrientation(Qt::Horizontal); });
+    l->addWidget(groupBox);
 
-  radio1->setChecked(true);
+    // Setup context menu for creating new nodes.
+    view.setContextMenuPolicy(Qt::ActionsContextMenu);
+    QAction createNodeAction(QStringLiteral("Create Node"), &view);
+    QObject::connect(&createNodeAction, &QAction::triggered, [&]() {
+        // Mouse position in scene coordinates.
+        QPointF posView = view.mapToScene(view.mapFromGlobal(QCursor::pos()));
 
-  l->addWidget(groupBox);
+        NodeId const newId = graphModel.addNode();
+        graphModel.setNodeData(newId, NodeRole::Position, posView);
+    });
+    view.insertAction(view.actions().front(), &createNodeAction);
 
+    window.setWindowTitle("Graph Orientation Demo");
+    window.resize(800, 600);
 
+    // Center window.
+    window.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
+    window.showNormal();
 
-  // Setup context menu for creating new nodes.
-  view.setContextMenuPolicy(Qt::ActionsContextMenu);
-  QAction createNodeAction(QStringLiteral("Create Node"), &view);
-  QObject::connect(&createNodeAction, &QAction::triggered,
-                   [&]()
-                   {
-                     // Mouse position in scene coordinates.
-                     QPointF posView =
-                       view.mapToScene(view.mapFromGlobal(QCursor::pos()));
-
-
-                     NodeId const newId = graphModel.addNode();
-                     graphModel.setNodeData(newId,
-                                            NodeRole::Position,
-                                            posView);
-                   });
-  view.insertAction(view.actions().front(), &createNodeAction);
-
-
-  window.setWindowTitle("Graph Orientation Demo");
-  window.resize(800, 600);
-
-  // Center window.
-  window.move(QApplication::primaryScreen()->availableGeometry().center() - view.rect().center());
-  window.showNormal();
-
-  return app.exec();
+    return app.exec();
 }
-

--- a/include/QtNodes/internal/AbstractGraphModel.hpp
+++ b/include/QtNodes/internal/AbstractGraphModel.hpp
@@ -2,19 +2,17 @@
 
 #include "Export.hpp"
 
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 
+#include <QtCore/QJsonObject>
 #include <QtCore/QObject>
 #include <QtCore/QVariant>
-#include <QtCore/QJsonObject>
 
-#include "Definitions.hpp"
 #include "ConnectionIdHash.hpp"
+#include "Definitions.hpp"
 
-
-namespace QtNodes
-{
+namespace QtNodes {
 
 /**
  * The central class in the Model-View approach. It delivers all kinds
@@ -28,186 +26,142 @@ namespace QtNodes
  */
 class NODE_EDITOR_PUBLIC AbstractGraphModel : public QObject
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  /// Generates a new unique NodeId.
-  virtual NodeId newNodeId() = 0;
+    /// Generates a new unique NodeId.
+    virtual NodeId newNodeId() = 0;
 
-  /// @brief Returns the full set of unique Node Ids.
-  /**
+    /// @brief Returns the full set of unique Node Ids.
+    /**
    * Model creator is responsible for generating unique `unsigned int`
    * Ids for all the nodes in the graph. From an Id it should be
    * possible to trace back to the model's internal representation of
    * the node.
    */
-  virtual
-  std::unordered_set<NodeId>
-  allNodeIds() const = 0;
+    virtual std::unordered_set<NodeId> allNodeIds() const = 0;
 
-  /**
+    /**
    * A collection of all input and output connections for the given `nodeId`.
    */
-  virtual
-  std::unordered_set<ConnectionId>
-  allConnectionIds(NodeId const nodeId) const = 0;
+    virtual std::unordered_set<ConnectionId> allConnectionIds(NodeId const nodeId) const = 0;
 
-  /// @brief Returns all connected Node Ids for given port.
-  /**
+    /// @brief Returns all connected Node Ids for given port.
+    /**
    * The returned set of nodes and port indices correspond to the type
    * opposite to the given `portType`.
    */
-  virtual
-  std::unordered_set<ConnectionId>
-  connections(NodeId    nodeId,
-              PortType  portType,
-              PortIndex index) const = 0;
+    virtual std::unordered_set<ConnectionId> connections(NodeId nodeId,
+                                                         PortType portType,
+                                                         PortIndex index) const = 0;
 
+    /// Checks if two nodes with the given `connectionId` are connected.
+    virtual bool connectionExists(ConnectionId const connectionId) const = 0;
 
-  /// Checks if two nodes with the given `connectionId` are connected.
-  virtual
-  bool
-  connectionExists(ConnectionId const connectionId) const = 0;
-
-
-  /// Creates a new node instance in the derived class.
-  /**
+    /// Creates a new node instance in the derived class.
+    /**
    * The model is responsible for generating a unique `NodeId`.
    * @param[in] nodeType is free to be used and interpreted by the
    * model on its own, it helps to distinguish between possible node
    * types and create a correct instance inside.
    */
-  virtual
-  NodeId
-  addNode(QString const nodeType = QString()) = 0;
+    virtual NodeId addNode(QString const nodeType = QString()) = 0;
 
-  /// Model decides if a conection with a given connection Id possible.
-  /**
+    /// Model decides if a conection with a given connection Id possible.
+    /**
    * The default implementation compares corresponding data types.
    *
    * It is possible to override the function and connect non-equal
    * data types.
    */
-  virtual
-  bool
-  connectionPossible(ConnectionId const connectionId) const = 0;
+    virtual bool connectionPossible(ConnectionId const connectionId) const = 0;
 
-  /// Defines if detaching the connection is possible.
-  virtual
-  bool
-  detachPossible(ConnectionId const) const { return true; }
+    /// Defines if detaching the connection is possible.
+    virtual bool detachPossible(ConnectionId const) const { return true; }
 
-  /// Creates a new connection between two nodes.
-  /**
+    /// Creates a new connection between two nodes.
+    /**
    * Default implementation emits signal
    * `connectionCreated(connectionId)`
    *
    * In the derived classes user must emite the signal to notify the
    * scene about the changes.
    */
-  virtual
-  void
-  addConnection(ConnectionId const connectionId) = 0;
+    virtual void addConnection(ConnectionId const connectionId) = 0;
 
-  /**
+    /**
    * @returns `true` if there is data in the model associated with the
    * given `nodeId`.
    */
-  virtual
-  bool
-  nodeExists(NodeId const nodeId) const = 0;
+    virtual bool nodeExists(NodeId const nodeId) const = 0;
 
-
-  /// @brief Returns node-related data for requested NodeRole.
-  /**
+    /// @brief Returns node-related data for requested NodeRole.
+    /**
    * @returns Node Caption, Node Caption Visibility, Node Position etc.
    */
-  virtual
-  QVariant
-  nodeData(NodeId nodeId, NodeRole role) const = 0;
+    virtual QVariant nodeData(NodeId nodeId, NodeRole role) const = 0;
 
-  /**
+    /**
    * A utility function that unwraps the `QVariant` value returned from the
    * standard `QVariant AbstractGraphModel::nodeData(NodeId, NodeRole)` function.
    */
-  template<typename T>
-  T
-  nodeData(NodeId nodeId, NodeRole role) const
-  {
-    return nodeData(nodeId, role).value<T>();
-  }
+    template<typename T>
+    T nodeData(NodeId nodeId, NodeRole role) const
+    {
+        return nodeData(nodeId, role).value<T>();
+    }
 
-  virtual
-  NodeFlags
-  nodeFlags(NodeId nodeId) const
-  {
-    Q_UNUSED(nodeId);
-    return NodeFlag::NoFlags;
-  }
+    virtual NodeFlags nodeFlags(NodeId nodeId) const
+    {
+        Q_UNUSED(nodeId);
+        return NodeFlag::NoFlags;
+    }
 
-  /// @brief Sets node properties.
-  /**
+    /// @brief Sets node properties.
+    /**
    * Sets: Node Caption, Node Caption Visibility,
    * Shyle, State, Node Position etc.
    * @see NodeRole.
    */
-  virtual
-  bool
-  setNodeData(NodeId   nodeId,
-              NodeRole role,
-              QVariant value) = 0;
+    virtual bool setNodeData(NodeId nodeId, NodeRole role, QVariant value) = 0;
 
-  /// @brief Returns port-related data for requested NodeRole.
-  /**
+    /// @brief Returns port-related data for requested NodeRole.
+    /**
    * @returns Port Data Type, Port Data, Connection Policy, Port
    * Caption.
    */
-  virtual
-  QVariant
-  portData(NodeId    nodeId,
-           PortType  portType,
-           PortIndex index,
-           PortRole  role) const = 0;
+    virtual QVariant portData(NodeId nodeId,
+                              PortType portType,
+                              PortIndex index,
+                              PortRole role) const = 0;
 
-  /**
+    /**
    * A utility function that unwraps the `QVariant` value returned from the
    * standard `QVariant AbstractGraphModel::portData(...)` function.
    */
-  template<typename T>
-  T
-  portData(NodeId    nodeId,
-           PortType  portType,
-           PortIndex index,
-           PortRole  role) const 
-  {
-    return portData(nodeId, portType, index, role).value<T>();
-  }
+    template<typename T>
+    T portData(NodeId nodeId, PortType portType, PortIndex index, PortRole role) const
+    {
+        return portData(nodeId, portType, index, role).value<T>();
+    }
 
-  virtual
-  bool
-  setPortData(NodeId          nodeId,
-              PortType        portType,
-              PortIndex       index,
-              QVariant const& value,
-              PortRole        role = PortRole::Data
-              ) = 0;
+    virtual bool setPortData(NodeId nodeId,
+                             PortType portType,
+                             PortIndex index,
+                             QVariant const &value,
+                             PortRole role = PortRole::Data)
+        = 0;
 
-  virtual
-  bool
-  deleteConnection(ConnectionId const connectionId) = 0;
+    virtual bool deleteConnection(ConnectionId const connectionId) = 0;
 
-  virtual
-  bool
-  deleteNode(NodeId const nodeId) = 0;
+    virtual bool deleteNode(NodeId const nodeId) = 0;
 
-  /**
+    /**
    * Reimplement the function if you want to store/restore the node's
    * inner state during undo/redo node deletion operations.
    */
-  virtual
-  QJsonObject
-  saveNode(NodeId const) const { return {}; }
+    virtual QJsonObject saveNode(NodeId const) const { return {}; }
 
-  /**
+    /**
    * Reimplement the function if you want to support:
    *
    *   - graph save/restore operations,
@@ -229,12 +183,10 @@ public:
    * The function must do almost exacly the same thing as the normal addNode().
    * The main difference is in a model-specific `inner-data` processing.
    */
-  virtual
-  void
-  loadNode(QJsonObject const &) {}
+    virtual void loadNode(QJsonObject const &) {}
 
 public:
-  /**
+    /**
    * Function clears connections attached to the ports that are scheduled to be
    * deleted. It must be called right before the model removes its old port data.
    *
@@ -243,20 +195,18 @@ public:
    * @param first Index of the first port to be removed
    * @param last Index of the last port to be removed
    */
-  void
-  portsAboutToBeDeleted(NodeId const    nodeId,
-                        PortType const  portType,
-                        PortIndex const first,
-                        PortIndex const last);
+    void portsAboutToBeDeleted(NodeId const nodeId,
+                               PortType const portType,
+                               PortIndex const first,
+                               PortIndex const last);
 
-  /**
+    /**
    * Signal emitted when model no longer has the old data associated with the
    * given port indices and when the node must be repainted.
    */
-  void
-  portsDeleted();
+    void portsDeleted();
 
-  /**
+    /**
    * Signal emitted when model is about to create new ports on the given node.
    * @param first Is the first index of the new port after insertion.
    * @param last Is the last index of the new port after insertion.
@@ -265,46 +215,36 @@ public:
    * index. For such connections the new "post-insertion" addresses are computed
    * and stored until the function AbstractGraphModel::portsInserted is called.
    */
-  void
-  portsAboutToBeInserted(NodeId const    nodeId,
-                         PortType const  portType,
-                         PortIndex const first,
-                         PortIndex const last);
+    void portsAboutToBeInserted(NodeId const nodeId,
+                                PortType const portType,
+                                PortIndex const first,
+                                PortIndex const last);
 
-  /**
+    /**
    * Function re-creates the connections that were shifted during the port
    * insertion. After that the node is updated.
    */
-  void
-  portsInserted();
+    void portsInserted();
 
 Q_SIGNALS:
-  void
-  connectionCreated(ConnectionId const connectionId);
+    void connectionCreated(ConnectionId const connectionId);
 
-  void
-  connectionDeleted(ConnectionId const connectionId);
+    void connectionDeleted(ConnectionId const connectionId);
 
-  void
-  nodeCreated(NodeId const nodeId);
+    void nodeCreated(NodeId const nodeId);
 
-  void
-  nodeDeleted(NodeId const nodeId);
+    void nodeDeleted(NodeId const nodeId);
 
-  void
-  nodeUpdated(NodeId const nodeId);
+    void nodeUpdated(NodeId const nodeId);
 
-  void
-  nodeFlagsUpdated(NodeId const nodeId);
+    void nodeFlagsUpdated(NodeId const nodeId);
 
-  void
-  nodePositionUpdated(NodeId const nodeId);
+    void nodePositionUpdated(NodeId const nodeId);
 
-  void
-  modelReset();
+    void modelReset();
 
 private:
-  std::vector<ConnectionId> _shiftedByDynamicPortsConnections;
+    std::vector<ConnectionId> _shiftedByDynamicPortsConnections;
 };
 
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/AbstractNodeGeometry.hpp
+++ b/include/QtNodes/internal/AbstractNodeGeometry.hpp
@@ -1,24 +1,23 @@
 #pragma once
 
-#include "Export.hpp"
 #include "Definitions.hpp"
+#include "Export.hpp"
 
 #include <QRectF>
 #include <QSize>
 #include <QTransform>
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class AbstractGraphModel;
 
 class NODE_EDITOR_PUBLIC AbstractNodeGeometry
 {
 public:
-  AbstractNodeGeometry(AbstractGraphModel &);
-  virtual ~AbstractNodeGeometry() {}
+    AbstractNodeGeometry(AbstractGraphModel &);
+    virtual ~AbstractNodeGeometry() {}
 
-  /**
+    /**
    * The node's size plus some additional margin around it to account for drawing
    * effects (for example shadows) or node's parts outside the size rectangle
    * (for example port points).
@@ -26,70 +25,53 @@ public:
    * The default implementation returns QSize + 20 percent of width and heights
    * at each side of the rectangle.
    */
-  virtual QRectF boundingRect(NodeId const nodeId) const;
+    virtual QRectF boundingRect(NodeId const nodeId) const;
 
-  /// A direct rectangle defining the borders of the node's rectangle.
-  virtual QSize size(NodeId const nodeId) const = 0;
+    /// A direct rectangle defining the borders of the node's rectangle.
+    virtual QSize size(NodeId const nodeId) const = 0;
 
-  /**
+    /**
    * The function is triggeren when a nuber of ports is changed or when an
    * embedded widget needs an update.
    */
-  virtual void recomputeSize(NodeId const nodeId) const = 0;
+    virtual void recomputeSize(NodeId const nodeId) const = 0;
 
-  /// Port position in node's coordinate system.
-  virtual
-  QPointF
-  portPosition(NodeId const    nodeId,
-               PortType const  portType,
-               PortIndex const index) const = 0;
+    /// Port position in node's coordinate system.
+    virtual QPointF portPosition(NodeId const nodeId,
+                                 PortType const portType,
+                                 PortIndex const index) const = 0;
 
-  /// A convenience function using the `portPosition` and a given transformation.
-  virtual
-  QPointF
-  portScenePosition(NodeId const       nodeId,
-                    PortType const     portType,
-                    PortIndex const    index,
-                    QTransform const & t) const;
+    /// A convenience function using the `portPosition` and a given transformation.
+    virtual QPointF portScenePosition(NodeId const nodeId,
+                                      PortType const portType,
+                                      PortIndex const index,
+                                      QTransform const &t) const;
 
-  /// Defines where to draw port label. The point corresponds to a font baseline.
-  virtual
-  QPointF
-  portTextPosition(NodeId const   nodeId,
-                   PortType const portType,
-                   PortIndex const portIndex) const = 0;
+    /// Defines where to draw port label. The point corresponds to a font baseline.
+    virtual QPointF portTextPosition(NodeId const nodeId,
+                                     PortType const portType,
+                                     PortIndex const portIndex) const = 0;
 
-  /**
+    /**
    * Defines where to start drawing the caption. The point corresponds to a font
    * baseline.
    */
-  virtual
-  QPointF
-  captionPosition(NodeId const nodeId) const = 0;
+    virtual QPointF captionPosition(NodeId const nodeId) const = 0;
 
+    /// Caption rect is needed for estimating the total node size.
+    virtual QRectF captionRect(NodeId const nodeId) const = 0;
 
-  /// Caption rect is needed for estimating the total node size.
-  virtual
-  QRectF
-  captionRect(NodeId const nodeId) const = 0;
+    /// Position for an embedded widget. Return any value if you don't embed.
+    virtual QPointF widgetPosition(NodeId const nodeId) const = 0;
 
-  /// Position for an embedded widget. Return any value if you don't embed.
-  virtual
-  QPointF
-  widgetPosition(NodeId const nodeId) const = 0;
+    virtual PortIndex checkPortHit(NodeId const nodeId,
+                                   PortType const portType,
+                                   QPointF const nodePoint) const;
 
-  virtual
-  PortIndex
-  checkPortHit(NodeId const   nodeId,
-               PortType const portType,
-               QPointF const  nodePoint) const;
-
-  virtual
-  QRect
-  resizeHandleRect(NodeId const nodeId) const = 0;
+    virtual QRect resizeHandleRect(NodeId const nodeId) const = 0;
 
 protected:
-  AbstractGraphModel & _graphModel;
+    AbstractGraphModel &_graphModel;
 };
 
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/AbstractNodePainter.hpp
+++ b/include/QtNodes/internal/AbstractNodePainter.hpp
@@ -15,18 +15,15 @@ class NodeDataModel;
 class NODE_EDITOR_PUBLIC AbstractNodePainter
 {
 public:
-  virtual ~AbstractNodePainter() = default;
+    virtual ~AbstractNodePainter() = default;
 
-  /**
+    /**
    * Reimplement this function in order to have a custom painting.
    *
    * Useful functions:
    * `NodeGraphicsObject::nodeScene()->nodeGeometry()`
    * `NodeGraphicsObject::graphModel()`
    */
-  virtual
-  void
-  paint(QPainter* painter,
-        NodeGraphicsObject & ngo) const = 0;
+    virtual void paint(QPainter *painter, NodeGraphicsObject &ngo) const = 0;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/BasicGraphicsScene.hpp
+++ b/include/QtNodes/internal/BasicGraphicsScene.hpp
@@ -17,11 +17,9 @@
 
 #include "QUuidStdHash.hpp"
 
-
 class QUndoStack;
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class AbstractGraphModel;
 class AbstractNodePainter;
@@ -32,180 +30,145 @@ class NodeStyle;
 /// An instance of QGraphicsScene, holds connections and nodes.
 class NODE_EDITOR_PUBLIC BasicGraphicsScene : public QGraphicsScene
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  BasicGraphicsScene(AbstractGraphModel &graphModel,
-                     QObject *    parent = nullptr);
+    BasicGraphicsScene(AbstractGraphModel &graphModel, QObject *parent = nullptr);
 
-  // Scenes without models are not supported
-  BasicGraphicsScene() = delete;
+    // Scenes without models are not supported
+    BasicGraphicsScene() = delete;
 
-  ~BasicGraphicsScene();
-
-public:
-  /// @returns associated AbstractGraphModel.
-  AbstractGraphModel const &
-  graphModel() const;
-
-  AbstractGraphModel &
-  graphModel();
-
-  AbstractNodeGeometry &
-  nodeGeometry();
-
-  AbstractNodePainter &
-  nodePainter();
-
-  void setNodePainter(std::unique_ptr<AbstractNodePainter> newPainter);
-
-  QUndoStack& undoStack();
+    ~BasicGraphicsScene();
 
 public:
-  /// Creates a "draft" instance of ConnectionGraphicsObject.
-  /**
+    /// @returns associated AbstractGraphModel.
+    AbstractGraphModel const &graphModel() const;
+
+    AbstractGraphModel &graphModel();
+
+    AbstractNodeGeometry &nodeGeometry();
+
+    AbstractNodePainter &nodePainter();
+
+    void setNodePainter(std::unique_ptr<AbstractNodePainter> newPainter);
+
+    QUndoStack &undoStack();
+
+public:
+    /// Creates a "draft" instance of ConnectionGraphicsObject.
+    /**
    * The scene caches a "draft" connection which has one loose end.
    * After attachment the "draft" instance is deleted and instead a
    * normal "full" connection is created.
    * Function @returns the "draft" instance for further geometry
    * manipulations.
    */
-  std::unique_ptr<ConnectionGraphicsObject> const &
-  makeDraftConnection(ConnectionId const newConnectionId);
+    std::unique_ptr<ConnectionGraphicsObject> const &makeDraftConnection(
+        ConnectionId const newConnectionId);
 
-  /// Deletes "draft" connection.
-  /**
+    /// Deletes "draft" connection.
+    /**
    * The function is called when user releases the mouse button during
    * the construction of the new connection without attaching it to any
    * node.
    */
-  void
-  resetDraftConnection();
+    void resetDraftConnection();
 
-  /// Deletes all the nodes. Connections are removed automatically.
-  void
-  clearScene();
+    /// Deletes all the nodes. Connections are removed automatically.
+    void clearScene();
 
 public:
-  /// @returns NodeGraphicsObject associated with the given nodeId.
-  /**
+    /// @returns NodeGraphicsObject associated with the given nodeId.
+    /**
    * @returns nullptr when the object is not found.
    */
-  NodeGraphicsObject *
-  nodeGraphicsObject(NodeId nodeId);
+    NodeGraphicsObject *nodeGraphicsObject(NodeId nodeId);
 
-  /// @returns ConnectionGraphicsObject corresponding to `connectionId`.
-  /**
+    /// @returns ConnectionGraphicsObject corresponding to `connectionId`.
+    /**
    * @returns `nullptr` when the object is not found.
    */
-  ConnectionGraphicsObject *
-  connectionGraphicsObject(ConnectionId connectionId);
+    ConnectionGraphicsObject *connectionGraphicsObject(ConnectionId connectionId);
 
-  Qt::Orientation orientation() const { return _orientation; }
+    Qt::Orientation orientation() const { return _orientation; }
 
-  void setOrientation(Qt::Orientation const orientation);
+    void setOrientation(Qt::Orientation const orientation);
 
 public:
-  /// Can @return an instance of the scene context menu in subclass.
-  /**
+    /// Can @return an instance of the scene context menu in subclass.
+    /**
    * Default implementation returns `nullptr`.
    */
-  virtual
-  QMenu *
-  createSceneMenu(QPointF const scenePos);
+    virtual QMenu *createSceneMenu(QPointF const scenePos);
 
 Q_SIGNALS:
-  void
-  nodeMoved(NodeId const nodeId, QPointF const & newLocation);
+    void nodeMoved(NodeId const nodeId, QPointF const &newLocation);
 
-  void
-  nodeClicked(NodeId const nodeId);
+    void nodeClicked(NodeId const nodeId);
 
-  void
-  nodeSelected(NodeId const nodeId);
+    void nodeSelected(NodeId const nodeId);
 
-  void
-  nodeDoubleClicked(NodeId const nodeId);
+    void nodeDoubleClicked(NodeId const nodeId);
 
-  void
-  nodeHovered(NodeId const nodeId, QPoint const screenPos);
+    void nodeHovered(NodeId const nodeId, QPoint const screenPos);
 
-  void
-  nodeHoverLeft(NodeId const nodeId);
+    void nodeHoverLeft(NodeId const nodeId);
 
-  void
-  connectionHovered(ConnectionId const connectionId, QPoint const screenPos);
+    void connectionHovered(ConnectionId const connectionId, QPoint const screenPos);
 
-  void
-  connectionHoverLeft(ConnectionId const connectionId);
+    void connectionHoverLeft(ConnectionId const connectionId);
 
-  /// Signal allows showing custom context menu upon clicking a node.
-  void
-  nodeContextMenu(NodeId const nodeId, QPointF const pos);
+    /// Signal allows showing custom context menu upon clicking a node.
+    void nodeContextMenu(NodeId const nodeId, QPointF const pos);
 
 private:
-  /// @brief Creates Node and Connection graphics objects.
-  /**
+    /// @brief Creates Node and Connection graphics objects.
+    /**
    * Function is used to populate an empty scene in the constructor. We
    * perform depth-first AbstractGraphModel traversal. The connections are
    * created by checking non-empty node `Out` ports.
    */
-  void
-  traverseGraphAndPopulateGraphicsObjects();
+    void traverseGraphAndPopulateGraphicsObjects();
 
-  /// Redraws adjacent nodes for given `connectionId`
-  void
-  updateAttachedNodes(ConnectionId const connectionId,
-                      PortType const portType);
+    /// Redraws adjacent nodes for given `connectionId`
+    void updateAttachedNodes(ConnectionId const connectionId, PortType const portType);
 
 public Q_SLOTS:
-  /// Slot called when the `connectionId` is erased form the AbstractGraphModel.
-  void
-  onConnectionDeleted(ConnectionId const connectionId);
+    /// Slot called when the `connectionId` is erased form the AbstractGraphModel.
+    void onConnectionDeleted(ConnectionId const connectionId);
 
-  /// Slot called when the `connectionId` is created in the AbstractGraphModel.
-  void
-  onConnectionCreated(ConnectionId const connectionId);
+    /// Slot called when the `connectionId` is created in the AbstractGraphModel.
+    void onConnectionCreated(ConnectionId const connectionId);
 
-  void
-  onNodeDeleted(NodeId const nodeId);
+    void onNodeDeleted(NodeId const nodeId);
 
-  void
-  onNodeCreated(NodeId const nodeId);
+    void onNodeCreated(NodeId const nodeId);
 
-  void
-  onNodePositionUpdated(NodeId const nodeId);
+    void onNodePositionUpdated(NodeId const nodeId);
 
-  void
-  onNodeUpdated(NodeId const nodeId);
+    void onNodeUpdated(NodeId const nodeId);
 
-  void
-  onModelReset();
+    void onModelReset();
 
 private:
-  AbstractGraphModel &_graphModel;
+    AbstractGraphModel &_graphModel;
 
-  using UniqueNodeGraphicsObject = std::unique_ptr<NodeGraphicsObject>;
+    using UniqueNodeGraphicsObject = std::unique_ptr<NodeGraphicsObject>;
 
-  using UniqueConnectionGraphicsObject = std::unique_ptr<ConnectionGraphicsObject>;
+    using UniqueConnectionGraphicsObject = std::unique_ptr<ConnectionGraphicsObject>;
 
-  std::unordered_map<NodeId, UniqueNodeGraphicsObject>
-    _nodeGraphicsObjects;
+    std::unordered_map<NodeId, UniqueNodeGraphicsObject> _nodeGraphicsObjects;
 
-  std::unordered_map<ConnectionId,
-                     UniqueConnectionGraphicsObject>
-    _connectionGraphicsObjects;
+    std::unordered_map<ConnectionId, UniqueConnectionGraphicsObject> _connectionGraphicsObjects;
 
+    std::unique_ptr<ConnectionGraphicsObject> _draftConnection;
 
-  std::unique_ptr<ConnectionGraphicsObject> _draftConnection;
+    std::unique_ptr<AbstractNodeGeometry> _nodeGeometry;
 
-  std::unique_ptr<AbstractNodeGeometry> _nodeGeometry;
+    std::unique_ptr<AbstractNodePainter> _nodePainter;
 
-  std::unique_ptr<AbstractNodePainter> _nodePainter;
+    QUndoStack *_undoStack;
 
-  QUndoStack* _undoStack;
-
-  Qt::Orientation _orientation;
+    Qt::Orientation _orientation;
 };
 
-
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/Compiler.hpp
+++ b/include/QtNodes/internal/Compiler.hpp
@@ -1,53 +1,40 @@
 #pragma once
 
-#if                                                               \
-  defined (__MINGW32__)                                        || \
-  defined (__MINGW64__)
-#  define NODE_EDITOR_COMPILER "MinGW"
-#  define NODE_EDITOR_COMPILER_MINGW
-#elif \
-  defined (__clang__)
-#  define NODE_EDITOR_COMPILER "Clang"
-#  define NODE_EDITOR_COMPILER_CLANG
-#elif \
-  defined (_MSC_VER)
-#  define NODE_EDITOR_COMPILER "Microsoft Visual C++"
-#  define NODE_EDITOR_COMPILER_MICROSOFT
-#elif \
-  defined (__GNUC__)
-#  define NODE_EDITOR_COMPILER "GNU"
-#  define NODE_EDITOR_COMPILER_GNU
-#  define NODE_EDITOR_COMPILER_GNU_VERSION_MAJOR __GNUC__
-#  define NODE_EDITOR_COMPILER_GNU_VERSION_MINOR __GNUC_MINOR__
-#  define NODE_EDITOR_COMPILER_GNU_VERSION_PATCH __GNUC_PATCHLEVEL__
-#elif \
-  defined (__BORLANDC__)
-#  define NODE_EDITOR_COMPILER "Borland C++ Builder"
-#  define NODE_EDITOR_COMPILER_BORLAND
-#elif \
-  defined (__CODEGEARC__)
-#  define NODE_EDITOR_COMPILER "CodeGear C++ Builder"
-#  define NODE_EDITOR_COMPILER_CODEGEAR
-#elif                                                             \
-  defined (__INTEL_COMPILER)                                   || \
-  defined (__ICL)
-#  define NODE_EDITOR_COMPILER "Intel C++"
-#  define NODE_EDITOR_COMPILER_INTEL
-#elif                                                             \
-  defined (__xlC__)                                            || \
-  defined (__IBMCPP__)
-#  define NODE_EDITOR_COMPILER "IBM XL C++"
-#  define NODE_EDITOR_COMPILER_IBM
-#elif \
-  defined (__HP_aCC)
-#  define NODE_EDITOR_COMPILER "HP aC++"
-#  define NODE_EDITOR_COMPILER_HP
-#elif \
-  defined (__WATCOMC__)
-#  define NODE_EDITOR_COMPILER "Watcom C++"
-#  define NODE_EDITOR_COMPILER_WATCOM
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define NODE_EDITOR_COMPILER "MinGW"
+#define NODE_EDITOR_COMPILER_MINGW
+#elif defined(__clang__)
+#define NODE_EDITOR_COMPILER "Clang"
+#define NODE_EDITOR_COMPILER_CLANG
+#elif defined(_MSC_VER)
+#define NODE_EDITOR_COMPILER "Microsoft Visual C++"
+#define NODE_EDITOR_COMPILER_MICROSOFT
+#elif defined(__GNUC__)
+#define NODE_EDITOR_COMPILER "GNU"
+#define NODE_EDITOR_COMPILER_GNU
+#define NODE_EDITOR_COMPILER_GNU_VERSION_MAJOR __GNUC__
+#define NODE_EDITOR_COMPILER_GNU_VERSION_MINOR __GNUC_MINOR__
+#define NODE_EDITOR_COMPILER_GNU_VERSION_PATCH __GNUC_PATCHLEVEL__
+#elif defined(__BORLANDC__)
+#define NODE_EDITOR_COMPILER "Borland C++ Builder"
+#define NODE_EDITOR_COMPILER_BORLAND
+#elif defined(__CODEGEARC__)
+#define NODE_EDITOR_COMPILER "CodeGear C++ Builder"
+#define NODE_EDITOR_COMPILER_CODEGEAR
+#elif defined(__INTEL_COMPILER) || defined(__ICL)
+#define NODE_EDITOR_COMPILER "Intel C++"
+#define NODE_EDITOR_COMPILER_INTEL
+#elif defined(__xlC__) || defined(__IBMCPP__)
+#define NODE_EDITOR_COMPILER "IBM XL C++"
+#define NODE_EDITOR_COMPILER_IBM
+#elif defined(__HP_aCC)
+#define NODE_EDITOR_COMPILER "HP aC++"
+#define NODE_EDITOR_COMPILER_HP
+#elif defined(__WATCOMC__)
+#define NODE_EDITOR_COMPILER "Watcom C++"
+#define NODE_EDITOR_COMPILER_WATCOM
 #endif
 
 #ifndef NODE_EDITOR_COMPILER
-#  error "Current compiler is not supported."
+#error "Current compiler is not supported."
 #endif

--- a/include/QtNodes/internal/ConnectionGraphicsObject.hpp
+++ b/include/QtNodes/internal/ConnectionGraphicsObject.hpp
@@ -5,13 +5,12 @@
 #include <QtCore/QUuid>
 #include <QtWidgets/QGraphicsObject>
 
-#include "Definitions.hpp"
 #include "ConnectionState.hpp"
+#include "Definitions.hpp"
 
 class QGraphicsSceneMouseEvent;
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class AbstractGraphModel;
 class BasicGraphicsScene;
@@ -19,104 +18,79 @@ class BasicGraphicsScene;
 /// Graphic Object for connection. Adds itself to scene
 class ConnectionGraphicsObject : public QGraphicsObject
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  // Needed for qgraphicsitem_cast
-  enum { Type = UserType + 2 };
+    // Needed for qgraphicsitem_cast
+    enum { Type = UserType + 2 };
 
-  int
-  type() const override { return Type; }
-
-public:
-  ConnectionGraphicsObject(BasicGraphicsScene &scene,
-                           ConnectionId const  connectionId);
-
-  ~ConnectionGraphicsObject() = default;
+    int type() const override { return Type; }
 
 public:
-  AbstractGraphModel &
-  graphModel() const;
+    ConnectionGraphicsObject(BasicGraphicsScene &scene, ConnectionId const connectionId);
 
-  BasicGraphicsScene *
-  nodeScene() const;
+    ~ConnectionGraphicsObject() = default;
 
-  ConnectionId const &
-  connectionId() const;
+public:
+    AbstractGraphModel &graphModel() const;
 
-  QRectF
-  boundingRect() const override;
+    BasicGraphicsScene *nodeScene() const;
 
-  QPainterPath
-  shape() const override;
+    ConnectionId const &connectionId() const;
 
-  QPointF const &
-  endPoint(PortType portType) const;
+    QRectF boundingRect() const override;
 
-  QPointF
-  out() const { return _out; }
+    QPainterPath shape() const override;
 
-  QPointF
-  in() const { return _in; }
+    QPointF const &endPoint(PortType portType) const;
 
-  std::pair<QPointF, QPointF>
-  pointsC1C2() const;
+    QPointF out() const { return _out; }
 
-  void
-  setEndPoint(PortType portType, QPointF const &point);
+    QPointF in() const { return _in; }
 
-  /// Updates the position of both ends
-  void
-  move();
+    std::pair<QPointF, QPointF> pointsC1C2() const;
 
-  ConnectionState const &
-  connectionState() const;
+    void setEndPoint(PortType portType, QPointF const &point);
 
-  ConnectionState &
-  connectionState();
+    /// Updates the position of both ends
+    void move();
+
+    ConnectionState const &connectionState() const;
+
+    ConnectionState &connectionState();
 
 protected:
-  void
-  paint(QPainter * painter,
-        QStyleOptionGraphicsItem const * option,
-        QWidget *  widget = 0) override;
+    void paint(QPainter *painter,
+               QStyleOptionGraphicsItem const *option,
+               QWidget *widget = 0) override;
 
-  void
-  mousePressEvent(QGraphicsSceneMouseEvent * event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  mouseMoveEvent(QGraphicsSceneMouseEvent * event) override;
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  mouseReleaseEvent(QGraphicsSceneMouseEvent * event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  hoverEnterEvent(QGraphicsSceneHoverEvent * event) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
 
-  void
-  hoverLeaveEvent(QGraphicsSceneHoverEvent * event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
 private:
-  void
-  initializePosition();
+    void initializePosition();
 
-  void
-  addGraphicsEffect();
+    void addGraphicsEffect();
 
-  std::pair<QPointF, QPointF>
-  pointsC1C2Horizontal() const;
+    std::pair<QPointF, QPointF> pointsC1C2Horizontal() const;
 
-  std::pair<QPointF, QPointF>
-  pointsC1C2Vertical() const;
+    std::pair<QPointF, QPointF> pointsC1C2Vertical() const;
 
 private:
-  ConnectionId _connectionId;
+    ConnectionId _connectionId;
 
-  AbstractGraphModel &_graphModel;
+    AbstractGraphModel &_graphModel;
 
-  ConnectionState _connectionState;
+    ConnectionState _connectionState;
 
-  mutable QPointF _out;
-  mutable QPointF _in;
+    mutable QPointF _out;
+    mutable QPointF _in;
 };
 
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/ConnectionIdHash.hpp
+++ b/include/QtNodes/internal/ConnectionIdHash.hpp
@@ -4,76 +4,52 @@
 
 #include "Definitions.hpp"
 
-inline void hash_combine(std::size_t& seed) { Q_UNUSED(seed); }
-
-template <typename T, typename ... Rest>
-inline void
-hash_combine(std::size_t& seed, const T& v, Rest... rest)
+inline void hash_combine(std::size_t &seed)
 {
-  std::hash<T> hasher;
-  seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-  hash_combine(seed, rest ...);
+    Q_UNUSED(seed);
 }
 
-
-namespace std
+template<typename T, typename... Rest>
+inline void hash_combine(std::size_t &seed, const T &v, Rest... rest)
 {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    hash_combine(seed, rest...);
+}
+
+namespace std {
 template<>
 struct hash<QtNodes::ConnectionId>
 {
-  inline
-  std::size_t
-  operator()(QtNodes::ConnectionId const& id) const
-  {
-    std::size_t h = 0;
-    hash_combine(h,
-                 id.outNodeId,
-                 id.outPortIndex,
-                 id.inNodeId,
-                 id.inPortIndex);
-    return h;
-  }
-
+    inline std::size_t operator()(QtNodes::ConnectionId const &id) const
+    {
+        std::size_t h = 0;
+        hash_combine(h, id.outNodeId, id.outPortIndex, id.inNodeId, id.inPortIndex);
+        return h;
+    }
 };
-
 
 template<>
 struct hash<std::pair<QtNodes::NodeId, QtNodes::PortIndex>>
 {
-  inline
-  std::size_t
-  operator()(std::pair<QtNodes::NodeId, QtNodes::PortIndex> const & nodePort) const
-  {
-    std::size_t h = 0;
-    hash_combine(h,
-                 nodePort.first,
-                 nodePort.second);
-    return h;
-  }
-
+    inline std::size_t operator()(std::pair<QtNodes::NodeId, QtNodes::PortIndex> const &nodePort) const
+    {
+        std::size_t h = 0;
+        hash_combine(h, nodePort.first, nodePort.second);
+        return h;
+    }
 };
 
 template<>
-struct hash<std::tuple<QtNodes::NodeId,
-                       QtNodes::PortType,
-                       QtNodes::PortIndex>>
+struct hash<std::tuple<QtNodes::NodeId, QtNodes::PortType, QtNodes::PortIndex>>
 {
-  using Key = std::tuple<QtNodes::NodeId,
-                         QtNodes::PortType,
-                         QtNodes::PortIndex>;
+    using Key = std::tuple<QtNodes::NodeId, QtNodes::PortType, QtNodes::PortIndex>;
 
-  inline
-  std::size_t
-  operator()(Key const &key) const
-  {
-    std::size_t h = 0;
-    hash_combine(h,
-                 std::get<0>(key),
-                 std::get<1>(key),
-                 std::get<2>(key));
-    return h;
-  }
-
+    inline std::size_t operator()(Key const &key) const
+    {
+        std::size_t h = 0;
+        hash_combine(h, std::get<0>(key), std::get<1>(key), std::get<2>(key));
+        return h;
+    }
 };
-}
-
+} // namespace std

--- a/include/QtNodes/internal/ConnectionIdUtils.hpp
+++ b/include/QtNodes/internal/ConnectionIdUtils.hpp
@@ -7,193 +7,145 @@
 #include <iostream>
 #include <string>
 
-namespace QtNodes
+namespace QtNodes {
+
+inline PortIndex getNodeId(PortType portType, ConnectionId connectionId)
 {
+    NodeId id = InvalidNodeId;
 
-inline
-PortIndex
-getNodeId(PortType portType, ConnectionId connectionId)
-{
-  NodeId id = InvalidNodeId;
+    if (portType == PortType::Out) {
+        id = connectionId.outNodeId;
+    } else if (portType == PortType::In) {
+        id = connectionId.inNodeId;
+    }
 
-  if (portType == PortType::Out)
-  {
-    id = connectionId.outNodeId;
-  }
-  else if (portType == PortType::In)
-  {
-    id = connectionId.inNodeId;
-  }
-
-  return id;
+    return id;
 }
 
-
-inline
-PortIndex
-getPortIndex(PortType portType, ConnectionId connectionId)
+inline PortIndex getPortIndex(PortType portType, ConnectionId connectionId)
 {
-  PortIndex index = InvalidPortIndex;
+    PortIndex index = InvalidPortIndex;
 
-  if (portType == PortType::Out)
-  {
-    index = connectionId.outPortIndex;
-  }
-  else if (portType == PortType::In)
-  {
-    index = connectionId.inPortIndex;
-  }
+    if (portType == PortType::Out) {
+        index = connectionId.outPortIndex;
+    } else if (portType == PortType::In) {
+        index = connectionId.inPortIndex;
+    }
 
-  return index;
+    return index;
 }
 
-
-inline
-PortType
-oppositePort(PortType port)
+inline PortType oppositePort(PortType port)
 {
-  PortType result = PortType::None;
+    PortType result = PortType::None;
 
-  switch (port)
-  {
+    switch (port) {
     case PortType::In:
-      result = PortType::Out;
-      break;
+        result = PortType::Out;
+        break;
 
     case PortType::Out:
-      result = PortType::In;
-      break;
+        result = PortType::In;
+        break;
 
     case PortType::None:
-      result = PortType::None;
-      break;
+        result = PortType::None;
+        break;
 
     default:
-      break;
-  }
-  return result;
+        break;
+    }
+    return result;
 }
 
-
-inline
-bool
-isPortIndexValid(PortIndex index)
+inline bool isPortIndexValid(PortIndex index)
 {
-  return index != InvalidPortIndex;
+    return index != InvalidPortIndex;
 }
 
-
-inline
-bool
-isPortTypeValid(PortType portType)
+inline bool isPortTypeValid(PortType portType)
 {
-  return portType != PortType::None;
+    return portType != PortType::None;
 }
-
 
 /**
  * Creates a connection Id instance filled just on one side.
  */
-inline
-ConnectionId
-makeIncompleteConnectionId(NodeId const    connectedNodeId,
-                           PortType const  connectedPort,
-                           PortIndex const connectedPortIndex)
+inline ConnectionId makeIncompleteConnectionId(NodeId const connectedNodeId,
+                                               PortType const connectedPort,
+                                               PortIndex const connectedPortIndex)
 {
-  return (connectedPort == PortType::In) ?
-         ConnectionId{InvalidNodeId, InvalidPortIndex,
-                      connectedNodeId, connectedPortIndex} :
-         ConnectionId{connectedNodeId, connectedPortIndex,
-                      InvalidNodeId, InvalidPortIndex};
+    return (connectedPort == PortType::In)
+               ? ConnectionId{InvalidNodeId, InvalidPortIndex, connectedNodeId, connectedPortIndex}
+               : ConnectionId{connectedNodeId, connectedPortIndex, InvalidNodeId, InvalidPortIndex};
 }
 
 /**
  * Turns a full connection Id into an incomplete one by removing the
  * data on the given side
  */
-inline
-ConnectionId
-makeIncompleteConnectionId(ConnectionId   connectionId,
-                           PortType const portToDisconnect)
+inline ConnectionId makeIncompleteConnectionId(ConnectionId connectionId,
+                                               PortType const portToDisconnect)
 {
-  if (portToDisconnect == PortType::Out)
-  {
-    connectionId.outNodeId = InvalidNodeId;
-    connectionId.outPortIndex = InvalidPortIndex;
-  }
-  else
-  {
-    connectionId.inNodeId = InvalidNodeId;
-    connectionId.inPortIndex = InvalidPortIndex;
-  }
+    if (portToDisconnect == PortType::Out) {
+        connectionId.outNodeId = InvalidNodeId;
+        connectionId.outPortIndex = InvalidPortIndex;
+    } else {
+        connectionId.inNodeId = InvalidNodeId;
+        connectionId.inPortIndex = InvalidPortIndex;
+    }
 
-  return connectionId;
+    return connectionId;
 }
 
-
-inline
-ConnectionId
-makeCompleteConnectionId(ConnectionId    incompleteConnectionId,
-                         NodeId const    nodeId,
-                         PortIndex const portIndex)
+inline ConnectionId makeCompleteConnectionId(ConnectionId incompleteConnectionId,
+                                             NodeId const nodeId,
+                                             PortIndex const portIndex)
 {
-  if (incompleteConnectionId.outNodeId == InvalidNodeId)
-  {
-    incompleteConnectionId.outNodeId = nodeId;
-    incompleteConnectionId.outPortIndex = portIndex;
-  }
-  else
-  {
-    incompleteConnectionId.inNodeId = nodeId;
-    incompleteConnectionId.inPortIndex = portIndex;
-  }
+    if (incompleteConnectionId.outNodeId == InvalidNodeId) {
+        incompleteConnectionId.outNodeId = nodeId;
+        incompleteConnectionId.outPortIndex = portIndex;
+    } else {
+        incompleteConnectionId.inNodeId = nodeId;
+        incompleteConnectionId.inPortIndex = portIndex;
+    }
 
-  return incompleteConnectionId;
+    return incompleteConnectionId;
 }
 
-
-
-
-inline
-std::ostream &
-operator<<(std::ostream & ostr, ConnectionId const connectionId)
+inline std::ostream &operator<<(std::ostream &ostr, ConnectionId const connectionId)
 {
-  ostr << "(" << connectionId.outNodeId
-       << ", " << (isPortIndexValid(connectionId.outPortIndex) ?  std::to_string(connectionId.outPortIndex) : "INVALID")
-       << ", " << connectionId.inNodeId
-       << ", " << (isPortIndexValid(connectionId.inPortIndex) ?  std::to_string(connectionId.inPortIndex) : "INVALID")
-       << ")" << std::endl;
+    ostr << "(" << connectionId.outNodeId << ", "
+         << (isPortIndexValid(connectionId.outPortIndex) ? std::to_string(connectionId.outPortIndex)
+                                                         : "INVALID")
+         << ", " << connectionId.inNodeId << ", "
+         << (isPortIndexValid(connectionId.inPortIndex) ? std::to_string(connectionId.inPortIndex)
+                                                        : "INVALID")
+         << ")" << std::endl;
 
-  return ostr;
+    return ostr;
 }
 
-
-inline
-QJsonObject
-toJson(ConnectionId const & connId)
+inline QJsonObject toJson(ConnectionId const &connId)
 {
-  QJsonObject connJson;
+    QJsonObject connJson;
 
-  connJson["outNodeId"] = static_cast<qint64>(connId.outNodeId);
-  connJson["outPortIndex"] = static_cast<qint64>(connId.outPortIndex);
-  connJson["intNodeId"] = static_cast<qint64>(connId.inNodeId);
-  connJson["inPortIndex"] = static_cast<qint64>(connId.inPortIndex);
+    connJson["outNodeId"] = static_cast<qint64>(connId.outNodeId);
+    connJson["outPortIndex"] = static_cast<qint64>(connId.outPortIndex);
+    connJson["intNodeId"] = static_cast<qint64>(connId.inNodeId);
+    connJson["inPortIndex"] = static_cast<qint64>(connId.inPortIndex);
 
-  return connJson;
+    return connJson;
 }
 
-
-inline
-ConnectionId
-fromJson(QJsonObject const & connJson)
+inline ConnectionId fromJson(QJsonObject const &connJson)
 {
-  ConnectionId connId{static_cast<NodeId>(connJson["outNodeId"].toInt(InvalidNodeId)),
-                      static_cast<PortIndex>(connJson["outPortIndex"].toInt(InvalidPortIndex)),
-                      static_cast<NodeId>(connJson["intNodeId"].toInt(InvalidNodeId)),
-                      static_cast<PortIndex>(connJson["inPortIndex"].toInt(InvalidPortIndex))};
+    ConnectionId connId{static_cast<NodeId>(connJson["outNodeId"].toInt(InvalidNodeId)),
+                        static_cast<PortIndex>(connJson["outPortIndex"].toInt(InvalidPortIndex)),
+                        static_cast<NodeId>(connJson["intNodeId"].toInt(InvalidNodeId)),
+                        static_cast<PortIndex>(connJson["inPortIndex"].toInt(InvalidPortIndex))};
 
-  return connId;
+    return connId;
 }
 
-
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/ConnectionState.hpp
+++ b/include/QtNodes/internal/ConnectionState.hpp
@@ -8,8 +8,7 @@
 
 class QPointF;
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class ConnectionGraphicsObject;
 
@@ -18,62 +17,44 @@ class ConnectionGraphicsObject;
 class NODE_EDITOR_PUBLIC ConnectionState
 {
 public:
-
-  /// Defines whether we construct a new connection
-  /// or it is already binding two nodes.
-  enum LooseEnd
-  {
-    Pending   = 0,
-    Connected = 1
-  };
+    /// Defines whether we construct a new connection
+    /// or it is already binding two nodes.
+    enum LooseEnd { Pending = 0, Connected = 1 };
 
 public:
+    ConnectionState(ConnectionGraphicsObject &cgo)
+        : _cgo(cgo)
+        , _hovered(false)
+    {}
 
-  ConnectionState(ConnectionGraphicsObject & cgo)
-    : _cgo(cgo)
-    , _hovered(false)
-  {}
+    ConnectionState(ConnectionState const &) = delete;
+    ConnectionState(ConnectionState &&) = delete;
 
-  ConnectionState(ConnectionState const&) = delete;
-  ConnectionState(ConnectionState &&) = delete;
+    ConnectionState &operator=(ConnectionState const &) = delete;
+    ConnectionState &operator=(ConnectionState &&) = delete;
 
-  ConnectionState&
-  operator=(ConnectionState const&) = delete;
-  ConnectionState&
-  operator=(ConnectionState &&) = delete;
-
-  ~ConnectionState();
+    ~ConnectionState();
 
 public:
+    PortType requiredPort() const;
+    bool requiresPort() const;
 
-  PortType
-  requiredPort() const;
-  bool
-  requiresPort() const;
-
-  bool
-  hovered() const;
-  void
-  setHovered(bool hovered);
+    bool hovered() const;
+    void setHovered(bool hovered);
 
 public:
+    /// Caches NodeId for further interaction.
+    void setLastHoveredNode(NodeId const nodeId);
 
-  /// Caches NodeId for further interaction.
-  void
-  setLastHoveredNode(NodeId const nodeId);
+    NodeId lastHoveredNode() const;
 
-  NodeId
-  lastHoveredNode() const;
-
-  void
-  resetLastHoveredNode();
+    void resetLastHoveredNode();
 
 private:
-  ConnectionGraphicsObject & _cgo;
+    ConnectionGraphicsObject &_cgo;
 
-  bool _hovered;
+    bool _hovered;
 
-  NodeId _lastHoveredNode{InvalidNodeId};
-
+    NodeId _lastHoveredNode{InvalidNodeId};
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/ConnectionStyle.hpp
+++ b/include/QtNodes/internal/ConnectionStyle.hpp
@@ -5,56 +5,50 @@
 #include "Export.hpp"
 #include "Style.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class NODE_EDITOR_PUBLIC ConnectionStyle : public Style
 {
 public:
+    ConnectionStyle();
 
-  ConnectionStyle();
+    ConnectionStyle(QString jsonText);
 
-  ConnectionStyle(QString jsonText);
-
-  ~ConnectionStyle() = default;
-
-public:
-
-  static void setConnectionStyle(QString jsonText);
+    ~ConnectionStyle() = default;
 
 public:
-
-  void loadJson(QJsonObject const & json) override;
-
-  QJsonObject toJson() const override;
+    static void setConnectionStyle(QString jsonText);
 
 public:
+    void loadJson(QJsonObject const &json) override;
 
-  QColor constructionColor() const;
-  QColor normalColor() const;
-  QColor normalColor(QString typeId) const;
-  QColor selectedColor() const;
-  QColor selectedHaloColor() const;
-  QColor hoveredColor() const;
+    QJsonObject toJson() const override;
 
-  float lineWidth() const;
-  float constructionLineWidth() const;
-  float pointDiameter() const;
+public:
+    QColor constructionColor() const;
+    QColor normalColor() const;
+    QColor normalColor(QString typeId) const;
+    QColor selectedColor() const;
+    QColor selectedHaloColor() const;
+    QColor hoveredColor() const;
 
-  bool useDataDefinedColors() const;
+    float lineWidth() const;
+    float constructionLineWidth() const;
+    float pointDiameter() const;
+
+    bool useDataDefinedColors() const;
 
 private:
+    QColor ConstructionColor;
+    QColor NormalColor;
+    QColor SelectedColor;
+    QColor SelectedHaloColor;
+    QColor HoveredColor;
 
-  QColor ConstructionColor;
-  QColor NormalColor;
-  QColor SelectedColor;
-  QColor SelectedHaloColor;
-  QColor HoveredColor;
+    float LineWidth;
+    float ConstructionLineWidth;
+    float PointDiameter;
 
-  float LineWidth;
-  float ConstructionLineWidth;
-  float PointDiameter;
-
-  bool UseDataDefinedColors;
+    bool UseDataDefinedColors;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/DataFlowGraphModel.hpp
+++ b/include/QtNodes/internal/DataFlowGraphModel.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "AbstractGraphModel.hpp"
 #include "ConnectionIdUtils.hpp"
 #include "NodeDelegateModelRegistry.hpp"
-#include "AbstractGraphModel.hpp"
-#include "StyleCollection.hpp"
 #include "Serializable.hpp"
+#include "StyleCollection.hpp"
 
 #include "Export.hpp"
 
@@ -12,126 +12,96 @@
 
 #include <memory>
 
-namespace QtNodes
+namespace QtNodes {
+
+class NODE_EDITOR_PUBLIC DataFlowGraphModel : public AbstractGraphModel, public Serializable
 {
-
-class NODE_EDITOR_PUBLIC DataFlowGraphModel
-  : public AbstractGraphModel
-  , public Serializable
-{
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  struct NodeGeometryData
-  {
-    QSize size;
-    QPointF pos;
-  };
+    struct NodeGeometryData
+    {
+        QSize size;
+        QPointF pos;
+    };
 
 public:
-  DataFlowGraphModel(std::shared_ptr<NodeDelegateModelRegistry> registry);
+    DataFlowGraphModel(std::shared_ptr<NodeDelegateModelRegistry> registry);
 
-  std::shared_ptr<NodeDelegateModelRegistry>
-  dataModelRegistry() { return _registry; }
+    std::shared_ptr<NodeDelegateModelRegistry> dataModelRegistry() { return _registry; }
 
 public:
-  std::unordered_set<NodeId>
-  allNodeIds() const override;
+    std::unordered_set<NodeId> allNodeIds() const override;
 
-  std::unordered_set<ConnectionId>
-  allConnectionIds(NodeId const nodeId) const override;
+    std::unordered_set<ConnectionId> allConnectionIds(NodeId const nodeId) const override;
 
-  std::unordered_set<ConnectionId>
-  connections(NodeId    nodeId,
-              PortType  portType,
-              PortIndex portIndex) const override;
+    std::unordered_set<ConnectionId> connections(NodeId nodeId,
+                                                 PortType portType,
+                                                 PortIndex portIndex) const override;
 
-  bool
-  connectionExists(ConnectionId const connectionId) const override;
+    bool connectionExists(ConnectionId const connectionId) const override;
 
-  NodeId
-  addNode(QString const nodeType) override;
+    NodeId addNode(QString const nodeType) override;
 
-  bool
-  connectionPossible(ConnectionId const connectionId) const override;
+    bool connectionPossible(ConnectionId const connectionId) const override;
 
-  void
-  addConnection(ConnectionId const connectionId) override;
+    void addConnection(ConnectionId const connectionId) override;
 
-  bool
-  nodeExists(NodeId const nodeId) const override;
+    bool nodeExists(NodeId const nodeId) const override;
 
-  QVariant
-  nodeData(NodeId nodeId, NodeRole role) const override;
+    QVariant nodeData(NodeId nodeId, NodeRole role) const override;
 
+    NodeFlags nodeFlags(NodeId nodeId) const override;
 
-  NodeFlags
-  nodeFlags(NodeId nodeId) const override;
+    bool setNodeData(NodeId nodeId, NodeRole role, QVariant value) override;
 
-  bool
-  setNodeData(NodeId   nodeId,
-              NodeRole role,
-              QVariant value) override;
+    QVariant portData(NodeId nodeId,
+                      PortType portType,
+                      PortIndex portIndex,
+                      PortRole role) const override;
 
-  QVariant
-  portData(NodeId    nodeId,
-           PortType  portType,
-           PortIndex portIndex,
-           PortRole  role) const override;
+    bool setPortData(NodeId nodeId,
+                     PortType portType,
+                     PortIndex portIndex,
+                     QVariant const &value,
+                     PortRole role = PortRole::Data) override;
 
-  bool
-  setPortData(NodeId          nodeId,
-              PortType        portType,
-              PortIndex       portIndex,
-              QVariant const& value,
-              PortRole        role = PortRole::Data) override;
+    bool deleteConnection(ConnectionId const connectionId) override;
 
-  bool
-  deleteConnection(ConnectionId const connectionId) override;
+    bool deleteNode(NodeId const nodeId) override;
 
-  bool
-  deleteNode(NodeId const nodeId) override;
+    QJsonObject saveNode(NodeId const) const override;
 
-  QJsonObject
-  saveNode(NodeId const) const override;
+    QJsonObject save() const override;
 
-  QJsonObject
-  save() const override;
+    void loadNode(QJsonObject const &nodeJson) override;
 
-  void
-  loadNode(QJsonObject const & nodeJson) override;
+    void load(QJsonObject const &json) override;
 
-  void
-  load(QJsonObject const &json) override;
-
-  /**
+    /**
    * Fetches the NodeDelegateModel for the given `nodeId` and tries to cast the
    * stored pointer to the given type
    */
-  template<typename NodeDelegateModelType>
-  NodeDelegateModelType*
-  delegateModel(NodeId const nodeId)
-  {
-    auto it = _models.find(nodeId);
-    if (it == _models.end())
-      return nullptr;
+    template<typename NodeDelegateModelType>
+    NodeDelegateModelType *delegateModel(NodeId const nodeId)
+    {
+        auto it = _models.find(nodeId);
+        if (it == _models.end())
+            return nullptr;
 
-    auto model = dynamic_cast<NodeDelegateModelType*>(it->second.get());
+        auto model = dynamic_cast<NodeDelegateModelType *>(it->second.get());
 
-    return model;
-  }
+        return model;
+    }
 
 Q_SIGNALS:
-  void
-  inPortDataWasSet(NodeId const,
-                   PortType const,
-                   PortIndex const);
+    void inPortDataWasSet(NodeId const, PortType const, PortIndex const);
 
 private:
-  NodeId newNodeId() override { return _nextNodeId++; }
+    NodeId newNodeId() override { return _nextNodeId++; }
 
 private Q_SLOTS:
-  /**
+    /**
    * Fuction is called in three cases:
    *
    * - By underlying NodeDelegateModel when a node has new data to propagate.
@@ -141,30 +111,21 @@ private Q_SLOTS:
    * - When a node restored from JSON an needs to send data downstream.
    *   @see DataFlowGraphModel::loadNode
    */
-  void
-  onOutPortDataUpdated(NodeId const    nodeId,
-                       PortIndex const portIndex);
+    void onOutPortDataUpdated(NodeId const nodeId, PortIndex const portIndex);
 
-
-  /// Function is called after detaching a connection.
-  void
-  propagateEmptyDataTo(NodeId const    nodeId,
-                       PortIndex const portIndex);
+    /// Function is called after detaching a connection.
+    void propagateEmptyDataTo(NodeId const nodeId, PortIndex const portIndex);
 
 private:
-  std::shared_ptr<NodeDelegateModelRegistry> _registry;
+    std::shared_ptr<NodeDelegateModelRegistry> _registry;
 
-  NodeId _nextNodeId;
+    NodeId _nextNodeId;
 
-  std::unordered_map<NodeId,
-                     std::unique_ptr<NodeDelegateModel>>
-  _models;
+    std::unordered_map<NodeId, std::unique_ptr<NodeDelegateModel>> _models;
 
-  std::unordered_set<ConnectionId> _connectivity;
+    std::unordered_set<ConnectionId> _connectivity;
 
-  mutable std::unordered_map<NodeId, NodeGeometryData>
-  _nodeGeometryData;
+    mutable std::unordered_map<NodeId, NodeGeometryData> _nodeGeometryData;
 };
 
-
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/DataFlowGraphicsScene.hpp
+++ b/include/QtNodes/internal/DataFlowGraphicsScene.hpp
@@ -4,49 +4,37 @@
 #include "DataFlowGraphModel.hpp"
 #include "Export.hpp"
 
-
-namespace QtNodes
-{
-
+namespace QtNodes {
 
 /// @brief An advanced scene working with data-propagating graphs.
 /**
  * The class represents a scene that existed in v2.x but built wit the
  * new model-view approach in mind.
  */
-class NODE_EDITOR_PUBLIC DataFlowGraphicsScene
-  : public BasicGraphicsScene
+class NODE_EDITOR_PUBLIC DataFlowGraphicsScene : public BasicGraphicsScene
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
+    DataFlowGraphicsScene(DataFlowGraphModel &graphModel, QObject *parent = nullptr);
 
-  DataFlowGraphicsScene(DataFlowGraphModel &graphModel,
-                        QObject * parent = nullptr);
-
-  ~DataFlowGraphicsScene() = default;
+    ~DataFlowGraphicsScene() = default;
 
 public:
-  std::vector<NodeId>
-  selectedNodes() const;
+    std::vector<NodeId> selectedNodes() const;
 
 public:
-  QMenu *
-  createSceneMenu(QPointF const scenePos) override;
-
+    QMenu *createSceneMenu(QPointF const scenePos) override;
 
 public Q_SLOTS:
-  void
-  save() const;
+    void save() const;
 
-  void
-  load();
+    void load();
 
 Q_SIGNALS:
-  void
-  sceneLoaded();
+    void sceneLoaded();
 
 private:
-  DataFlowGraphModel &_graphModel;
+    DataFlowGraphModel &_graphModel;
 };
 
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/DefaultNodePainter.hpp
+++ b/include/QtNodes/internal/DefaultNodePainter.hpp
@@ -2,11 +2,10 @@
 
 #include <QtGui/QPainter>
 
-#include "Definitions.hpp"
 #include "AbstractNodePainter.hpp"
+#include "Definitions.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class BasicGraphicsScene;
 class GraphModel;
@@ -18,25 +17,18 @@ class NodeState;
 class NODE_EDITOR_PUBLIC DefaultNodePainter : public AbstractNodePainter
 {
 public:
-  void paint(QPainter * painter,
-             NodeGraphicsObject  & ngo) const override;
+    void paint(QPainter *painter, NodeGraphicsObject &ngo) const override;
 
-  void drawNodeRect(QPainter * painter,
-                    NodeGraphicsObject  & ngo) const;
+    void drawNodeRect(QPainter *painter, NodeGraphicsObject &ngo) const;
 
-  void drawConnectionPoints(QPainter * painter,
-                            NodeGraphicsObject  & ngo) const;
+    void drawConnectionPoints(QPainter *painter, NodeGraphicsObject &ngo) const;
 
-  void drawFilledConnectionPoints(QPainter * painter,
-                                  NodeGraphicsObject  & ngo) const;
+    void drawFilledConnectionPoints(QPainter *painter, NodeGraphicsObject &ngo) const;
 
-  void drawNodeCaption(QPainter * painter,
-                       NodeGraphicsObject  & ngo) const;
+    void drawNodeCaption(QPainter *painter, NodeGraphicsObject &ngo) const;
 
-  void drawEntryLabels(QPainter * painter,
-                       NodeGraphicsObject  & ngo) const;
+    void drawEntryLabels(QPainter *painter, NodeGraphicsObject &ngo) const;
 
-  void drawResizeRect(QPainter * painter,
-                      NodeGraphicsObject  & ngo) const;
+    void drawResizeRect(QPainter *painter, NodeGraphicsObject &ngo) const;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/Definitions.hpp
+++ b/include/QtNodes/internal/Definitions.hpp
@@ -11,95 +11,82 @@
  * Important definitions used throughout the library.
  */
 
-namespace QtNodes
-{
+namespace QtNodes {
 Q_NAMESPACE_EXPORT(NODE_EDITOR_PUBLIC)
 
 /**
  * Constants used for fetching QVariant data from GraphModel.
  */
-enum class NodeRole
-{
-  Type             = 0, ///< Type of the current node, usually a string.
-  Position         = 1, ///< `QPointF` positon of the node on the scene.
-  Size             = 2, ///< `QSize` for resizable nodes.
-  CaptionVisible   = 3, ///< `bool` for caption visibility.
-  Caption          = 4, ///< `QString` for node caption.
-  Style            = 5, ///< Custom NodeStyle as QJsonDocument
-  InternalData     = 6, ///< Node-stecific user data as QJsonObject
-  InPortCount      = 7, ///< `unsigned int`
-  OutPortCount     = 9, ///< `unsigned int`
-  Widget           = 10, ///< Optional `QWidget*` or `nullptr`
+enum class NodeRole {
+    Type = 0,           ///< Type of the current node, usually a string.
+    Position = 1,       ///< `QPointF` positon of the node on the scene.
+    Size = 2,           ///< `QSize` for resizable nodes.
+    CaptionVisible = 3, ///< `bool` for caption visibility.
+    Caption = 4,        ///< `QString` for node caption.
+    Style = 5,          ///< Custom NodeStyle as QJsonDocument
+    InternalData = 6,   ///< Node-stecific user data as QJsonObject
+    InPortCount = 7,    ///< `unsigned int`
+    OutPortCount = 9,   ///< `unsigned int`
+    Widget = 10,        ///< Optional `QWidget*` or `nullptr`
 };
 Q_ENUM_NS(NodeRole)
-
 
 /**
  * Specific flags regulating node features and appeaarence.
  */
-enum NodeFlag
-{
-  NoFlags   = 0x0, ///< Default NodeFlag
-  Resizable = 0x1, ///< Lets the node be resizable
-  Locked    = 0x2
+enum NodeFlag {
+    NoFlags = 0x0,   ///< Default NodeFlag
+    Resizable = 0x1, ///< Lets the node be resizable
+    Locked = 0x2
 };
 
 Q_DECLARE_FLAGS(NodeFlags, NodeFlag)
 Q_FLAG_NS(NodeFlags)
 Q_DECLARE_OPERATORS_FOR_FLAGS(NodeFlags)
 
-
 /**
  * Constants for fetching port-related information from the GraphModel.
  */
-enum class PortRole
-{
-  Data                 = 0, ///< `std::shared_ptr<NodeData>`.
-  DataType             = 1, ///< `QString` describing the port data type.
-  ConnectionPolicyRole = 2, ///< `enum` ConnectionPolicyRole
-  CaptionVisible       = 3, ///< `bool` for caption visibility.
-  Caption              = 4, ///< `QString` for port caption.
+enum class PortRole {
+    Data = 0,                 ///< `std::shared_ptr<NodeData>`.
+    DataType = 1,             ///< `QString` describing the port data type.
+    ConnectionPolicyRole = 2, ///< `enum` ConnectionPolicyRole
+    CaptionVisible = 3,       ///< `bool` for caption visibility.
+    Caption = 4,              ///< `QString` for port caption.
 };
 Q_ENUM_NS(PortRole)
-
 
 /**
  * Defines how many connections are possible to attach to ports. The
  * values are fetched using PortRole::ConnectionPolicy.
  */
-enum class ConnectionPolicy
-{
-  One, ///< Just one connection for each port.
-  Many, ///< Any number of connections possible for the port.
+enum class ConnectionPolicy {
+    One,  ///< Just one connection for each port.
+    Many, ///< Any number of connections possible for the port.
 };
 Q_ENUM_NS(ConnectionPolicy)
-
 
 /**
  * Used for distinguishing input and output node ports.
  */
-enum class PortType
-{
-  In   = 0, ///< Input node port (from the left).
-  Out  = 1, ///< Output node port (from the right).
-  None = 2
+enum class PortType {
+    In = 0,  ///< Input node port (from the left).
+    Out = 1, ///< Output node port (from the right).
+    None = 2
 };
 Q_ENUM_NS(PortType)
-
 
 using PortCount = unsigned int;
 
 /// ports are consecutively numbered starting from zero.
 using PortIndex = unsigned int;
 
-static constexpr PortIndex InvalidPortIndex =
-  std::numeric_limits<PortIndex>::max();
+static constexpr PortIndex InvalidPortIndex = std::numeric_limits<PortIndex>::max();
 
 /// Unique Id associated with each node in the GraphModel.
 using NodeId = unsigned int;
 
-static constexpr NodeId InvalidNodeId =
-  std::numeric_limits<NodeId>::max();
+static constexpr NodeId InvalidNodeId = std::numeric_limits<NodeId>::max();
 
 /**
  * A unique connection identificator that stores
@@ -107,32 +94,27 @@ static constexpr NodeId InvalidNodeId =
  */
 struct ConnectionId
 {
-  NodeId outNodeId;
-  PortIndex outPortIndex;
-  NodeId inNodeId;
-  PortIndex inPortIndex;
+    NodeId outNodeId;
+    PortIndex outPortIndex;
+    NodeId inNodeId;
+    PortIndex inPortIndex;
 };
 
-
-inline bool operator==(ConnectionId const& a, ConnectionId const& b)
+inline bool operator==(ConnectionId const &a, ConnectionId const &b)
 {
-  return a.outNodeId == b.outNodeId &&
-         a.outPortIndex == b.outPortIndex &&
-         a.inNodeId == b.inNodeId &&
-         a.inPortIndex == b.inPortIndex;
+    return a.outNodeId == b.outNodeId && a.outPortIndex == b.outPortIndex
+           && a.inNodeId == b.inNodeId && a.inPortIndex == b.inPortIndex;
 }
 
-inline bool operator!=(ConnectionId const& a, ConnectionId const& b)
+inline bool operator!=(ConnectionId const &a, ConnectionId const &b)
 {
-  return !(a == b);
+    return !(a == b);
 }
 
-
-inline void invertConnection(ConnectionId& id)
+inline void invertConnection(ConnectionId &id)
 {
-  std::swap(id.outNodeId, id.inNodeId);
-  std::swap(id.outPortIndex, id.inPortIndex);
+    std::swap(id.outNodeId, id.inNodeId);
+    std::swap(id.outPortIndex, id.inPortIndex);
 }
 
-
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/Export.hpp
+++ b/include/QtNodes/internal/Export.hpp
@@ -4,48 +4,45 @@
 #include "OperatingSystem.hpp"
 
 #ifdef NODE_EDITOR_PLATFORM_WINDOWS
-#  define NODE_EDITOR_EXPORT __declspec(dllexport)
-#  define NODE_EDITOR_IMPORT __declspec(dllimport)
-#  define NODE_EDITOR_LOCAL
-#elif                                                           \
-  NODE_EDITOR_COMPILER_GNU_VERSION_MAJOR >= 4                         || \
-  defined (NODE_EDITOR_COMPILER_CLANG)
-#  define NODE_EDITOR_EXPORT __attribute__((visibility("default")))
-#  define NODE_EDITOR_IMPORT __attribute__((visibility("default")))
-#  define NODE_EDITOR_LOCAL  __attribute__((visibility("hidden")))
+#define NODE_EDITOR_EXPORT __declspec(dllexport)
+#define NODE_EDITOR_IMPORT __declspec(dllimport)
+#define NODE_EDITOR_LOCAL
+#elif NODE_EDITOR_COMPILER_GNU_VERSION_MAJOR >= 4 || defined(NODE_EDITOR_COMPILER_CLANG)
+#define NODE_EDITOR_EXPORT __attribute__((visibility("default")))
+#define NODE_EDITOR_IMPORT __attribute__((visibility("default")))
+#define NODE_EDITOR_LOCAL __attribute__((visibility("hidden")))
 #else
-#  define NODE_EDITOR_EXPORT
-#  define NODE_EDITOR_IMPORT
-#  define NODE_EDITOR_LOCAL
+#define NODE_EDITOR_EXPORT
+#define NODE_EDITOR_IMPORT
+#define NODE_EDITOR_LOCAL
 #endif
 
 #ifdef __cplusplus
-#  define NODE_EDITOR_DEMANGLED extern "C"
+#define NODE_EDITOR_DEMANGLED extern "C"
 #else
-#  define NODE_EDITOR_DEMANGLED
+#define NODE_EDITOR_DEMANGLED
 #endif
 
-
-#if defined (NODE_EDITOR_SHARED) && !defined (NODE_EDITOR_STATIC)
-#  ifdef NODE_EDITOR_EXPORTS
-#    define NODE_EDITOR_PUBLIC NODE_EDITOR_EXPORT
-#  else
-#    define NODE_EDITOR_PUBLIC NODE_EDITOR_IMPORT
-#  endif
-#  define NODE_EDITOR_PRIVATE NODE_EDITOR_LOCAL
-#elif !defined (NODE_EDITOR_SHARED) && defined (NODE_EDITOR_STATIC)
-#  define NODE_EDITOR_PUBLIC
-#  define NODE_EDITOR_PRIVATE
-#elif defined (NODE_EDITOR_SHARED) && defined (NODE_EDITOR_STATIC)
-#  ifdef NODE_EDITOR_EXPORTS
-#    error "Cannot build as shared and static simultaneously."
-#  else
-#    error "Cannot link against shared and static simultaneously."
-#  endif
+#if defined(NODE_EDITOR_SHARED) && !defined(NODE_EDITOR_STATIC)
+#ifdef NODE_EDITOR_EXPORTS
+#define NODE_EDITOR_PUBLIC NODE_EDITOR_EXPORT
 #else
-#  ifdef NODE_EDITOR_EXPORTS
-#    error "Choose whether to build as shared or static."
-#  else
-#    error "Choose whether to link against shared or static."
-#  endif
+#define NODE_EDITOR_PUBLIC NODE_EDITOR_IMPORT
+#endif
+#define NODE_EDITOR_PRIVATE NODE_EDITOR_LOCAL
+#elif !defined(NODE_EDITOR_SHARED) && defined(NODE_EDITOR_STATIC)
+#define NODE_EDITOR_PUBLIC
+#define NODE_EDITOR_PRIVATE
+#elif defined(NODE_EDITOR_SHARED) && defined(NODE_EDITOR_STATIC)
+#ifdef NODE_EDITOR_EXPORTS
+#error "Cannot build as shared and static simultaneously."
+#else
+#error "Cannot link against shared and static simultaneously."
+#endif
+#else
+#ifdef NODE_EDITOR_EXPORTS
+#error "Choose whether to build as shared or static."
+#else
+#error "Choose whether to link against shared or static."
+#endif
 #endif

--- a/include/QtNodes/internal/GraphicsView.hpp
+++ b/include/QtNodes/internal/GraphicsView.hpp
@@ -4,111 +4,85 @@
 
 #include "Export.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class BasicGraphicsScene;
-
 
 /**
  * @brief A central view able to render objects from `BasicGraphicsScene`.
  */
-class NODE_EDITOR_PUBLIC GraphicsView
-  : public QGraphicsView
+class NODE_EDITOR_PUBLIC GraphicsView : public QGraphicsView
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  struct ScaleRange
-  {
-    double minimum = 0;
-    double maximum = 0;
-  };
+    struct ScaleRange
+    {
+        double minimum = 0;
+        double maximum = 0;
+    };
 
 public:
-  GraphicsView(QWidget* parent = Q_NULLPTR);
-  GraphicsView(BasicGraphicsScene* scene, QWidget* parent = Q_NULLPTR);
+    GraphicsView(QWidget *parent = Q_NULLPTR);
+    GraphicsView(BasicGraphicsScene *scene, QWidget *parent = Q_NULLPTR);
 
-  GraphicsView(const GraphicsView &) = delete;
-  GraphicsView
-  operator=(const GraphicsView &) = delete;
+    GraphicsView(const GraphicsView &) = delete;
+    GraphicsView operator=(const GraphicsView &) = delete;
 
-  QAction*
-  clearSelectionAction() const;
+    QAction *clearSelectionAction() const;
 
-  QAction*
-  deleteSelectionAction() const;
+    QAction *deleteSelectionAction() const;
 
-  void
-  setScene(BasicGraphicsScene* scene);
+    void setScene(BasicGraphicsScene *scene);
 
-  void
-  centerScene();
+    void centerScene();
 
-  /// @brief max=0/min=0 indicates infinite zoom in/out
-  void
-  setScaleRange(double minimum = 0, double maximum = 0);
+    /// @brief max=0/min=0 indicates infinite zoom in/out
+    void setScaleRange(double minimum = 0, double maximum = 0);
 
-  void
-  setScaleRange(ScaleRange range);
+    void setScaleRange(ScaleRange range);
 
-  double
-  getScale() const;
+    double getScale() const;
 
 public Q_SLOTS:
-  void
-  scaleUp();
+    void scaleUp();
 
-  void
-  scaleDown();
+    void scaleDown();
 
-  void
-  setupScale(double scale);
+    void setupScale(double scale);
 
-  void
-  onDeleteSelectedObjects();
+    void onDeleteSelectedObjects();
 
-  void
-  onDuplicateSelectedObjects();
+    void onDuplicateSelectedObjects();
 
 Q_SIGNALS:
-  void
-  scaleChanged(double scale);
+    void scaleChanged(double scale);
 
 protected:
-  void
-  contextMenuEvent(QContextMenuEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent *event) override;
 
-  void
-  wheelEvent(QWheelEvent* event) override;
+    void wheelEvent(QWheelEvent *event) override;
 
-  void
-  keyPressEvent(QKeyEvent* event) override;
+    void keyPressEvent(QKeyEvent *event) override;
 
-  void
-  keyReleaseEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
 
-  void
-  mousePressEvent(QMouseEvent* event) override;
+    void mousePressEvent(QMouseEvent *event) override;
 
-  void
-  mouseMoveEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
-  void
-  drawBackground(QPainter* painter, const QRectF & r) override;
+    void drawBackground(QPainter *painter, const QRectF &r) override;
 
-  void
-  showEvent(QShowEvent* event) override;
+    void showEvent(QShowEvent *event) override;
 
 protected:
-  BasicGraphicsScene*
-  nodeScene();
+    BasicGraphicsScene *nodeScene();
 
 private:
-  QAction* _clearSelectionAction = nullptr;
-  QAction* _deleteSelectionAction = nullptr;
-  QAction* _duplicateSelectionAction = nullptr;
+    QAction *_clearSelectionAction = nullptr;
+    QAction *_deleteSelectionAction = nullptr;
+    QAction *_duplicateSelectionAction = nullptr;
 
-  QPointF _clickPos;
-  ScaleRange _scaleRange;
+    QPointF _clickPos;
+    ScaleRange _scaleRange;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/GraphicsViewStyle.hpp
+++ b/include/QtNodes/internal/GraphicsViewStyle.hpp
@@ -5,33 +5,28 @@
 #include "Export.hpp"
 #include "Style.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class NODE_EDITOR_PUBLIC GraphicsViewStyle : public Style
 {
 public:
+    GraphicsViewStyle();
 
-  GraphicsViewStyle();
+    GraphicsViewStyle(QString jsonText);
 
-  GraphicsViewStyle(QString jsonText);
-
-  ~GraphicsViewStyle() = default;
+    ~GraphicsViewStyle() = default;
 
 public:
-
-  static void setStyle(QString jsonText);
+    static void setStyle(QString jsonText);
 
 private:
+    void loadJson(QJsonObject const &json) override;
 
-  void loadJson(QJsonObject const & json) override;
-
-  QJsonObject toJson() const override;
+    QJsonObject toJson() const override;
 
 public:
-
-  QColor BackgroundColor;
-  QColor FineGridColor;
-  QColor CoarseGridColor;
+    QColor BackgroundColor;
+    QColor FineGridColor;
+    QColor CoarseGridColor;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/NodeData.hpp
+++ b/include/QtNodes/internal/NodeData.hpp
@@ -7,8 +7,7 @@
 
 #include "Export.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 /**
  * `id` represents an internal unique data type for the given port.
@@ -16,8 +15,8 @@ namespace QtNodes
  */
 struct NODE_EDITOR_PUBLIC NodeDataType
 {
-  QString id;
-  QString name;
+    QString id;
+    QString name;
 };
 
 /**
@@ -28,21 +27,17 @@ struct NODE_EDITOR_PUBLIC NodeDataType
 class NODE_EDITOR_PUBLIC NodeData
 {
 public:
+    virtual ~NodeData() = default;
 
-  virtual
-  ~NodeData() = default;
+    virtual bool sameType(NodeData const &nodeData) const
+    {
+        return (this->type().id == nodeData.type().id);
+    }
 
-  virtual bool
-  sameType(NodeData const &nodeData) const
-  {
-    return (this->type().id == nodeData.type().id);
-  }
-
-  /// Type for inner use
-  virtual NodeDataType
-  type() const = 0;
+    /// Type for inner use
+    virtual NodeDataType type() const = 0;
 };
 
-}
+} // namespace QtNodes
 Q_DECLARE_METATYPE(QtNodes::NodeDataType)
 Q_DECLARE_METATYPE(std::shared_ptr<QtNodes::NodeData>)

--- a/include/QtNodes/internal/NodeDelegateModel.hpp
+++ b/include/QtNodes/internal/NodeDelegateModel.hpp
@@ -10,8 +10,7 @@
 #include "NodeStyle.hpp"
 #include "Serializable.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class StyleCollection;
 
@@ -21,80 +20,53 @@ class StyleCollection;
  * AbstractGrapModel.
  * This class is the same what has been called NodeDataModel before v3.
  */
-class NODE_EDITOR_PUBLIC NodeDelegateModel
-  : public QObject
-  , public Serializable
+class NODE_EDITOR_PUBLIC NodeDelegateModel : public QObject, public Serializable
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  NodeDelegateModel();
+    NodeDelegateModel();
 
-  virtual
-  ~NodeDelegateModel() = default;
+    virtual ~NodeDelegateModel() = default;
 
-  /// It is possible to hide caption in GUI
-  virtual
-  bool
-  captionVisible() const { return true; }
+    /// It is possible to hide caption in GUI
+    virtual bool captionVisible() const { return true; }
 
-  /// Caption is used in GUI
-  virtual
-  QString
-  caption() const = 0;
+    /// Caption is used in GUI
+    virtual QString caption() const = 0;
 
-  /// It is possible to hide port caption in GUI
-  virtual
-  bool
-  portCaptionVisible(PortType, PortIndex) const { return false; }
+    /// It is possible to hide port caption in GUI
+    virtual bool portCaptionVisible(PortType, PortIndex) const { return false; }
 
-  /// Port caption is used in GUI to label individual ports
-  virtual
-  QString
-  portCaption(PortType, PortIndex) const { return QString(); }
+    /// Port caption is used in GUI to label individual ports
+    virtual QString portCaption(PortType, PortIndex) const { return QString(); }
 
-  /// Name makes this model unique
-  virtual
-  QString
-  name() const = 0;
+    /// Name makes this model unique
+    virtual QString name() const = 0;
 
 public:
-  QJsonObject
-  save() const override;
+    QJsonObject save() const override;
 
-  void
-  load(QJsonObject const &) override;
+    void load(QJsonObject const &) override;
 
 public:
-  virtual
-  unsigned int
-  nPorts(PortType portType) const = 0;
+    virtual unsigned int nPorts(PortType portType) const = 0;
 
-  virtual
-  NodeDataType
-  dataType(PortType portType, PortIndex portIndex) const = 0;
+    virtual NodeDataType dataType(PortType portType, PortIndex portIndex) const = 0;
 
 public:
-  virtual
-  ConnectionPolicy
-  portConnectionPolicy(PortType, PortIndex) const;
+    virtual ConnectionPolicy portConnectionPolicy(PortType, PortIndex) const;
 
-  NodeStyle const &
-  nodeStyle() const;
+    NodeStyle const &nodeStyle() const;
 
-  void
-  setNodeStyle(NodeStyle const & style);
+    void setNodeStyle(NodeStyle const &style);
 
 public:
-  virtual
-  void
-  setInData(std::shared_ptr<NodeData> nodeData, PortIndex const portIndex) = 0;
+    virtual void setInData(std::shared_ptr<NodeData> nodeData, PortIndex const portIndex) = 0;
 
-  virtual
-  std::shared_ptr<NodeData>
-  outData(PortIndex const port) = 0;
+    virtual std::shared_ptr<NodeData> outData(PortIndex const port) = 0;
 
-  /**
+    /**
    * It is recommented to preform a lazy initialization for the
    * embedded widget and create it inside this function, not in the
    * constructor of the current model.
@@ -104,81 +76,58 @@ public:
    * allocated in the constructor but not actually embedded into some
    * QGraphicsProxyWidget, we'll gonna have a dangling pointer.
    */
-  virtual
-  QWidget *
-  embeddedWidget() = 0;
+    virtual QWidget *embeddedWidget() = 0;
 
-  virtual
-  bool
-  resizable() const { return false; }
+    virtual bool resizable() const { return false; }
 
 public Q_SLOTS:
 
-  virtual
-  void
-  inputConnectionCreated(ConnectionId const &) {}
+    virtual void inputConnectionCreated(ConnectionId const &) {}
 
-  virtual
-  void
-  inputConnectionDeleted(ConnectionId const &) {}
+    virtual void inputConnectionDeleted(ConnectionId const &) {}
 
-  virtual
-  void
-  outputConnectionCreated(ConnectionId const &) {}
+    virtual void outputConnectionCreated(ConnectionId const &) {}
 
-  virtual
-  void
-  outputConnectionDeleted(ConnectionId const &) {}
+    virtual void outputConnectionDeleted(ConnectionId const &) {}
 
 Q_SIGNALS:
 
-  /// Triggers the updates in the nodes downstream.
-  void
-  dataUpdated(PortIndex const index);
+    /// Triggers the updates in the nodes downstream.
+    void dataUpdated(PortIndex const index);
 
-  /// Triggers the propagation of the empty data downstream.
-  void
-  dataInvalidated(PortIndex const index);
+    /// Triggers the propagation of the empty data downstream.
+    void dataInvalidated(PortIndex const index);
 
-  void
-  computingStarted();
+    void computingStarted();
 
-  void
-  computingFinished();
+    void computingFinished();
 
-  void
-  embeddedWidgetSizeUpdated();
+    void embeddedWidgetSizeUpdated();
 
-  /// Call this function before deleting the data associated with ports.
-  /**
+    /// Call this function before deleting the data associated with ports.
+    /**
    * The function notifies the Graph Model and makes it remove and recompute the
    * affected connection addresses.
    */
-  void
-  portsAboutToBeDeleted(PortType const  portType,
-                        PortIndex const first,
-                        PortIndex const last);
+    void portsAboutToBeDeleted(PortType const portType, PortIndex const first, PortIndex const last);
 
-  /// Call this function when data and port moditications are finished.
-  void
-  portsDeleted();
+    /// Call this function when data and port moditications are finished.
+    void portsDeleted();
 
-  /// Call this function before inserting the data associated with ports.
-  /**
+    /// Call this function before inserting the data associated with ports.
+    /**
    * The function notifies the Graph Model and makes it recompute the affected
    * connection addresses.
    */
-  void
-  portsAboutToBeInserted(PortType const  portType,
-                         PortIndex const first,
-                         PortIndex const last);
+    void portsAboutToBeInserted(PortType const portType,
+                                PortIndex const first,
+                                PortIndex const last);
 
-  /// Call this function when data and port moditications are finished.
-  void
-  portsInserted();
+    /// Call this function when data and port moditications are finished.
+    void portsInserted();
 
 private:
-  NodeStyle _nodeStyle;
+    NodeStyle _nodeStyle;
 };
 
 } // namespace QtNodes

--- a/include/QtNodes/internal/NodeDelegateModelRegistry.hpp
+++ b/include/QtNodes/internal/NodeDelegateModelRegistry.hpp
@@ -15,62 +15,48 @@
 #include <utility>
 #include <vector>
 
-
-namespace QtNodes
-{
-
+namespace QtNodes {
 
 /// Class uses map for storing models (name, model)
 class NODE_EDITOR_PUBLIC NodeDelegateModelRegistry
 {
+public:
+    using RegistryItemPtr = std::unique_ptr<NodeDelegateModel>;
+    using RegistryItemCreator = std::function<RegistryItemPtr()>;
+    using RegisteredModelCreatorsMap = std::unordered_map<QString, RegistryItemCreator>;
+    using RegisteredModelsCategoryMap = std::unordered_map<QString, QString>;
+    using CategoriesSet = std::set<QString>;
+
+    //using RegisteredTypeConvertersMap = std::map<TypeConverterId, TypeConverter>;
+
+    NodeDelegateModelRegistry() = default;
+    ~NodeDelegateModelRegistry() = default;
+
+    NodeDelegateModelRegistry(NodeDelegateModelRegistry const &) = delete;
+    NodeDelegateModelRegistry(NodeDelegateModelRegistry &&) = default;
+
+    NodeDelegateModelRegistry &operator=(NodeDelegateModelRegistry const &) = delete;
+
+    NodeDelegateModelRegistry &operator=(NodeDelegateModelRegistry &&) = default;
 
 public:
-
-  using RegistryItemPtr = std::unique_ptr<NodeDelegateModel>;
-  using RegistryItemCreator = std::function<RegistryItemPtr ()>;
-  using RegisteredModelCreatorsMap = std::unordered_map<QString, RegistryItemCreator>;
-  using RegisteredModelsCategoryMap = std::unordered_map<QString, QString>;
-  using CategoriesSet = std::set<QString>;
-
-  //using RegisteredTypeConvertersMap = std::map<TypeConverterId, TypeConverter>;
-
-  NodeDelegateModelRegistry() = default;
-  ~NodeDelegateModelRegistry() = default;
-
-  NodeDelegateModelRegistry(NodeDelegateModelRegistry const&) = delete;
-  NodeDelegateModelRegistry(NodeDelegateModelRegistry&&) = default;
-
-  NodeDelegateModelRegistry &
-  operator=(NodeDelegateModelRegistry const&) = delete;
-
-  NodeDelegateModelRegistry &
-  operator=(NodeDelegateModelRegistry&&) = default;
-
-public:
-
-  template<typename ModelType>
-  void
-  registerModel(RegistryItemCreator creator,
-                QString const&      category = "Nodes")
-  {
-    QString const name = computeName<ModelType>(HasStaticMethodName<ModelType>{}, creator);
-    if (!_registeredItemCreators.count(name))
+    template<typename ModelType>
+    void registerModel(RegistryItemCreator creator, QString const &category = "Nodes")
     {
-      _registeredItemCreators[name] = std::move(creator);
-      _categories.insert(category);
-      _registeredModelsCategory[name] = category;
+        QString const name = computeName<ModelType>(HasStaticMethodName<ModelType>{}, creator);
+        if (!_registeredItemCreators.count(name)) {
+            _registeredItemCreators[name] = std::move(creator);
+            _categories.insert(category);
+            _registeredModelsCategory[name] = category;
+        }
     }
-  }
 
-
-  template<typename ModelType>
-  void
-  registerModel(QString const& category = "Nodes")
-  {
-    RegistryItemCreator creator = [](){ return std::make_unique<ModelType>(); };
-    registerModel<ModelType>(std::move(creator), category);
-  }
-
+    template<typename ModelType>
+    void registerModel(QString const &category = "Nodes")
+    {
+        RegistryItemCreator creator = []() { return std::make_unique<ModelType>(); };
+        registerModel<ModelType>(std::move(creator), category);
+    }
 
 #if 0
   template<typename ModelType>
@@ -106,21 +92,15 @@ public:
     _registeredTypeConverters[id] = std::move(typeConverter);
   }
 
-
 #endif
 
+    std::unique_ptr<NodeDelegateModel> create(QString const &modelName);
 
-  std::unique_ptr<NodeDelegateModel>
-  create(QString const& modelName);
+    RegisteredModelCreatorsMap const &registeredModelCreators() const;
 
-  RegisteredModelCreatorsMap const &
-  registeredModelCreators() const;
+    RegisteredModelsCategoryMap const &registeredModelsCategoryAssociation() const;
 
-  RegisteredModelsCategoryMap const &
-  registeredModelsCategoryAssociation() const;
-
-  CategoriesSet const &
-  categories() const;
+    CategoriesSet const &categories() const;
 
 #if 0
   TypeConverter
@@ -129,70 +109,63 @@ public:
 #endif
 
 private:
+    RegisteredModelsCategoryMap _registeredModelsCategory;
 
-  RegisteredModelsCategoryMap _registeredModelsCategory;
+    CategoriesSet _categories;
 
-  CategoriesSet _categories;
-
-  RegisteredModelCreatorsMap _registeredItemCreators;
+    RegisteredModelCreatorsMap _registeredItemCreators;
 
 #if 0
   RegisteredTypeConvertersMap _registeredTypeConverters;
 #endif
 
 private:
+    // If the registered ModelType class has the static member method
+    // `static QString Name();`, use it. Otherwise use the non-static
+    // method: `virtual QString name() const;`
+    template<typename T, typename = void>
+    struct HasStaticMethodName : std::false_type
+    {};
 
-  // If the registered ModelType class has the static member method
-  // `static QString Name();`, use it. Otherwise use the non-static
-  // method: `virtual QString name() const;`
-  template<typename T, typename = void>
-  struct HasStaticMethodName
-    : std::false_type
-  {};
+    template<typename T>
+    struct HasStaticMethodName<
+        T,
+        typename std::enable_if<std::is_same<decltype(T::Name()), QString>::value>::type>
+        : std::true_type
+    {};
 
-  template <typename T>
-  struct HasStaticMethodName<T, typename std::enable_if<std::is_same<decltype(T::Name()),
-                                                                     QString>::value>::type>
-    : std::true_type
-  {};
+    template<typename ModelType>
+    static QString computeName(std::true_type, RegistryItemCreator const &)
+    {
+        return ModelType::Name();
+    }
 
-  template <typename ModelType>
-  static QString
-  computeName(std::true_type, RegistryItemCreator const&)
-  {
-    return ModelType::Name();
-  }
+    template<typename ModelType>
+    static QString computeName(std::false_type, RegistryItemCreator const &creator)
+    {
+        return creator()->name();
+    }
 
+    template<typename T>
+    struct UnwrapUniquePtr
+    {
+        // Assert always fires, but the compiler doesn't know this:
+        static_assert(!std::is_same<T, T>::value,
+                      "The ModelCreator must return a std::unique_ptr<T>, where T "
+                      "inherits from NodeDelegateModel");
+    };
 
-  template <typename ModelType>
-  static QString
-  computeName(std::false_type, RegistryItemCreator const& creator)
-  {
-    return creator()->name();
-  }
+    template<typename T>
+    struct UnwrapUniquePtr<std::unique_ptr<T>>
+    {
+        static_assert(std::is_base_of<NodeDelegateModel, T>::value,
+                      "The ModelCreator must return a std::unique_ptr<T>, where T "
+                      "inherits from NodeDelegateModel");
+        using type = T;
+    };
 
-
-  template <typename T>
-  struct UnwrapUniquePtr
-  {
-    // Assert always fires, but the compiler doesn't know this:
-    static_assert(!std::is_same<T, T>::value,
-                  "The ModelCreator must return a std::unique_ptr<T>, where T "
-                  "inherits from NodeDelegateModel");
-  };
-
-  template <typename T>
-  struct UnwrapUniquePtr<std::unique_ptr<T> >
-  {
-    static_assert(std::is_base_of<NodeDelegateModel, T>::value,
-                  "The ModelCreator must return a std::unique_ptr<T>, where T "
-                  "inherits from NodeDelegateModel");
-    using type = T;
-  };
-
-  template <typename CreatorResult>
-  using compute_model_type_t = typename UnwrapUniquePtr<CreatorResult>::type;
+    template<typename CreatorResult>
+    using compute_model_type_t = typename UnwrapUniquePtr<CreatorResult>::type;
 };
 
-
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/NodeGraphicsObject.hpp
+++ b/include/QtNodes/internal/NodeGraphicsObject.hpp
@@ -7,110 +7,85 @@
 
 class QGraphicsProxyWidget;
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class BasicGraphicsScene;
 class AbstractGraphModel;
 
 class NodeGraphicsObject : public QGraphicsObject
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  // Needed for qgraphicsitem_cast
-  enum { Type = UserType + 1 };
+    // Needed for qgraphicsitem_cast
+    enum { Type = UserType + 1 };
 
-  int
-  type() const override { return Type; }
-
-public:
-  NodeGraphicsObject(BasicGraphicsScene &scene,
-                     NodeId node);
-
-  ~NodeGraphicsObject() override = default;
+    int type() const override { return Type; }
 
 public:
-  AbstractGraphModel &
-  graphModel() const;
+    NodeGraphicsObject(BasicGraphicsScene &scene, NodeId node);
 
-  BasicGraphicsScene *
-  nodeScene() const;
+    ~NodeGraphicsObject() override = default;
 
-  NodeId
-  nodeId() { return _nodeId; }
+public:
+    AbstractGraphModel &graphModel() const;
 
-  NodeId
-  nodeId() const { return _nodeId; }
+    BasicGraphicsScene *nodeScene() const;
 
-  NodeState &
-  nodeState() { return _nodeState; }
+    NodeId nodeId() { return _nodeId; }
 
-  NodeState const &
-  nodeState() const { return _nodeState; }
+    NodeId nodeId() const { return _nodeId; }
 
-  QRectF
-  boundingRect() const override;
+    NodeState &nodeState() { return _nodeState; }
 
-  void
-  setGeometryChanged();
+    NodeState const &nodeState() const { return _nodeState; }
 
-  /// Visits all attached connections and corrects
-  /// their corresponding end points.
-  void
-  moveConnections() const;
+    QRectF boundingRect() const override;
 
-  /// Repaints the node once with reacting ports.
-  void
-  reactToConnection(ConnectionGraphicsObject const * cgo);
+    void setGeometryChanged();
+
+    /// Visits all attached connections and corrects
+    /// their corresponding end points.
+    void moveConnections() const;
+
+    /// Repaints the node once with reacting ports.
+    void reactToConnection(ConnectionGraphicsObject const *cgo);
 
 protected:
-  void
-  paint(QPainter* painter,
-        QStyleOptionGraphicsItem const* option,
-        QWidget*  widget = 0) override;
+    void paint(QPainter *painter,
+               QStyleOptionGraphicsItem const *option,
+               QWidget *widget = 0) override;
 
-  QVariant
-  itemChange(GraphicsItemChange change, const QVariant &value) override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
-  void
-  mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
 
-  void
-  hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
-  void
-  hoverMoveEvent(QGraphicsSceneHoverEvent *) override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent *) override;
 
-  void
-  mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
 
-  void
-  contextMenuEvent(QGraphicsSceneContextMenuEvent* event) override;
+    void contextMenuEvent(QGraphicsSceneContextMenuEvent *event) override;
 
 private:
-  void
-  embedQWidget();
+    void embedQWidget();
 
-  void
-  setLockedState();
+    void setLockedState();
 
 private:
-  NodeId _nodeId;
+    NodeId _nodeId;
 
-  AbstractGraphModel &_graphModel;
+    AbstractGraphModel &_graphModel;
 
-  NodeState _nodeState;
+    NodeState _nodeState;
 
-  // either nullptr or owned by parent QGraphicsItem
-  QGraphicsProxyWidget * _proxyWidget;
+    // either nullptr or owned by parent QGraphicsItem
+    QGraphicsProxyWidget *_proxyWidget;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/NodeState.hpp
+++ b/include/QtNodes/internal/NodeState.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include <QtCore/QPointF>
-#include <QtCore/QUuid>
 #include <QtCore/QPointer>
+#include <QtCore/QUuid>
 
 #include "Export.hpp"
 
 #include "Definitions.hpp"
 #include "NodeData.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class ConnectionGraphicsObject;
 class NodeGraphicsObject;
@@ -22,44 +21,32 @@ class NodeGraphicsObject;
 class NODE_EDITOR_PUBLIC NodeState
 {
 public:
-
-  NodeState(NodeGraphicsObject & ngo);
+    NodeState(NodeGraphicsObject &ngo);
 
 public:
+    bool hovered() const { return _hovered; }
 
-  bool
-  hovered() const
-  { return _hovered; }
+    void setHovered(bool hovered = true) { _hovered = hovered; }
 
-  void
-  setHovered(bool hovered = true)
-  { _hovered = hovered; }
+    void setResizing(bool resizing);
 
-  void
-  setResizing(bool resizing);
+    bool resizing() const;
 
-  bool
-  resizing() const;
+    ConnectionGraphicsObject const *connectionForReaction() const;
 
-  ConnectionGraphicsObject const *
-  connectionForReaction() const;
+    void storeConnectionForReaction(ConnectionGraphicsObject const *cgo);
 
-  void
-  storeConnectionForReaction(ConnectionGraphicsObject const * cgo);
-
-  void
-  resetConnectionForReaction();
+    void resetConnectionForReaction();
 
 private:
+    NodeGraphicsObject &_ngo;
 
-  NodeGraphicsObject & _ngo;
+    bool _hovered;
 
-  bool _hovered;
+    bool _resizing;
 
-  bool _resizing;
-
-  // QPointer tracks the QObject inside and is automatically cleared
-  // when the object is destroyed.
-  QPointer<ConnectionGraphicsObject const> _connectionForReaction;
+    // QPointer tracks the QObject inside and is automatically cleared
+    // when the object is destroyed.
+    QPointer<ConnectionGraphicsObject const> _connectionForReaction;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/NodeStyle.hpp
+++ b/include/QtNodes/internal/NodeStyle.hpp
@@ -5,50 +5,49 @@
 #include "Export.hpp"
 #include "Style.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class NODE_EDITOR_PUBLIC NodeStyle : public Style
 {
 public:
-  NodeStyle();
+    NodeStyle();
 
-  NodeStyle(QString jsonText);
+    NodeStyle(QString jsonText);
 
-  NodeStyle(QJsonObject const & json);
+    NodeStyle(QJsonObject const &json);
 
-  virtual ~NodeStyle() = default;
-
-public:
-  static void setNodeStyle(QString jsonText);
+    virtual ~NodeStyle() = default;
 
 public:
-  void loadJson(QJsonObject const & json) override;
-
-  QJsonObject toJson() const override;
+    static void setNodeStyle(QString jsonText);
 
 public:
-  QColor NormalBoundaryColor;
-  QColor SelectedBoundaryColor;
-  QColor GradientColor0;
-  QColor GradientColor1;
-  QColor GradientColor2;
-  QColor GradientColor3;
-  QColor ShadowColor;
-  QColor FontColor;
-  QColor FontColorFaded;
+    void loadJson(QJsonObject const &json) override;
 
-  QColor ConnectionPointColor;
-  QColor FilledConnectionPointColor;
+    QJsonObject toJson() const override;
 
-  QColor WarningColor;
-  QColor ErrorColor;
+public:
+    QColor NormalBoundaryColor;
+    QColor SelectedBoundaryColor;
+    QColor GradientColor0;
+    QColor GradientColor1;
+    QColor GradientColor2;
+    QColor GradientColor3;
+    QColor ShadowColor;
+    QColor FontColor;
+    QColor FontColorFaded;
 
-  float PenWidth;
-  float HoveredPenWidth;
+    QColor ConnectionPointColor;
+    QColor FilledConnectionPointColor;
 
-  float ConnectionPointDiameter;
+    QColor WarningColor;
+    QColor ErrorColor;
 
-  float Opacity;
+    float PenWidth;
+    float HoveredPenWidth;
+
+    float ConnectionPointDiameter;
+
+    float Opacity;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/OperatingSystem.hpp
+++ b/include/QtNodes/internal/OperatingSystem.hpp
@@ -1,78 +1,49 @@
 #pragma once
 
-#if                                                                            \
-  defined (__CYGWIN__)                                                      || \
-  defined (__CYGWIN32__)
-#  define NODE_EDITOR_PLATFORM "Cygwin"
-#  define NODE_EDITOR_PLATFORM_CYGWIN
-#  define NODE_EDITOR_PLATFORM_UNIX
-#  define NODE_EDITOR_PLATFORM_WINDOWS
-#elif                                                                          \
-  defined (_WIN16)                                                          || \
-  defined (_WIN32)                                                          || \
-  defined (_WIN64)                                                          || \
-  defined (__WIN32__)                                                       || \
-  defined (__TOS_WIN__)                                                     || \
-  defined (__WINDOWS__)
-#  define NODE_EDITOR_PLATFORM "Windows"
-#  define NODE_EDITOR_PLATFORM_WINDOWS
-#elif                                                                          \
-  defined (macintosh)                                                       || \
-  defined (Macintosh)                                                       || \
-  defined (__TOS_MACOS__)                                                   || \
-  (defined (__APPLE__) && defined (__MACH__))
-#  define NODE_EDITOR_PLATFORM "Mac"
-#  define NODE_EDITOR_PLATFORM_MAC
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif                                                                          \
-  defined (linux)                                                           || \
-  defined (__linux)                                                         || \
-  defined (__linux__)                                                       || \
-  defined (__TOS_LINUX__)
-#  define NODE_EDITOR_PLATFORM "Linux"
-#  define NODE_EDITOR_PLATFORM_LINUX
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif                                                                          \
-  defined (__FreeBSD__)                                                     || \
-  defined (__OpenBSD__)                                                     || \
-  defined (__NetBSD__)                                                      || \
-  defined (__bsdi__)                                                        || \
-  defined (__DragonFly__)
-#  define NODE_EDITOR_PLATFORM "BSD"
-#  define NODE_EDITOR_PLATFORM_BSD
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif                                                                          \
-  defined (sun)                                                             || \
-  defined (__sun)
-#  define NODE_EDITOR_PLATFORM "Solaris"
-#  define NODE_EDITOR_PLATFORM_SOLARIS
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif                                                                          \
-  defined (_AIX)                                                            || \
-  defined (__TOS_AIX__)
-#  define NODE_EDITOR_PLATFORM "AIX"
-#  define NODE_EDITOR_PLATFORM_AIX
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif                                                                          \
-  defined (hpux)                                                            || \
-  defined (_hpux)                                                           || \
-  defined (__hpux)
-#  define NODE_EDITOR_PLATFORM "HPUX"
-#  define NODE_EDITOR_PLATFORM_HPUX
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif \
-  defined (__QNX__)
-#  define NODE_EDITOR_PLATFORM "QNX"
-#  define NODE_EDITOR_PLATFORM_QNX
-#  define NODE_EDITOR_PLATFORM_UNIX
-#elif                                                                          \
-  defined (unix)                                                            || \
-  defined (__unix)                                                          || \
-  defined (__unix__)
-#  define NODE_EDITOR_PLATFORM "Unix"
-#  define NODE_EDITOR_PLATFORM_UNIX
+#if defined(__CYGWIN__) || defined(__CYGWIN32__)
+#define NODE_EDITOR_PLATFORM "Cygwin"
+#define NODE_EDITOR_PLATFORM_CYGWIN
+#define NODE_EDITOR_PLATFORM_UNIX
+#define NODE_EDITOR_PLATFORM_WINDOWS
+#elif defined(_WIN16) || defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) \
+    || defined(__TOS_WIN__) || defined(__WINDOWS__)
+#define NODE_EDITOR_PLATFORM "Windows"
+#define NODE_EDITOR_PLATFORM_WINDOWS
+#elif defined(macintosh) || defined(Macintosh) || defined(__TOS_MACOS__) \
+    || (defined(__APPLE__) && defined(__MACH__))
+#define NODE_EDITOR_PLATFORM "Mac"
+#define NODE_EDITOR_PLATFORM_MAC
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__TOS_LINUX__)
+#define NODE_EDITOR_PLATFORM "Linux"
+#define NODE_EDITOR_PLATFORM_LINUX
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__bsdi__) \
+    || defined(__DragonFly__)
+#define NODE_EDITOR_PLATFORM "BSD"
+#define NODE_EDITOR_PLATFORM_BSD
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(sun) || defined(__sun)
+#define NODE_EDITOR_PLATFORM "Solaris"
+#define NODE_EDITOR_PLATFORM_SOLARIS
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(_AIX) || defined(__TOS_AIX__)
+#define NODE_EDITOR_PLATFORM "AIX"
+#define NODE_EDITOR_PLATFORM_AIX
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(hpux) || defined(_hpux) || defined(__hpux)
+#define NODE_EDITOR_PLATFORM "HPUX"
+#define NODE_EDITOR_PLATFORM_HPUX
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(__QNX__)
+#define NODE_EDITOR_PLATFORM "QNX"
+#define NODE_EDITOR_PLATFORM_QNX
+#define NODE_EDITOR_PLATFORM_UNIX
+#elif defined(unix) || defined(__unix) || defined(__unix__)
+#define NODE_EDITOR_PLATFORM "Unix"
+#define NODE_EDITOR_PLATFORM_UNIX
 #endif
 
 #ifndef NODE_EDITOR_PLATFORM
-#  error "Current platform is not supported."
+#error "Current platform is not supported."
 #endif

--- a/include/QtNodes/internal/QStringStdHash.hpp
+++ b/include/QtNodes/internal/QStringStdHash.hpp
@@ -11,17 +11,12 @@
 #include <QtCore/QString>
 #include <QtCore/QVariant>
 
-namespace std
-{
+namespace std {
 template<>
 struct hash<QString>
 {
-  inline std::size_t
-  operator()(QString const &s) const
-  {
-    return qHash(s);
-  }
+    inline std::size_t operator()(QString const &s) const { return qHash(s); }
 };
-}
+} // namespace std
 
 #endif

--- a/include/QtNodes/internal/QUuidStdHash.hpp
+++ b/include/QtNodes/internal/QUuidStdHash.hpp
@@ -5,17 +5,10 @@
 #include <QtCore/QUuid>
 #include <QtCore/QVariant>
 
-namespace std
-{
+namespace std {
 template<>
 struct hash<QUuid>
 {
-  inline
-  std::size_t
-  operator()(QUuid const& uid) const
-  {
-    return qHash(uid);
-  }
+    inline std::size_t operator()(QUuid const &uid) const { return qHash(uid); }
 };
-}
-
+} // namespace std

--- a/include/QtNodes/internal/Serializable.hpp
+++ b/include/QtNodes/internal/Serializable.hpp
@@ -2,21 +2,15 @@
 
 #include <QtCore/QJsonObject>
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class Serializable
 {
 public:
+    virtual ~Serializable() = default;
 
-  virtual
-  ~Serializable() = default;
+    virtual QJsonObject save() const { return {}; }
 
-  virtual
-  QJsonObject
-  save() const { return {}; }
-
-  virtual void
-  load(QJsonObject const & /*p*/) {}
+    virtual void load(QJsonObject const & /*p*/) {}
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/Style.hpp
+++ b/include/QtNodes/internal/Style.hpp
@@ -7,55 +7,42 @@
 #include <QtCore/QObject>
 #include <QtCore/QString>
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class Style // : public QObject
 {
-  //Q_OBJECT
+    //Q_OBJECT
 
 public:
-
-  virtual ~Style() = default;
+    virtual ~Style() = default;
 
 public:
+    virtual void loadJson(QJsonObject const &json) = 0;
 
-  virtual
-  void loadJson(QJsonObject const & json) = 0;
+    virtual QJsonObject toJson() const = 0;
 
-  virtual
-  QJsonObject toJson() const = 0;
-
-  /// Loads from utf-8 byte array.
-  virtual
-  void loadJsonFromByteArray(QByteArray const & byteArray)
-  {
-    auto json = QJsonDocument::fromJson(byteArray).object();
-
-    loadJson(json);
-  }
-
-  virtual
-  void loadJsonText(QString jsonText)
-  {
-    loadJsonFromByteArray(jsonText.toUtf8());
-  }
-
-  virtual
-  void loadJsonFile(QString fileName)
-  {
-    QFile file(fileName);
-
-    if (!file.open(QIODevice::ReadOnly))
+    /// Loads from utf-8 byte array.
+    virtual void loadJsonFromByteArray(QByteArray const &byteArray)
     {
-      qWarning() << "Couldn't open file " << fileName;
+        auto json = QJsonDocument::fromJson(byteArray).object();
 
-      return;
+        loadJson(json);
     }
 
-    loadJsonFromByteArray(file.readAll());
-  }
+    virtual void loadJsonText(QString jsonText) { loadJsonFromByteArray(jsonText.toUtf8()); }
 
+    virtual void loadJsonFile(QString fileName)
+    {
+        QFile file(fileName);
+
+        if (!file.open(QIODevice::ReadOnly)) {
+            qWarning() << "Couldn't open file " << fileName;
+
+            return;
+        }
+
+        loadJsonFromByteArray(file.readAll());
+    }
 };
 
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/StyleCollection.hpp
+++ b/include/QtNodes/internal/StyleCollection.hpp
@@ -6,50 +6,38 @@
 #include "GraphicsViewStyle.hpp"
 #include "NodeStyle.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class NODE_EDITOR_PUBLIC StyleCollection
 {
 public:
+    static NodeStyle const &nodeStyle();
 
-  static
-  NodeStyle const & nodeStyle();
+    static ConnectionStyle const &connectionStyle();
 
-  static
-  ConnectionStyle const & connectionStyle();
-
-  static
-  GraphicsViewStyle const & flowViewStyle();
+    static GraphicsViewStyle const &flowViewStyle();
 
 public:
+    static void setNodeStyle(NodeStyle);
 
-  static
-  void setNodeStyle(NodeStyle);
+    static void setConnectionStyle(ConnectionStyle);
 
-  static
-  void setConnectionStyle(ConnectionStyle);
-
-  static
-  void setGraphicsViewStyle(GraphicsViewStyle);
+    static void setGraphicsViewStyle(GraphicsViewStyle);
 
 private:
+    StyleCollection() = default;
 
-  StyleCollection() = default;
+    StyleCollection(StyleCollection const &) = delete;
 
-  StyleCollection(StyleCollection const &) = delete;
+    StyleCollection &operator=(StyleCollection const &) = delete;
 
-  StyleCollection & operator=(StyleCollection const &) = delete;
-
-  static
-  StyleCollection & instance();
+    static StyleCollection &instance();
 
 private:
+    NodeStyle _nodeStyle;
 
-  NodeStyle _nodeStyle;
+    ConnectionStyle _connectionStyle;
 
-  ConnectionStyle _connectionStyle;
-
-  GraphicsViewStyle _flowViewStyle;
+    GraphicsViewStyle _flowViewStyle;
 };
-}
+} // namespace QtNodes

--- a/include/QtNodes/internal/locateNode.hpp
+++ b/include/QtNodes/internal/locateNode.hpp
@@ -3,19 +3,14 @@
 #include <QtCore/QPointF>
 #include <QtGui/QTransform>
 
-
 class QGraphicsScene;
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class NodeGraphicsObject;
 
+NodeGraphicsObject *locateNodeAt(QPointF scenePoint,
+                                 QGraphicsScene &scene,
+                                 QTransform const &viewTransform);
 
-NodeGraphicsObject*
-locateNodeAt(QPointF scenePoint,
-             QGraphicsScene &scene,
-             QTransform const & viewTransform);
-
-
-}
+} // namespace QtNodes

--- a/src/AbstractGraphModel.cpp
+++ b/src/AbstractGraphModel.cpp
@@ -2,138 +2,104 @@
 
 #include <QtNodes/ConnectionIdUtils>
 
+namespace QtNodes {
 
-namespace QtNodes
+void AbstractGraphModel::portsAboutToBeDeleted(NodeId const nodeId,
+                                               PortType const portType,
+                                               PortIndex const first,
+                                               PortIndex const last)
 {
+    _shiftedByDynamicPortsConnections.clear();
 
-void
-AbstractGraphModel::
-portsAboutToBeDeleted(NodeId const    nodeId,
-                      PortType const  portType,
-                      PortIndex const first,
-                      PortIndex const last)
-{
-  _shiftedByDynamicPortsConnections.clear();
+    auto portCountRole = portType == PortType::In ? NodeRole::InPortCount : NodeRole::OutPortCount;
 
-  auto portCountRole = portType == PortType::In ?
-                       NodeRole::InPortCount :
-                       NodeRole::OutPortCount;
+    unsigned int portCount = nodeData(nodeId, portCountRole).toUInt();
 
-  unsigned int portCount = nodeData(nodeId, portCountRole).toUInt();
+    if (first > portCount - 1)
+        return;
 
-  if (first > portCount - 1)
-    return;
+    if (last < first)
+        return;
 
-  if (last < first)
-    return;
+    auto clampedLast = std::min(last, portCount - 1);
 
-  auto clampedLast = std::min(last, portCount - 1);
+    for (PortIndex portIndex = first; portIndex <= clampedLast; ++portIndex) {
+        std::unordered_set<ConnectionId> conns = connections(nodeId, portType, portIndex);
 
-  for (PortIndex portIndex = first; portIndex <= clampedLast; ++portIndex)
-  {
-    std::unordered_set<ConnectionId> conns =
-      connections(nodeId, portType, portIndex);
-
-    for (auto connectionId : conns)
-    {
-      deleteConnection(connectionId);
+        for (auto connectionId : conns) {
+            deleteConnection(connectionId);
+        }
     }
-  }
 
+    std::size_t const nRemovedPorts = clampedLast - first + 1;
 
-  std::size_t const nRemovedPorts = clampedLast - first + 1;
+    for (PortIndex portIndex = clampedLast + 1; portIndex < portCount; ++portIndex) {
+        std::unordered_set<ConnectionId> conns = connections(nodeId, portType, portIndex);
 
-  for (PortIndex portIndex = clampedLast + 1; portIndex < portCount; ++portIndex)
-  {
-    std::unordered_set<ConnectionId> conns =
-      connections(nodeId, portType, portIndex);
+        for (auto connectionId : conns) {
+            // Erases the information about the port on one side;
+            auto c = makeIncompleteConnectionId(connectionId, portType);
 
-    for (auto connectionId : conns)
-    {
-      // Erases the information about the port on one side;
-      auto c = makeIncompleteConnectionId(connectionId, portType);
+            c = makeCompleteConnectionId(c, nodeId, portIndex - nRemovedPorts);
 
-      c = makeCompleteConnectionId(c,
-                                   nodeId,
-                                   portIndex - nRemovedPorts);
+            _shiftedByDynamicPortsConnections.push_back(c);
 
-      _shiftedByDynamicPortsConnections.push_back(c);
-
-      deleteConnection(connectionId);
+            deleteConnection(connectionId);
+        }
     }
-  }
 }
 
-
-void
-AbstractGraphModel::
-portsDeleted()
+void AbstractGraphModel::portsDeleted()
 {
-  for (auto const connectionId : _shiftedByDynamicPortsConnections)
-  {
-    addConnection(connectionId);
-  }
-
-  _shiftedByDynamicPortsConnections.clear();
-}
-
-
-void
-AbstractGraphModel::
-portsAboutToBeInserted(NodeId const    nodeId,
-                       PortType const  portType,
-                       PortIndex const first,
-                       PortIndex const last)
-{
-  _shiftedByDynamicPortsConnections.clear();
-
-  auto portCountRole = portType == PortType::In ?
-                       NodeRole::InPortCount :
-                       NodeRole::OutPortCount;
-
-  unsigned int portCount = nodeData(nodeId, portCountRole).toUInt();
-
-  if (first > portCount)
-    return;
-
-  if (last < first)
-    return;
-
-  std::size_t const nNewPorts = last - first + 1;
-
-  for (PortIndex portIndex = first; portIndex < portCount; ++portIndex)
-  {
-    std::unordered_set<ConnectionId> conns =
-      connections(nodeId, portType, portIndex);
-
-    for( auto connectionId : conns )
-    {
-      // Erases the information about the port on one side;
-      auto c = makeIncompleteConnectionId(connectionId,
-                                          portType);
-
-      c = makeCompleteConnectionId(c,
-                                   nodeId,
-                                   portIndex + nNewPorts);
-
-      _shiftedByDynamicPortsConnections.push_back(c);
-
-      deleteConnection(connectionId);
+    for (auto const connectionId : _shiftedByDynamicPortsConnections) {
+        addConnection(connectionId);
     }
-  }
+
+    _shiftedByDynamicPortsConnections.clear();
 }
 
-
-void
-AbstractGraphModel::
-portsInserted()
+void AbstractGraphModel::portsAboutToBeInserted(NodeId const nodeId,
+                                                PortType const portType,
+                                                PortIndex const first,
+                                                PortIndex const last)
 {
-  for (auto const connectionId : _shiftedByDynamicPortsConnections)
-  {
-    addConnection(connectionId);
-  }
+    _shiftedByDynamicPortsConnections.clear();
 
-  _shiftedByDynamicPortsConnections.clear();
+    auto portCountRole = portType == PortType::In ? NodeRole::InPortCount : NodeRole::OutPortCount;
+
+    unsigned int portCount = nodeData(nodeId, portCountRole).toUInt();
+
+    if (first > portCount)
+        return;
+
+    if (last < first)
+        return;
+
+    std::size_t const nNewPorts = last - first + 1;
+
+    for (PortIndex portIndex = first; portIndex < portCount; ++portIndex) {
+        std::unordered_set<ConnectionId> conns = connections(nodeId, portType, portIndex);
+
+        for (auto connectionId : conns) {
+            // Erases the information about the port on one side;
+            auto c = makeIncompleteConnectionId(connectionId, portType);
+
+            c = makeCompleteConnectionId(c, nodeId, portIndex + nNewPorts);
+
+            _shiftedByDynamicPortsConnections.push_back(c);
+
+            deleteConnection(connectionId);
+        }
+    }
 }
 
+void AbstractGraphModel::portsInserted()
+{
+    for (auto const connectionId : _shiftedByDynamicPortsConnections) {
+        addConnection(connectionId);
+    }
+
+    _shiftedByDynamicPortsConnections.clear();
 }
+
+} // namespace QtNodes

--- a/src/AbstractNodeGeometry.cpp
+++ b/src/AbstractNodeGeometry.cpp
@@ -7,86 +7,71 @@
 
 #include <cmath>
 
-namespace QtNodes
-{
+namespace QtNodes {
 
-AbstractNodeGeometry::
-AbstractNodeGeometry(AbstractGraphModel & graphModel)
-  : _graphModel(graphModel)
+AbstractNodeGeometry::AbstractNodeGeometry(AbstractGraphModel &graphModel)
+    : _graphModel(graphModel)
 {
-  //
+    //
 }
 
-
-QRectF
-AbstractNodeGeometry::
-boundingRect(NodeId const nodeId) const
+QRectF AbstractNodeGeometry::boundingRect(NodeId const nodeId) const
 {
-  QSize s = size(nodeId);
+    QSize s = size(nodeId);
 
-  double ratio = 0.20;
+    double ratio = 0.20;
 
-  int widthMargin = s.width() * ratio;
-  int heightMargin = s.height() * ratio;
+    int widthMargin = s.width() * ratio;
+    int heightMargin = s.height() * ratio;
 
-  QMargins margins(widthMargin, heightMargin, widthMargin, heightMargin);
+    QMargins margins(widthMargin, heightMargin, widthMargin, heightMargin);
 
-  QRectF r(QPointF(0, 0), s);
+    QRectF r(QPointF(0, 0), s);
 
-  return r.marginsAdded(margins);
+    return r.marginsAdded(margins);
 }
 
-
-QPointF
-AbstractNodeGeometry::
-portScenePosition(NodeId const nodeId,
-                  PortType const portType,
-                  PortIndex const index,
-                  QTransform const & t) const
+QPointF AbstractNodeGeometry::portScenePosition(NodeId const nodeId,
+                                                PortType const portType,
+                                                PortIndex const index,
+                                                QTransform const &t) const
 {
-  QPointF result = portPosition(nodeId, portType, index);
+    QPointF result = portPosition(nodeId, portType, index);
 
-  return t.map(result);
+    return t.map(result);
 }
 
-
-PortIndex
-AbstractNodeGeometry::
-checkPortHit(NodeId const nodeId,
-             PortType const portType,
-             QPointF const nodePoint) const
+PortIndex AbstractNodeGeometry::checkPortHit(NodeId const nodeId,
+                                             PortType const portType,
+                                             QPointF const nodePoint) const
 {
-  auto const & nodeStyle = StyleCollection::nodeStyle();
+    auto const &nodeStyle = StyleCollection::nodeStyle();
 
-  PortIndex result = InvalidPortIndex;
+    PortIndex result = InvalidPortIndex;
 
-  if (portType == PortType::None)
-    return result;
+    if (portType == PortType::None)
+        return result;
 
-  double const tolerance = 2.0 * nodeStyle.ConnectionPointDiameter;
+    double const tolerance = 2.0 * nodeStyle.ConnectionPointDiameter;
 
-  size_t const n =
-    _graphModel.nodeData<unsigned int>(nodeId,
-                                       (portType == PortType::Out) ?
-                                       NodeRole::OutPortCount :
-                                       NodeRole::InPortCount);
+    size_t const n = _graphModel.nodeData<unsigned int>(nodeId,
+                                                        (portType == PortType::Out)
+                                                            ? NodeRole::OutPortCount
+                                                            : NodeRole::InPortCount);
 
-  for (unsigned int portIndex = 0; portIndex < n; ++portIndex)
-  {
-    auto pp = portPosition(nodeId, portType, portIndex);
+    for (unsigned int portIndex = 0; portIndex < n; ++portIndex) {
+        auto pp = portPosition(nodeId, portType, portIndex);
 
-    QPointF p = pp - nodePoint;
-    auto distance = std::sqrt(QPointF::dotProduct(p, p));
+        QPointF p = pp - nodePoint;
+        auto distance = std::sqrt(QPointF::dotProduct(p, p));
 
-    if (distance < tolerance)
-    {
-      result = portIndex;
-      break;
+        if (distance < tolerance) {
+            result = portIndex;
+            break;
+        }
     }
-  }
 
-  return result;
+    return result;
 }
 
-
-}
+} // namespace QtNodes

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -11,8 +11,8 @@
 
 #include <QUndoStack>
 
-#include <QtWidgets/QGraphicsSceneMoveEvent>
 #include <QtWidgets/QFileDialog>
+#include <QtWidgets/QGraphicsSceneMoveEvent>
 
 #include <QtCore/QBuffer>
 #include <QtCore/QByteArray>
@@ -23,352 +23,265 @@
 #include <QtCore/QJsonObject>
 #include <QtCore/QtGlobal>
 
-#include <queue>
 #include <iostream>
 #include <stdexcept>
 #include <unordered_set>
 #include <utility>
+#include <queue>
 
+namespace QtNodes {
 
-namespace QtNodes
+BasicGraphicsScene::BasicGraphicsScene(AbstractGraphModel &graphModel, QObject *parent)
+    : QGraphicsScene(parent)
+    , _graphModel(graphModel)
+    , _nodeGeometry(std::make_unique<DefaultHorizontalNodeGeometry>(_graphModel))
+    , _nodePainter(std::make_unique<DefaultNodePainter>())
+    , _undoStack(new QUndoStack(this))
+    , _orientation(Qt::Horizontal)
 {
+    setItemIndexMethod(QGraphicsScene::NoIndex);
 
-BasicGraphicsScene::
-BasicGraphicsScene(AbstractGraphModel &graphModel,
-                   QObject *   parent)
-  : QGraphicsScene(parent)
-  , _graphModel(graphModel)
-  , _nodeGeometry(std::make_unique<DefaultHorizontalNodeGeometry>(_graphModel))
-  , _nodePainter(std::make_unique<DefaultNodePainter>())
-  , _undoStack(new QUndoStack(this))
-  , _orientation(Qt::Horizontal)
-{
-  setItemIndexMethod(QGraphicsScene::NoIndex);
+    connect(&_graphModel,
+            &AbstractGraphModel::connectionCreated,
+            this,
+            &BasicGraphicsScene::onConnectionCreated);
 
+    connect(&_graphModel,
+            &AbstractGraphModel::connectionDeleted,
+            this,
+            &BasicGraphicsScene::onConnectionDeleted);
 
-  connect(&_graphModel, &AbstractGraphModel::connectionCreated,
-          this, &BasicGraphicsScene::onConnectionCreated);
+    connect(&_graphModel,
+            &AbstractGraphModel::nodeCreated,
+            this,
+            &BasicGraphicsScene::onNodeCreated);
 
-  connect(&_graphModel, &AbstractGraphModel::connectionDeleted,
-          this, &BasicGraphicsScene::onConnectionDeleted);
+    connect(&_graphModel,
+            &AbstractGraphModel::nodeDeleted,
+            this,
+            &BasicGraphicsScene::onNodeDeleted);
 
-  connect(&_graphModel, &AbstractGraphModel::nodeCreated,
-          this, &BasicGraphicsScene::onNodeCreated);
+    connect(&_graphModel,
+            &AbstractGraphModel::nodePositionUpdated,
+            this,
+            &BasicGraphicsScene::onNodePositionUpdated);
 
-  connect(&_graphModel, &AbstractGraphModel::nodeDeleted,
-          this, &BasicGraphicsScene::onNodeDeleted);
+    connect(&_graphModel,
+            &AbstractGraphModel::nodeUpdated,
+            this,
+            &BasicGraphicsScene::onNodeUpdated);
 
-  connect(&_graphModel, &AbstractGraphModel::nodePositionUpdated,
-          this, &BasicGraphicsScene::onNodePositionUpdated);
+    connect(&_graphModel, &AbstractGraphModel::modelReset, this, &BasicGraphicsScene::onModelReset);
 
-  connect(&_graphModel, &AbstractGraphModel::nodeUpdated,
-          this, &BasicGraphicsScene::onNodeUpdated);
-
-  connect(&_graphModel, &AbstractGraphModel::modelReset,
-          this, &BasicGraphicsScene::onModelReset);
-
-  traverseGraphAndPopulateGraphicsObjects();
+    traverseGraphAndPopulateGraphicsObjects();
 }
 
+BasicGraphicsScene::~BasicGraphicsScene() = default;
 
-BasicGraphicsScene::
-~BasicGraphicsScene() = default;
-
-
-AbstractGraphModel const &
-BasicGraphicsScene::
-graphModel() const
+AbstractGraphModel const &BasicGraphicsScene::graphModel() const
 {
-  return _graphModel;
+    return _graphModel;
 }
 
-
-AbstractGraphModel &
-BasicGraphicsScene::
-graphModel()
+AbstractGraphModel &BasicGraphicsScene::graphModel()
 {
-  return _graphModel;
+    return _graphModel;
 }
 
-
-AbstractNodeGeometry &
-BasicGraphicsScene::
-nodeGeometry()
+AbstractNodeGeometry &BasicGraphicsScene::nodeGeometry()
 {
-  return *_nodeGeometry;
+    return *_nodeGeometry;
 }
 
-
-AbstractNodePainter &
-BasicGraphicsScene::
-nodePainter()
+AbstractNodePainter &BasicGraphicsScene::nodePainter()
 {
-  return *_nodePainter;
+    return *_nodePainter;
 }
 
-
-void
-BasicGraphicsScene::
-setNodePainter(std::unique_ptr<AbstractNodePainter> newPainter)
+void BasicGraphicsScene::setNodePainter(std::unique_ptr<AbstractNodePainter> newPainter)
 {
-  _nodePainter = std::move(newPainter);
+    _nodePainter = std::move(newPainter);
 }
 
-
-QUndoStack &
-BasicGraphicsScene::
-undoStack()
+QUndoStack &BasicGraphicsScene::undoStack()
 {
-  return *_undoStack;
+    return *_undoStack;
 }
 
-
-std::unique_ptr<ConnectionGraphicsObject> const &
-BasicGraphicsScene::
-makeDraftConnection(ConnectionId const incompleteConnectionId)
+std::unique_ptr<ConnectionGraphicsObject> const &BasicGraphicsScene::makeDraftConnection(
+    ConnectionId const incompleteConnectionId)
 {
-  _draftConnection =
-    std::make_unique<ConnectionGraphicsObject>(*this,
-                                               incompleteConnectionId);
+    _draftConnection = std::make_unique<ConnectionGraphicsObject>(*this, incompleteConnectionId);
 
-  _draftConnection->grabMouse();
+    _draftConnection->grabMouse();
 
-  return _draftConnection;
+    return _draftConnection;
 }
 
-
-void
-BasicGraphicsScene::
-resetDraftConnection()
+void BasicGraphicsScene::resetDraftConnection()
 {
-  _draftConnection.reset();
-}
-
-
-void
-BasicGraphicsScene::
-clearScene()
-{
-  auto const &allNodeIds = graphModel().allNodeIds();
-
-  for ( auto nodeId : allNodeIds)
-  {
-    graphModel().deleteNode(nodeId);
-  }
-}
-
-
-NodeGraphicsObject*
-BasicGraphicsScene::
-nodeGraphicsObject(NodeId nodeId)
-{
-  NodeGraphicsObject * ngo = nullptr;
-  auto it = _nodeGraphicsObjects.find(nodeId);
-  if (it != _nodeGraphicsObjects.end())
-  {
-    ngo = it->second.get();
-  }
-
-  return ngo;
-}
-
-
-ConnectionGraphicsObject*
-BasicGraphicsScene::
-connectionGraphicsObject(ConnectionId connectionId)
-{
-  ConnectionGraphicsObject * cgo = nullptr;
-  auto it = _connectionGraphicsObjects.find(connectionId);
-  if (it != _connectionGraphicsObjects.end())
-  {
-    cgo = it->second.get();
-  }
-
-  return cgo;
-}
-
-
-void
-BasicGraphicsScene::
-setOrientation(Qt::Orientation const orientation)
-{
-  if (_orientation != orientation)
-  {
-    _orientation = orientation;
-
-    switch(_orientation)
-    {
-      case Qt::Horizontal:
-        _nodeGeometry = std::make_unique<DefaultHorizontalNodeGeometry>(_graphModel);
-        break;
-
-      case Qt::Vertical:
-        _nodeGeometry = std::make_unique<DefaultVerticalNodeGeometry>(_graphModel);
-        break;
-    }
-
-    onModelReset();
-  }
-}
-
-
-QMenu *
-BasicGraphicsScene::
-createSceneMenu(QPointF const scenePos)
-{
-  Q_UNUSED(scenePos);
-  return nullptr;
-}
-
-
-void
-BasicGraphicsScene::
-traverseGraphAndPopulateGraphicsObjects()
-{
-  auto allNodeIds = _graphModel.allNodeIds();
-
-  // First create all the nodes.
-  for (NodeId const nodeId : allNodeIds)
-  {
-    _nodeGraphicsObjects[nodeId] =
-      std::make_unique<NodeGraphicsObject>(*this, nodeId);
-  }
-
-  // Then for each node check output connections and insert them.
-  for (NodeId const nodeId : allNodeIds)
-  {
-    unsigned int nOutPorts =
-      _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
-
-    for (PortIndex index = 0; index < nOutPorts; ++index)
-    {
-      auto const& outConnectionIds =
-        _graphModel.connections(nodeId,
-                                PortType::Out,
-                                index);
-
-      for (auto cid : outConnectionIds)
-      {
-        _connectionGraphicsObjects[cid] =
-          std::make_unique<ConnectionGraphicsObject>(*this, cid);
-      }
-    }
-  }
-}
-
-
-void
-BasicGraphicsScene::
-updateAttachedNodes(ConnectionId const connectionId,
-                    PortType const portType)
-{
-  auto node = nodeGraphicsObject(getNodeId(portType, connectionId));
-
-  if (node)
-  {
-    node->update();
-  }
-}
-
-
-void
-BasicGraphicsScene::
-onConnectionDeleted(ConnectionId const connectionId)
-{
-  auto it = _connectionGraphicsObjects.find(connectionId);
-  if (it != _connectionGraphicsObjects.end())
-  {
-    _connectionGraphicsObjects.erase(it);
-  }
-
-  // TODO: do we need it?
-  if (_draftConnection &&
-      _draftConnection->connectionId() == connectionId)
-  {
     _draftConnection.reset();
-  }
-
-  updateAttachedNodes(connectionId, PortType::Out);
-  updateAttachedNodes(connectionId, PortType::In);
 }
 
-
-void
-BasicGraphicsScene::
-onConnectionCreated(ConnectionId const connectionId)
+void BasicGraphicsScene::clearScene()
 {
-  _connectionGraphicsObjects[connectionId] =
-    std::make_unique<ConnectionGraphicsObject>(*this,
-                                               connectionId);
+    auto const &allNodeIds = graphModel().allNodeIds();
 
-  updateAttachedNodes(connectionId, PortType::Out);
-  updateAttachedNodes(connectionId, PortType::In);
+    for (auto nodeId : allNodeIds) {
+        graphModel().deleteNode(nodeId);
+    }
 }
 
-
-void
-BasicGraphicsScene::
-onNodeDeleted(NodeId const nodeId)
+NodeGraphicsObject *BasicGraphicsScene::nodeGraphicsObject(NodeId nodeId)
 {
-  auto it = _nodeGraphicsObjects.find(nodeId);
-  if (it != _nodeGraphicsObjects.end())
-  {
-    _nodeGraphicsObjects.erase(it);
-  }
+    NodeGraphicsObject *ngo = nullptr;
+    auto it = _nodeGraphicsObjects.find(nodeId);
+    if (it != _nodeGraphicsObjects.end()) {
+        ngo = it->second.get();
+    }
+
+    return ngo;
 }
 
-
-void
-BasicGraphicsScene::
-onNodeCreated(NodeId const nodeId)
+ConnectionGraphicsObject *BasicGraphicsScene::connectionGraphicsObject(ConnectionId connectionId)
 {
-  _nodeGraphicsObjects[nodeId] =
-    std::make_unique<NodeGraphicsObject>(*this, nodeId);
+    ConnectionGraphicsObject *cgo = nullptr;
+    auto it = _connectionGraphicsObjects.find(connectionId);
+    if (it != _connectionGraphicsObjects.end()) {
+        cgo = it->second.get();
+    }
+
+    return cgo;
 }
 
-
-void
-BasicGraphicsScene::
-onNodePositionUpdated(NodeId const nodeId)
+void BasicGraphicsScene::setOrientation(Qt::Orientation const orientation)
 {
-  auto node = nodeGraphicsObject(nodeId);
-  if (node)
-  {
-    node->setPos(_graphModel.nodeData(nodeId,
-                                      NodeRole::Position).value<QPointF>());
-    node->update();
-  }
+    if (_orientation != orientation) {
+        _orientation = orientation;
+
+        switch (_orientation) {
+        case Qt::Horizontal:
+            _nodeGeometry = std::make_unique<DefaultHorizontalNodeGeometry>(_graphModel);
+            break;
+
+        case Qt::Vertical:
+            _nodeGeometry = std::make_unique<DefaultVerticalNodeGeometry>(_graphModel);
+            break;
+        }
+
+        onModelReset();
+    }
 }
 
-
-void
-BasicGraphicsScene::
-onNodeUpdated(NodeId const nodeId)
+QMenu *BasicGraphicsScene::createSceneMenu(QPointF const scenePos)
 {
-  auto node = nodeGraphicsObject(nodeId);
-
-  if (node)
-  {
-    node->setGeometryChanged();
-
-    _nodeGeometry->recomputeSize(nodeId);
-
-    node->update();
-    node->moveConnections();
-  }
+    Q_UNUSED(scenePos);
+    return nullptr;
 }
 
-
-void
-BasicGraphicsScene::
-onModelReset()
+void BasicGraphicsScene::traverseGraphAndPopulateGraphicsObjects()
 {
-  _connectionGraphicsObjects.clear();
-  _nodeGraphicsObjects.clear();
+    auto allNodeIds = _graphModel.allNodeIds();
 
-  clear();
+    // First create all the nodes.
+    for (NodeId const nodeId : allNodeIds) {
+        _nodeGraphicsObjects[nodeId] = std::make_unique<NodeGraphicsObject>(*this, nodeId);
+    }
 
-  traverseGraphAndPopulateGraphicsObjects();
+    // Then for each node check output connections and insert them.
+    for (NodeId const nodeId : allNodeIds) {
+        unsigned int nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+
+        for (PortIndex index = 0; index < nOutPorts; ++index) {
+            auto const &outConnectionIds = _graphModel.connections(nodeId, PortType::Out, index);
+
+            for (auto cid : outConnectionIds) {
+                _connectionGraphicsObjects[cid] = std::make_unique<ConnectionGraphicsObject>(*this,
+                                                                                             cid);
+            }
+        }
+    }
 }
 
+void BasicGraphicsScene::updateAttachedNodes(ConnectionId const connectionId,
+                                             PortType const portType)
+{
+    auto node = nodeGraphicsObject(getNodeId(portType, connectionId));
+
+    if (node) {
+        node->update();
+    }
 }
+
+void BasicGraphicsScene::onConnectionDeleted(ConnectionId const connectionId)
+{
+    auto it = _connectionGraphicsObjects.find(connectionId);
+    if (it != _connectionGraphicsObjects.end()) {
+        _connectionGraphicsObjects.erase(it);
+    }
+
+    // TODO: do we need it?
+    if (_draftConnection && _draftConnection->connectionId() == connectionId) {
+        _draftConnection.reset();
+    }
+
+    updateAttachedNodes(connectionId, PortType::Out);
+    updateAttachedNodes(connectionId, PortType::In);
+}
+
+void BasicGraphicsScene::onConnectionCreated(ConnectionId const connectionId)
+{
+    _connectionGraphicsObjects[connectionId]
+        = std::make_unique<ConnectionGraphicsObject>(*this, connectionId);
+
+    updateAttachedNodes(connectionId, PortType::Out);
+    updateAttachedNodes(connectionId, PortType::In);
+}
+
+void BasicGraphicsScene::onNodeDeleted(NodeId const nodeId)
+{
+    auto it = _nodeGraphicsObjects.find(nodeId);
+    if (it != _nodeGraphicsObjects.end()) {
+        _nodeGraphicsObjects.erase(it);
+    }
+}
+
+void BasicGraphicsScene::onNodeCreated(NodeId const nodeId)
+{
+    _nodeGraphicsObjects[nodeId] = std::make_unique<NodeGraphicsObject>(*this, nodeId);
+}
+
+void BasicGraphicsScene::onNodePositionUpdated(NodeId const nodeId)
+{
+    auto node = nodeGraphicsObject(nodeId);
+    if (node) {
+        node->setPos(_graphModel.nodeData(nodeId, NodeRole::Position).value<QPointF>());
+        node->update();
+    }
+}
+
+void BasicGraphicsScene::onNodeUpdated(NodeId const nodeId)
+{
+    auto node = nodeGraphicsObject(nodeId);
+
+    if (node) {
+        node->setGeometryChanged();
+
+        _nodeGeometry->recomputeSize(nodeId);
+
+        node->update();
+        node->moveConnections();
+    }
+}
+
+void BasicGraphicsScene::onModelReset()
+{
+    _connectionGraphicsObjects.clear();
+    _nodeGraphicsObjects.clear();
+
+    clear();
+
+    traverseGraphAndPopulateGraphicsObjects();
+}
+
+} // namespace QtNodes

--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -1,10 +1,10 @@
 #include "ConnectionGraphicsObject.hpp"
 
-#include <QtWidgets/QGraphicsSceneMouseEvent>
-#include <QtWidgets/QGraphicsDropShadowEffect>
 #include <QtWidgets/QGraphicsBlurEffect>
-#include <QtWidgets/QStyleOptionGraphicsItem>
+#include <QtWidgets/QGraphicsDropShadowEffect>
+#include <QtWidgets/QGraphicsSceneMouseEvent>
 #include <QtWidgets/QGraphicsView>
+#include <QtWidgets/QStyleOptionGraphicsItem>
 
 #include <QtCore/QDebug>
 
@@ -20,453 +20,357 @@
 #include "StyleCollection.hpp"
 #include "locateNode.hpp"
 
+namespace QtNodes {
 
-namespace QtNodes
+ConnectionGraphicsObject::ConnectionGraphicsObject(BasicGraphicsScene &scene,
+                                                   ConnectionId const connectionId)
+    : _connectionId(connectionId)
+    , _graphModel(scene.graphModel())
+    , _connectionState(*this)
+    , _out{0, 0}
+    , _in{0, 0}
 {
+    scene.addItem(this);
 
-ConnectionGraphicsObject::
-ConnectionGraphicsObject(BasicGraphicsScene &scene,
-                         ConnectionId const  connectionId)
-  : _connectionId(connectionId)
-  , _graphModel(scene.graphModel())
-  , _connectionState(*this)
-  , _out{0, 0}
-  , _in{0, 0}
-{
-  scene.addItem(this);
+    setFlag(QGraphicsItem::ItemIsMovable, true);
+    setFlag(QGraphicsItem::ItemIsFocusable, true);
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-  setFlag(QGraphicsItem::ItemIsMovable,    true);
-  setFlag(QGraphicsItem::ItemIsFocusable,  true);
-  setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setAcceptHoverEvents(true);
 
-  setAcceptHoverEvents(true);
+    //addGraphicsEffect();
 
-  //addGraphicsEffect();
+    setZValue(-1.0);
 
-  setZValue(-1.0);
-
-  initializePosition();
+    initializePosition();
 }
 
-
-void
-ConnectionGraphicsObject::
-initializePosition()
+void ConnectionGraphicsObject::initializePosition()
 {
-  // This function is only called when the ConnectionGraphicsObject
-  // is newly created. At this moment both end coordinates are (0, 0)
-  // in Connection G.O. coordinates. The position of the whole
-  // Connection G. O. in scene coordinate system is also (0, 0).
-  // By moving the whole object to the Node Port position
-  // we position both connection ends correctly.
+    // This function is only called when the ConnectionGraphicsObject
+    // is newly created. At this moment both end coordinates are (0, 0)
+    // in Connection G.O. coordinates. The position of the whole
+    // Connection G. O. in scene coordinate system is also (0, 0).
+    // By moving the whole object to the Node Port position
+    // we position both connection ends correctly.
 
-  if (_connectionState.requiredPort() != PortType::None)
-  {
-    PortType attachedPort = oppositePort(_connectionState.requiredPort());
+    if (_connectionState.requiredPort() != PortType::None) {
+        PortType attachedPort = oppositePort(_connectionState.requiredPort());
 
-    PortIndex portIndex = getPortIndex(attachedPort, _connectionId);
-    NodeId nodeId = getNodeId(attachedPort, _connectionId);
+        PortIndex portIndex = getPortIndex(attachedPort, _connectionId);
+        NodeId nodeId = getNodeId(attachedPort, _connectionId);
 
-    NodeGraphicsObject * ngo =
-      nodeScene()->nodeGraphicsObject(nodeId);
+        NodeGraphicsObject *ngo = nodeScene()->nodeGraphicsObject(nodeId);
 
-    if (ngo)
-    {
-      QTransform nodeSceneTransform =
-        ngo->sceneTransform();
+        if (ngo) {
+            QTransform nodeSceneTransform = ngo->sceneTransform();
 
-      AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
+            AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
 
-      QPointF pos = geometry.portScenePosition(nodeId,
-                                               attachedPort,
-                                               portIndex,
-                                               nodeSceneTransform);
+            QPointF pos = geometry.portScenePosition(nodeId,
+                                                     attachedPort,
+                                                     portIndex,
+                                                     nodeSceneTransform);
 
-      this->setPos(pos);
+            this->setPos(pos);
+        }
     }
-  }
 
-  move();
+    move();
 }
 
-
-AbstractGraphModel &
-ConnectionGraphicsObject::
-graphModel() const
+AbstractGraphModel &ConnectionGraphicsObject::graphModel() const
 {
-  return _graphModel;
+    return _graphModel;
 }
 
-
-BasicGraphicsScene *
-ConnectionGraphicsObject::
-nodeScene() const
+BasicGraphicsScene *ConnectionGraphicsObject::nodeScene() const
 {
-  return dynamic_cast<BasicGraphicsScene*>(scene());
+    return dynamic_cast<BasicGraphicsScene *>(scene());
 }
 
-
-ConnectionId const &
-ConnectionGraphicsObject::
-connectionId() const
+ConnectionId const &ConnectionGraphicsObject::connectionId() const
 {
-  return _connectionId;
+    return _connectionId;
 }
 
-
-
-QRectF
-ConnectionGraphicsObject::
-boundingRect() const
+QRectF ConnectionGraphicsObject::boundingRect() const
 {
-  auto points = pointsC1C2();
+    auto points = pointsC1C2();
 
-  // `normalized()` fixes inverted rects.
-  QRectF basicRect = QRectF(_out, _in).normalized();
+    // `normalized()` fixes inverted rects.
+    QRectF basicRect = QRectF(_out, _in).normalized();
 
-  QRectF c1c2Rect = QRectF(points.first, points.second).normalized();
+    QRectF c1c2Rect = QRectF(points.first, points.second).normalized();
 
-  QRectF commonRect = basicRect.united(c1c2Rect);
+    QRectF commonRect = basicRect.united(c1c2Rect);
 
-  auto const &connectionStyle = StyleCollection::connectionStyle();
-  float const diam = connectionStyle.pointDiameter();
-  QPointF const cornerOffset(diam, diam);
+    auto const &connectionStyle = StyleCollection::connectionStyle();
+    float const diam = connectionStyle.pointDiameter();
+    QPointF const cornerOffset(diam, diam);
 
-  // Expand rect by port circle diameter
-  commonRect.setTopLeft(commonRect.topLeft() - cornerOffset);
-  commonRect.setBottomRight(commonRect.bottomRight() + 2 * cornerOffset);
+    // Expand rect by port circle diameter
+    commonRect.setTopLeft(commonRect.topLeft() - cornerOffset);
+    commonRect.setBottomRight(commonRect.bottomRight() + 2 * cornerOffset);
 
-  return commonRect;
+    return commonRect;
 }
 
-
-QPainterPath
-ConnectionGraphicsObject::
-shape() const
+QPainterPath ConnectionGraphicsObject::shape() const
 {
 #ifdef DEBUG_DRAWING
 
-  //QPainterPath path;
+    //QPainterPath path;
 
-  //path.addRect(boundingRect());
-  //return path;
+    //path.addRect(boundingRect());
+    //return path;
 
 #else
-  return ConnectionPainter::getPainterStroke(*this);
+    return ConnectionPainter::getPainterStroke(*this);
 #endif
 }
 
-
-QPointF const &
-ConnectionGraphicsObject::
-endPoint(PortType portType) const
+QPointF const &ConnectionGraphicsObject::endPoint(PortType portType) const
 {
-  Q_ASSERT(portType != PortType::None);
+    Q_ASSERT(portType != PortType::None);
 
-  return (portType == PortType::Out ?
-          _out :
-          _in);
+    return (portType == PortType::Out ? _out : _in);
 }
 
-
-void
-ConnectionGraphicsObject::
-setEndPoint(PortType portType, QPointF const &point)
+void ConnectionGraphicsObject::setEndPoint(PortType portType, QPointF const &point)
 {
-  if (portType == PortType::In)
-    _in = point;
-  else
-    _out = point;
+    if (portType == PortType::In)
+        _in = point;
+    else
+        _out = point;
 }
 
-
-void
-ConnectionGraphicsObject::
-move()
+void ConnectionGraphicsObject::move()
 {
-  auto moveEnd =
-    [this](ConnectionId cId, PortType portType)
-    {
-      NodeId nodeId = getNodeId(portType, cId);
+    auto moveEnd = [this](ConnectionId cId, PortType portType) {
+        NodeId nodeId = getNodeId(portType, cId);
 
-      if (nodeId == InvalidNodeId)
-        return;
+        if (nodeId == InvalidNodeId)
+            return;
 
-      NodeGraphicsObject * ngo =
-        nodeScene()->nodeGraphicsObject(nodeId);
+        NodeGraphicsObject *ngo = nodeScene()->nodeGraphicsObject(nodeId);
 
-      if (ngo)
-      {
-        AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
+        if (ngo) {
+            AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
 
-        QPointF scenePos =
-          geometry.portScenePosition(nodeId,
-                                     portType,
-                                     getPortIndex(portType, cId),
-                                     ngo->sceneTransform());
+            QPointF scenePos = geometry.portScenePosition(nodeId,
+                                                          portType,
+                                                          getPortIndex(portType, cId),
+                                                          ngo->sceneTransform());
 
-        QPointF connectionPos = sceneTransform().inverted().map(scenePos);
+            QPointF connectionPos = sceneTransform().inverted().map(scenePos);
 
-        setEndPoint(portType, connectionPos);
-      }
+            setEndPoint(portType, connectionPos);
+        }
     };
 
-  moveEnd(_connectionId, PortType::Out);
-  moveEnd(_connectionId, PortType::In);
+    moveEnd(_connectionId, PortType::Out);
+    moveEnd(_connectionId, PortType::In);
 
-  prepareGeometryChange();
+    prepareGeometryChange();
 
-  update();
+    update();
 }
 
-
-ConnectionState const &
-ConnectionGraphicsObject::
-connectionState() const
+ConnectionState const &ConnectionGraphicsObject::connectionState() const
 {
-  return _connectionState;
+    return _connectionState;
 }
 
-
-ConnectionState &
-ConnectionGraphicsObject::
-connectionState()
+ConnectionState &ConnectionGraphicsObject::connectionState()
 {
-  return _connectionState;
+    return _connectionState;
 }
 
-
-void
-ConnectionGraphicsObject::
-paint(QPainter * painter,
-      QStyleOptionGraphicsItem const * option,
-      QWidget *)
+void ConnectionGraphicsObject::paint(QPainter *painter,
+                                     QStyleOptionGraphicsItem const *option,
+                                     QWidget *)
 {
-  if (!scene())
-    return;
+    if (!scene())
+        return;
 
-  painter->setClipRect(option->exposedRect);
+    painter->setClipRect(option->exposedRect);
 
-  ConnectionPainter::paint(painter, *this);
+    ConnectionPainter::paint(painter, *this);
 }
 
-
-void
-ConnectionGraphicsObject::
-mousePressEvent(QGraphicsSceneMouseEvent * event)
+void ConnectionGraphicsObject::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-  QGraphicsItem::mousePressEvent(event);
+    QGraphicsItem::mousePressEvent(event);
 }
 
-
-void
-ConnectionGraphicsObject::
-mouseMoveEvent(QGraphicsSceneMouseEvent * event)
+void ConnectionGraphicsObject::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
-  prepareGeometryChange();
+    prepareGeometryChange();
 
-  auto view = static_cast<QGraphicsView *>(event->widget());
-  auto ngo  = locateNodeAt(event->scenePos(),
-                           *nodeScene(),
-                           view->transform());
-  if (ngo)
-  {
-    ngo->reactToConnection(this);
+    auto view = static_cast<QGraphicsView *>(event->widget());
+    auto ngo = locateNodeAt(event->scenePos(), *nodeScene(), view->transform());
+    if (ngo) {
+        ngo->reactToConnection(this);
 
-    _connectionState.setLastHoveredNode(ngo->nodeId());
-  }
-  else
-  {
-    _connectionState.resetLastHoveredNode();
-  }
+        _connectionState.setLastHoveredNode(ngo->nodeId());
+    } else {
+        _connectionState.resetLastHoveredNode();
+    }
 
-  //-------------------
+    //-------------------
 
-  auto requiredPort = _connectionState.requiredPort();
+    auto requiredPort = _connectionState.requiredPort();
 
-  if (requiredPort != PortType::None)
-  {
-    setEndPoint(requiredPort, event->pos());
-  }
+    if (requiredPort != PortType::None) {
+        setEndPoint(requiredPort, event->pos());
+    }
 
-  //-------------------
+    //-------------------
 
-  update();
+    update();
 
-  event->accept();
+    event->accept();
 }
 
-
-void
-ConnectionGraphicsObject::
-mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
+void ConnectionGraphicsObject::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
-  QGraphicsItem::mouseReleaseEvent(event);
+    QGraphicsItem::mouseReleaseEvent(event);
 
-  ungrabMouse();
-  event->accept();
+    ungrabMouse();
+    event->accept();
 
-  auto view = static_cast<QGraphicsView *>(event->widget());
+    auto view = static_cast<QGraphicsView *>(event->widget());
 
-  Q_ASSERT(view);
+    Q_ASSERT(view);
 
-  auto ngo = locateNodeAt(event->scenePos(),
-                          *nodeScene(),
-                          view->transform());
+    auto ngo = locateNodeAt(event->scenePos(), *nodeScene(), view->transform());
 
-  bool wasConnected = false;
+    bool wasConnected = false;
 
-  if (ngo)
-  {
-    NodeConnectionInteraction interaction(*ngo, *this, *nodeScene());
+    if (ngo) {
+        NodeConnectionInteraction interaction(*ngo, *this, *nodeScene());
 
-    wasConnected = interaction.tryConnect();
-  }
+        wasConnected = interaction.tryConnect();
+    }
 
-  // If connection attempt was unsuccessful
-  if (!wasConnected)
-  {
-    // Resulting unique_ptr is not used and automatically deleted.
-    nodeScene()->resetDraftConnection();
-  }
+    // If connection attempt was unsuccessful
+    if (!wasConnected) {
+        // Resulting unique_ptr is not used and automatically deleted.
+        nodeScene()->resetDraftConnection();
+    }
 }
 
-
-void
-ConnectionGraphicsObject::
-hoverEnterEvent(QGraphicsSceneHoverEvent * event)
+void ConnectionGraphicsObject::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
-  _connectionState.setHovered(true);
+    _connectionState.setHovered(true);
 
-  update();
+    update();
 
-  // Signal
-  nodeScene()->connectionHovered(connectionId(), event->screenPos());
+    // Signal
+    nodeScene()->connectionHovered(connectionId(), event->screenPos());
 
-  event->accept();
+    event->accept();
 }
 
-
-void
-ConnectionGraphicsObject::
-hoverLeaveEvent(QGraphicsSceneHoverEvent * event)
+void ConnectionGraphicsObject::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
-  _connectionState.setHovered(false);
+    _connectionState.setHovered(false);
 
-  update();
+    update();
 
-  // Signal
-  nodeScene()->connectionHoverLeft(connectionId());
+    // Signal
+    nodeScene()->connectionHoverLeft(connectionId());
 
-  event->accept();
+    event->accept();
 }
 
-
-std::pair<QPointF, QPointF>
-ConnectionGraphicsObject::
-pointsC1C2() const
+std::pair<QPointF, QPointF> ConnectionGraphicsObject::pointsC1C2() const
 {
-  switch (nodeScene()->orientation())
-  {
+    switch (nodeScene()->orientation()) {
     case Qt::Horizontal:
-      return pointsC1C2Horizontal();
-      break;
+        return pointsC1C2Horizontal();
+        break;
 
     case Qt::Vertical:
-      return pointsC1C2Vertical();
-      break;
-  }
+        return pointsC1C2Vertical();
+        break;
+    }
 }
 
-
-void
-ConnectionGraphicsObject::
-addGraphicsEffect()
+void ConnectionGraphicsObject::addGraphicsEffect()
 {
-  auto effect = new QGraphicsBlurEffect;
+    auto effect = new QGraphicsBlurEffect;
 
-  effect->setBlurRadius(5);
-  setGraphicsEffect(effect);
+    effect->setBlurRadius(5);
+    setGraphicsEffect(effect);
 
-  //auto effect = new QGraphicsDropShadowEffect;
-  //auto effect = new ConnectionBlurEffect(this);
-  //effect->setOffset(4, 4);
-  //effect->setColor(QColor(Qt::gray).darker(800));
+    //auto effect = new QGraphicsDropShadowEffect;
+    //auto effect = new ConnectionBlurEffect(this);
+    //effect->setOffset(4, 4);
+    //effect->setColor(QColor(Qt::gray).darker(800));
 }
 
-
-std::pair<QPointF, QPointF>
-ConnectionGraphicsObject::
-pointsC1C2Horizontal() const
+std::pair<QPointF, QPointF> ConnectionGraphicsObject::pointsC1C2Horizontal() const
 {
-  double const defaultOffset = 200;
+    double const defaultOffset = 200;
 
-  double xDistance = _in.x() - _out.x();
+    double xDistance = _in.x() - _out.x();
 
-  double horizontalOffset = qMin(defaultOffset, std::abs(xDistance));
+    double horizontalOffset = qMin(defaultOffset, std::abs(xDistance));
 
-  double verticalOffset = 0;
+    double verticalOffset = 0;
 
-  double ratioX = 0.5;
+    double ratioX = 0.5;
 
-  if (xDistance <= 0)
-  {
-    double yDistance = _in.y() - _out.y() + 20;
+    if (xDistance <= 0) {
+        double yDistance = _in.y() - _out.y() + 20;
 
-    double vector = yDistance < 0 ? -1.0 : 1.0;
+        double vector = yDistance < 0 ? -1.0 : 1.0;
 
-    verticalOffset = qMin(defaultOffset, std::abs(yDistance)) * vector;
+        verticalOffset = qMin(defaultOffset, std::abs(yDistance)) * vector;
 
-    ratioX = 1.0;
-  }
+        ratioX = 1.0;
+    }
 
-  horizontalOffset *= ratioX;
+    horizontalOffset *= ratioX;
 
-  QPointF c1(_out.x() + horizontalOffset,
-             _out.y() + verticalOffset);
+    QPointF c1(_out.x() + horizontalOffset, _out.y() + verticalOffset);
 
-  QPointF c2(_in.x() - horizontalOffset,
-             _in.y() - verticalOffset);
+    QPointF c2(_in.x() - horizontalOffset, _in.y() - verticalOffset);
 
-  return std::make_pair(c1, c2);
+    return std::make_pair(c1, c2);
 }
 
-
-std::pair<QPointF, QPointF>
-ConnectionGraphicsObject::
-pointsC1C2Vertical() const
+std::pair<QPointF, QPointF> ConnectionGraphicsObject::pointsC1C2Vertical() const
 {
-  double const defaultOffset = 200;
+    double const defaultOffset = 200;
 
-  double yDistance = _in.y() - _out.y();
+    double yDistance = _in.y() - _out.y();
 
-  double verticalOffset = qMin(defaultOffset, std::abs(yDistance));
+    double verticalOffset = qMin(defaultOffset, std::abs(yDistance));
 
-  double horizontalOffset = 0;
+    double horizontalOffset = 0;
 
-  double ratioY = 0.5;
+    double ratioY = 0.5;
 
-  if (yDistance <= 0)
-  {
-    double xDistance = _in.x() - _out.x() + 20;
+    if (yDistance <= 0) {
+        double xDistance = _in.x() - _out.x() + 20;
 
-    double vector = xDistance < 0 ? -1.0 : 1.0;
+        double vector = xDistance < 0 ? -1.0 : 1.0;
 
-    horizontalOffset = qMin(defaultOffset, std::abs(xDistance)) * vector;
+        horizontalOffset = qMin(defaultOffset, std::abs(xDistance)) * vector;
 
-    ratioY = 1.0;
-  }
+        ratioY = 1.0;
+    }
 
-  verticalOffset *= ratioY;
+    verticalOffset *= ratioY;
 
-  QPointF c1(_out.x() + horizontalOffset,
-             _out.y() + verticalOffset);
+    QPointF c1(_out.x() + horizontalOffset, _out.y() + verticalOffset);
 
-  QPointF c2(_in.x() - horizontalOffset,
-             _in.y() - verticalOffset);
+    QPointF c2(_in.x() - horizontalOffset, _in.y() - verticalOffset);
 
-  return std::make_pair(c1, c2);
+    return std::make_pair(c1, c2);
 }
 
-
-}
+} // namespace QtNodes

--- a/src/ConnectionPainter.cpp
+++ b/src/ConnectionPainter.cpp
@@ -9,291 +9,246 @@
 #include "NodeData.hpp"
 #include "StyleCollection.hpp"
 
+namespace QtNodes {
 
-namespace QtNodes
+static QPainterPath cubicPath(ConnectionGraphicsObject const &connection)
 {
+    QPointF const &in = connection.endPoint(PortType::In);
+    QPointF const &out = connection.endPoint(PortType::Out);
 
-static
-QPainterPath
-cubicPath(ConnectionGraphicsObject const &connection)
-{
-  QPointF const &in  = connection.endPoint(PortType::In);
-  QPointF const &out = connection.endPoint(PortType::Out);
+    auto const c1c2 = connection.pointsC1C2();
 
-  auto const c1c2 = connection.pointsC1C2();
+    // cubic spline
+    QPainterPath cubic(out);
 
-  // cubic spline
-  QPainterPath cubic(out);
+    cubic.cubicTo(c1c2.first, c1c2.second, in);
 
-  cubic.cubicTo(c1c2.first, c1c2.second, in);
-
-  return cubic;
+    return cubic;
 }
 
-
-QPainterPath
-ConnectionPainter::
-getPainterStroke(ConnectionGraphicsObject const &connection)
+QPainterPath ConnectionPainter::getPainterStroke(ConnectionGraphicsObject const &connection)
 {
-  auto cubic = cubicPath(connection);
+    auto cubic = cubicPath(connection);
 
-  QPointF const &out = connection.endPoint(PortType::Out);
-  QPainterPath result(out);
+    QPointF const &out = connection.endPoint(PortType::Out);
+    QPainterPath result(out);
 
-  unsigned segments = 20;
+    unsigned segments = 20;
 
-  for (auto i = 0ul; i < segments; ++i)
-  {
-    double ratio = double(i + 1) / segments;
-    result.lineTo(cubic.pointAtPercent(ratio));
-  }
+    for (auto i = 0ul; i < segments; ++i) {
+        double ratio = double(i + 1) / segments;
+        result.lineTo(cubic.pointAtPercent(ratio));
+    }
 
-  QPainterPathStroker stroker; stroker.setWidth(10.0);
+    QPainterPathStroker stroker;
+    stroker.setWidth(10.0);
 
-  return stroker.createStroke(result);
+    return stroker.createStroke(result);
 }
-
 
 #ifdef NODE_DEBUG_DRAWING
-static
-void
-debugDrawing(QPainter * painter,
-             ConnectionGraphicsObject const &cgo)
+static void debugDrawing(QPainter *painter, ConnectionGraphicsObject const &cgo)
 {
-  Q_UNUSED(painter);
+    Q_UNUSED(painter);
 
-  {
-    QPointF const &in  = cgo.endPoint(PortType::In);
-    QPointF const &out = cgo.endPoint(PortType::Out);
+    {
+        QPointF const &in = cgo.endPoint(PortType::In);
+        QPointF const &out = cgo.endPoint(PortType::Out);
 
-    auto const points = cgo.pointsC1C2();
+        auto const points = cgo.pointsC1C2();
 
-    painter->setPen(Qt::red);
-    painter->setBrush(Qt::red);
+        painter->setPen(Qt::red);
+        painter->setBrush(Qt::red);
 
-    painter->drawLine(QLineF(out, points.first));
-    painter->drawLine(QLineF(points.first, points.second));
-    painter->drawLine(QLineF(points.second, in));
-    painter->drawEllipse(points.first,  3, 3);
-    painter->drawEllipse(points.second, 3, 3);
+        painter->drawLine(QLineF(out, points.first));
+        painter->drawLine(QLineF(points.first, points.second));
+        painter->drawLine(QLineF(points.second, in));
+        painter->drawEllipse(points.first, 3, 3);
+        painter->drawEllipse(points.second, 3, 3);
 
-    painter->setBrush(Qt::NoBrush);
-    painter->drawPath(cubicPath(cgo));
-  }
+        painter->setBrush(Qt::NoBrush);
+        painter->drawPath(cubicPath(cgo));
+    }
 
-  {
-    painter->setPen(Qt::yellow);
-    painter->drawRect(cgo.boundingRect());
-  }
+    {
+        painter->setPen(Qt::yellow);
+        painter->drawRect(cgo.boundingRect());
+    }
 }
-
 
 #endif
 
-static
-void
-drawSketchLine(QPainter * painter,
-               ConnectionGraphicsObject const &cgo)
+static void drawSketchLine(QPainter *painter, ConnectionGraphicsObject const &cgo)
 {
-  ConnectionState const &state = cgo.connectionState();
+    ConnectionState const &state = cgo.connectionState();
 
-  if (state.requiresPort())
-  {
-    auto const &connectionStyle =
-      QtNodes::StyleCollection::connectionStyle();
+    if (state.requiresPort()) {
+        auto const &connectionStyle = QtNodes::StyleCollection::connectionStyle();
 
-    QPen pen;
-    pen.setWidth(connectionStyle.constructionLineWidth());
-    pen.setColor(connectionStyle.constructionColor());
-    pen.setStyle(Qt::DashLine);
+        QPen pen;
+        pen.setWidth(connectionStyle.constructionLineWidth());
+        pen.setColor(connectionStyle.constructionColor());
+        pen.setStyle(Qt::DashLine);
 
-    painter->setPen(pen);
-    painter->setBrush(Qt::NoBrush);
+        painter->setPen(pen);
+        painter->setBrush(Qt::NoBrush);
 
-    auto cubic = cubicPath(cgo);
+        auto cubic = cubicPath(cgo);
 
-    // cubic spline
-    painter->drawPath(cubic);
-  }
+        // cubic spline
+        painter->drawPath(cubic);
+    }
 }
 
-
-static
-void
-drawHoveredOrSelected(QPainter * painter,
-                      ConnectionGraphicsObject const &cgo)
+static void drawHoveredOrSelected(QPainter *painter, ConnectionGraphicsObject const &cgo)
 {
-  bool const hovered  = cgo.connectionState().hovered();
-  bool const selected = cgo.isSelected();
+    bool const hovered = cgo.connectionState().hovered();
+    bool const selected = cgo.isSelected();
 
-  // drawn as a fat background
-  if (hovered || selected)
-  {
-    auto const &connectionStyle =
-      QtNodes::StyleCollection::connectionStyle();
+    // drawn as a fat background
+    if (hovered || selected) {
+        auto const &connectionStyle = QtNodes::StyleCollection::connectionStyle();
+
+        double const lineWidth = connectionStyle.lineWidth();
+
+        QPen pen;
+        pen.setWidth(2 * lineWidth);
+        pen.setColor(selected ? connectionStyle.selectedHaloColor()
+                              : connectionStyle.hoveredColor());
+
+        painter->setPen(pen);
+        painter->setBrush(Qt::NoBrush);
+
+        // cubic spline
+        auto const cubic = cubicPath(cgo);
+        painter->drawPath(cubic);
+    }
+}
+
+static void drawNormalLine(QPainter *painter, ConnectionGraphicsObject const &cgo)
+{
+    ConnectionState const &state = cgo.connectionState();
+
+    if (state.requiresPort())
+        return;
+
+    // colors
+
+    auto const &connectionStyle = QtNodes::StyleCollection::connectionStyle();
+
+    QColor normalColorOut = connectionStyle.normalColor();
+    QColor normalColorIn = connectionStyle.normalColor();
+    QColor selectedColor = connectionStyle.selectedColor();
+
+    bool useGradientColor = false;
+
+    AbstractGraphModel const &graphModel = cgo.graphModel();
+
+    if (connectionStyle.useDataDefinedColors()) {
+        using QtNodes::PortType;
+
+        auto const cId = cgo.connectionId();
+
+        auto dataTypeOut = graphModel
+                               .portData(cId.outNodeId,
+                                         PortType::Out,
+                                         cId.outPortIndex,
+                                         PortRole::DataType)
+                               .value<NodeDataType>();
+
+        auto dataTypeIn
+            = graphModel.portData(cId.inNodeId, PortType::In, cId.inPortIndex, PortRole::DataType)
+                  .value<NodeDataType>();
+
+        useGradientColor = (dataTypeOut.id != dataTypeIn.id);
+
+        normalColorOut = connectionStyle.normalColor(dataTypeOut.id);
+        normalColorIn = connectionStyle.normalColor(dataTypeIn.id);
+        selectedColor = normalColorOut.darker(200);
+    }
+
+    // geometry
 
     double const lineWidth = connectionStyle.lineWidth();
 
-    QPen pen;
-    pen.setWidth(2 * lineWidth);
-    pen.setColor(selected ?
-                 connectionStyle.selectedHaloColor() :
-                 connectionStyle.hoveredColor());
+    // draw normal line
+    QPen p;
 
-    painter->setPen(pen);
-    painter->setBrush(Qt::NoBrush);
+    p.setWidth(lineWidth);
 
-    // cubic spline
-    auto const cubic = cubicPath(cgo);
-    painter->drawPath(cubic);
-  }
-}
+    bool const selected = cgo.isSelected();
 
+    auto cubic = cubicPath(cgo);
+    if (useGradientColor) {
+        painter->setBrush(Qt::NoBrush);
 
-static
-void
-drawNormalLine(QPainter * painter,
-               ConnectionGraphicsObject const &cgo)
-{
-  ConnectionState const &state = cgo.connectionState();
-
-  if (state.requiresPort())
-    return;
-
-  // colors
-
-  auto const &connectionStyle =
-    QtNodes::StyleCollection::connectionStyle();
-
-  QColor normalColorOut = connectionStyle.normalColor();
-  QColor normalColorIn  = connectionStyle.normalColor();
-  QColor selectedColor  = connectionStyle.selectedColor();
-
-  bool useGradientColor = false;
-
-  AbstractGraphModel const &graphModel = cgo.graphModel();
-
-  if (connectionStyle.useDataDefinedColors())
-  {
-    using QtNodes::PortType;
-
-    auto const cId = cgo.connectionId();
-
-    auto dataTypeOut =
-      graphModel.portData(cId.outNodeId,
-                          PortType::Out,
-                          cId.outPortIndex,
-                          PortRole::DataType).value<NodeDataType>();
-
-    auto dataTypeIn =
-      graphModel.portData(cId.inNodeId,
-                          PortType::In,
-                          cId.inPortIndex,
-                          PortRole::DataType).value<NodeDataType>();
-
-    useGradientColor = (dataTypeOut.id != dataTypeIn.id);
-
-    normalColorOut = connectionStyle.normalColor(dataTypeOut.id);
-    normalColorIn  = connectionStyle.normalColor(dataTypeIn.id);
-    selectedColor  = normalColorOut.darker(200);
-  }
-
-  // geometry
-
-  double const lineWidth = connectionStyle.lineWidth();
-
-  // draw normal line
-  QPen p;
-
-  p.setWidth(lineWidth);
-
-  bool const selected = cgo.isSelected();
-
-  auto cubic = cubicPath(cgo);
-  if (useGradientColor)
-  {
-    painter->setBrush(Qt::NoBrush);
-
-    QColor cOut = normalColorOut;
-    if (selected)
-      cOut = cOut.darker(200);
-    p.setColor(cOut);
-    painter->setPen(p);
-
-    unsigned int const segments = 60;
-
-    for (unsigned int i = 0ul; i < segments; ++i)
-    {
-      double ratioPrev = double(i) / segments;
-      double ratio     = double(i + 1) / segments;
-
-      if (i == segments / 2)
-      {
-        QColor cIn = normalColorIn;
+        QColor cOut = normalColorOut;
         if (selected)
-          cIn = cIn.darker(200);
-
-        p.setColor(cIn);
+            cOut = cOut.darker(200);
+        p.setColor(cOut);
         painter->setPen(p);
-      }
-      painter->drawLine(cubic.pointAtPercent(ratioPrev),
-                        cubic.pointAtPercent(ratio));
+
+        unsigned int const segments = 60;
+
+        for (unsigned int i = 0ul; i < segments; ++i) {
+            double ratioPrev = double(i) / segments;
+            double ratio = double(i + 1) / segments;
+
+            if (i == segments / 2) {
+                QColor cIn = normalColorIn;
+                if (selected)
+                    cIn = cIn.darker(200);
+
+                p.setColor(cIn);
+                painter->setPen(p);
+            }
+            painter->drawLine(cubic.pointAtPercent(ratioPrev), cubic.pointAtPercent(ratio));
+        }
+
+        {
+            QIcon icon(":convert.png");
+
+            QPixmap pixmap = icon.pixmap(QSize(22, 22));
+            painter->drawPixmap(cubic.pointAtPercent(0.50)
+                                    - QPoint(pixmap.width() / 2, pixmap.height() / 2),
+                                pixmap);
+        }
+    } else {
+        p.setColor(normalColorOut);
+
+        if (selected) {
+            p.setColor(selectedColor);
+        }
+
+        painter->setPen(p);
+        painter->setBrush(Qt::NoBrush);
+
+        painter->drawPath(cubic);
     }
-
-    {
-      QIcon icon(":convert.png");
-
-      QPixmap pixmap = icon.pixmap(QSize(22, 22));
-      painter->drawPixmap(cubic.pointAtPercent(0.50) - QPoint(pixmap.width() / 2,
-                                                              pixmap.height() / 2),
-                          pixmap);
-
-    }
-  }
-  else
-  {
-    p.setColor(normalColorOut);
-
-    if (selected)
-    {
-      p.setColor(selectedColor);
-    }
-
-    painter->setPen(p);
-    painter->setBrush(Qt::NoBrush);
-
-    painter->drawPath(cubic);
-  }
 }
 
-
-void
-ConnectionPainter::
-paint(QPainter * painter,
-      ConnectionGraphicsObject const &cgo)
+void ConnectionPainter::paint(QPainter *painter, ConnectionGraphicsObject const &cgo)
 {
-  drawHoveredOrSelected(painter, cgo);
+    drawHoveredOrSelected(painter, cgo);
 
-  drawSketchLine(painter, cgo);
+    drawSketchLine(painter, cgo);
 
-  drawNormalLine(painter, cgo);
+    drawNormalLine(painter, cgo);
 
 #ifdef NODE_DEBUG_DRAWING
-  debugDrawing(painter, cgo);
+    debugDrawing(painter, cgo);
 #endif
 
-  // draw end points
-  auto const &connectionStyle =
-    QtNodes::StyleCollection::connectionStyle();
+    // draw end points
+    auto const &connectionStyle = QtNodes::StyleCollection::connectionStyle();
 
-  double const pointDiameter = connectionStyle.pointDiameter();
+    double const pointDiameter = connectionStyle.pointDiameter();
 
-  painter->setPen(connectionStyle.constructionColor());
-  painter->setBrush(connectionStyle.constructionColor());
-  double const pointRadius = pointDiameter / 2.0;
-  painter->drawEllipse(cgo.out(), pointRadius, pointRadius);
-  painter->drawEllipse(cgo.in(),   pointRadius, pointRadius);
+    painter->setPen(connectionStyle.constructionColor());
+    painter->setBrush(connectionStyle.constructionColor());
+    double const pointRadius = pointDiameter / 2.0;
+    painter->drawEllipse(cgo.out(), pointRadius, pointRadius);
+    painter->drawEllipse(cgo.in(), pointRadius, pointRadius);
 }
 
-
-}
+} // namespace QtNodes

--- a/src/ConnectionPainter.hpp
+++ b/src/ConnectionPainter.hpp
@@ -5,8 +5,7 @@
 
 #include "Definitions.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class ConnectionGeometry;
 class ConnectionGraphicsObject;
@@ -14,13 +13,9 @@ class ConnectionGraphicsObject;
 class ConnectionPainter
 {
 public:
+    static void paint(QPainter *painter, ConnectionGraphicsObject const &cgo);
 
-  static
-  void paint(QPainter * painter,
-             ConnectionGraphicsObject const & cgo);
-
-  static
-  QPainterPath getPainterStroke(ConnectionGraphicsObject const & cgo);
+    static QPainterPath getPainterStroke(ConnectionGraphicsObject const &cgo);
 };
 
-}
+} // namespace QtNodes

--- a/src/ConnectionState.cpp
+++ b/src/ConnectionState.cpp
@@ -7,90 +7,60 @@
 #include "ConnectionGraphicsObject.hpp"
 #include "NodeGraphicsObject.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
-ConnectionState::
-~ConnectionState()
+ConnectionState::~ConnectionState()
 {
-  //resetLastHoveredNode();
+    //resetLastHoveredNode();
 }
 
-
-PortType
-ConnectionState::
-requiredPort() const
+PortType ConnectionState::requiredPort() const
 {
-  PortType t = PortType::None;
+    PortType t = PortType::None;
 
-  if (_cgo.connectionId().outNodeId == InvalidNodeId)
-  {
-    t = PortType::Out;
-  }
-  else if (_cgo.connectionId().inNodeId == InvalidNodeId)
-  {
-    t = PortType::In;
-  }
+    if (_cgo.connectionId().outNodeId == InvalidNodeId) {
+        t = PortType::Out;
+    } else if (_cgo.connectionId().inNodeId == InvalidNodeId) {
+        t = PortType::In;
+    }
 
-  return t;
+    return t;
 }
 
-
-bool
-ConnectionState::
-requiresPort() const
+bool ConnectionState::requiresPort() const
 {
-  const ConnectionId& id = _cgo.connectionId();
-  return id.outNodeId == InvalidNodeId ||
-         id.inNodeId == InvalidNodeId;
+    const ConnectionId &id = _cgo.connectionId();
+    return id.outNodeId == InvalidNodeId || id.inNodeId == InvalidNodeId;
 }
 
-
-bool
-ConnectionState::
-hovered() const
+bool ConnectionState::hovered() const
 {
-  return _hovered;
+    return _hovered;
 }
 
-
-void
-ConnectionState::
-setHovered(bool hovered)
+void ConnectionState::setHovered(bool hovered)
 {
-  _hovered = hovered;
+    _hovered = hovered;
 }
 
-
-void
-ConnectionState::
-setLastHoveredNode(NodeId const nodeId)
+void ConnectionState::setLastHoveredNode(NodeId const nodeId)
 {
-  _lastHoveredNode = nodeId;
+    _lastHoveredNode = nodeId;
 }
 
-
-NodeId
-ConnectionState::
-lastHoveredNode() const
+NodeId ConnectionState::lastHoveredNode() const
 {
-  return _lastHoveredNode;
+    return _lastHoveredNode;
 }
 
-
-void
-ConnectionState::
-resetLastHoveredNode()
+void ConnectionState::resetLastHoveredNode()
 {
-  if (_lastHoveredNode != InvalidNodeId)
-  {
-    auto ngo =
-      _cgo.nodeScene()->nodeGraphicsObject(_lastHoveredNode);
-    ngo->update();
-  }
+    if (_lastHoveredNode != InvalidNodeId) {
+        auto ngo = _cgo.nodeScene()->nodeGraphicsObject(_lastHoveredNode);
+        ngo->update();
+    }
 
-  _lastHoveredNode = InvalidNodeId;
+    _lastHoveredNode = InvalidNodeId;
 }
 
-
-}
+} // namespace QtNodes

--- a/src/ConnectionStyle.cpp
+++ b/src/ConnectionStyle.cpp
@@ -2,9 +2,9 @@
 
 #include "StyleCollection.hpp"
 
+#include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonValueRef>
-#include <QtCore/QJsonArray>
 
 #include <QDebug>
 
@@ -12,231 +12,194 @@
 
 using QtNodes::ConnectionStyle;
 
-inline void initResources() { Q_INIT_RESOURCE(resources); }
-
-ConnectionStyle::
-ConnectionStyle()
+inline void initResources()
 {
-  // Explicit resources inialization for preventing the static initialization
-  // order fiasco: https://isocpp.org/wiki/faq/ctors#static-init-order
-  initResources();
-
-  // This configuration is stored inside the compiled unit and is loaded statically
-  loadJsonFile(":DefaultStyle.json");
+    Q_INIT_RESOURCE(resources);
 }
 
-
-ConnectionStyle::
-ConnectionStyle(QString jsonText)
+ConnectionStyle::ConnectionStyle()
 {
-  loadJsonFile(":DefaultStyle.json");
-  loadJsonText(jsonText);
+    // Explicit resources inialization for preventing the static initialization
+    // order fiasco: https://isocpp.org/wiki/faq/ctors#static-init-order
+    initResources();
+
+    // This configuration is stored inside the compiled unit and is loaded statically
+    loadJsonFile(":DefaultStyle.json");
 }
 
-
-void
-ConnectionStyle::
-setConnectionStyle(QString jsonText)
+ConnectionStyle::ConnectionStyle(QString jsonText)
 {
-  ConnectionStyle style(jsonText);
-
-  StyleCollection::setConnectionStyle(style);
+    loadJsonFile(":DefaultStyle.json");
+    loadJsonText(jsonText);
 }
 
+void ConnectionStyle::setConnectionStyle(QString jsonText)
+{
+    ConnectionStyle style(jsonText);
+
+    StyleCollection::setConnectionStyle(style);
+}
 
 #ifdef STYLE_DEBUG
-  #define CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(v, variable) { \
-    if (v.type() == QJsonValue::Undefined || \
-        v.type() == QJsonValue::Null) \
-    qWarning() << "Undefined value for parameter:" << #variable; \
-}
+#define CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(v, variable) \
+    { \
+        if (v.type() == QJsonValue::Undefined || v.type() == QJsonValue::Null) \
+            qWarning() << "Undefined value for parameter:" << #variable; \
+    }
 #else
-  #define CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
+#define CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
 #endif
 
-
 #define CONNECTION_VALUE_EXISTS(v) \
-  (v.type() != QJsonValue::Undefined && \
-   v.type() != QJsonValue::Null)
+    (v.type() != QJsonValue::Undefined && v.type() != QJsonValue::Null)
 
-#define CONNECTION_STYLE_READ_COLOR(values, variable)  { \
-    auto valueRef = values[#variable]; \
-    CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    if (CONNECTION_VALUE_EXISTS(valueRef)) { \
-      if (valueRef.isArray()) { \
-        auto colorArray = valueRef.toArray(); \
-        std::vector<int> rgb; rgb.reserve(3); \
-        for (auto it = colorArray.begin(); it != colorArray.end(); ++it) { \
-          rgb.push_back((*it).toInt()); \
+#define CONNECTION_STYLE_READ_COLOR(values, variable) \
+    { \
+        auto valueRef = values[#variable]; \
+        CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+        if (CONNECTION_VALUE_EXISTS(valueRef)) { \
+            if (valueRef.isArray()) { \
+                auto colorArray = valueRef.toArray(); \
+                std::vector<int> rgb; \
+                rgb.reserve(3); \
+                for (auto it = colorArray.begin(); it != colorArray.end(); ++it) { \
+                    rgb.push_back((*it).toInt()); \
+                } \
+                variable = QColor(rgb[0], rgb[1], rgb[2]); \
+            } else { \
+                variable = QColor(valueRef.toString()); \
+            } \
         } \
-        variable = QColor(rgb[0], rgb[1], rgb[2]); \
-      } else { \
-        variable = QColor(valueRef.toString()); \
-      } \
-    } \
-}
+    }
 
-#define CONNECTION_STYLE_WRITE_COLOR(values, variable)  { \
-    values[#variable] = variable.name(); \
-}
+#define CONNECTION_STYLE_WRITE_COLOR(values, variable) \
+    { \
+        values[#variable] = variable.name(); \
+    }
 
-#define CONNECTION_STYLE_READ_FLOAT(values, variable)  { \
-    auto valueRef = values[#variable]; \
-    CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    if (CONNECTION_VALUE_EXISTS(valueRef)) \
-    variable = valueRef.toDouble(); \
-}
+#define CONNECTION_STYLE_READ_FLOAT(values, variable) \
+    { \
+        auto valueRef = values[#variable]; \
+        CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+        if (CONNECTION_VALUE_EXISTS(valueRef)) \
+            variable = valueRef.toDouble(); \
+    }
 
-#define CONNECTION_STYLE_WRITE_FLOAT(values, variable)  { \
-    values[#variable] = variable; \
-}
+#define CONNECTION_STYLE_WRITE_FLOAT(values, variable) \
+    { \
+        values[#variable] = variable; \
+    }
 
-#define CONNECTION_STYLE_READ_BOOL(values, variable)  { \
-    auto valueRef = values[#variable]; \
-    CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    if (CONNECTION_VALUE_EXISTS(valueRef)) \
-    variable = valueRef.toBool(); \
-}
+#define CONNECTION_STYLE_READ_BOOL(values, variable) \
+    { \
+        auto valueRef = values[#variable]; \
+        CONNECTION_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+        if (CONNECTION_VALUE_EXISTS(valueRef)) \
+            variable = valueRef.toBool(); \
+    }
 
-#define CONNECTION_STYLE_WRITE_BOOL(values, variable)  { \
-    values[#variable] = variable; \
-}
+#define CONNECTION_STYLE_WRITE_BOOL(values, variable) \
+    { \
+        values[#variable] = variable; \
+    }
 
-
-void
-ConnectionStyle::
-loadJson(QJsonObject const & json)
+void ConnectionStyle::loadJson(QJsonObject const &json)
 {
-  QJsonValue nodeStyleValues = json["ConnectionStyle"];
+    QJsonValue nodeStyleValues = json["ConnectionStyle"];
 
-  QJsonObject obj = nodeStyleValues.toObject();
+    QJsonObject obj = nodeStyleValues.toObject();
 
-  CONNECTION_STYLE_READ_COLOR(obj, ConstructionColor);
-  CONNECTION_STYLE_READ_COLOR(obj, NormalColor);
-  CONNECTION_STYLE_READ_COLOR(obj, SelectedColor);
-  CONNECTION_STYLE_READ_COLOR(obj, SelectedHaloColor);
-  CONNECTION_STYLE_READ_COLOR(obj, HoveredColor);
+    CONNECTION_STYLE_READ_COLOR(obj, ConstructionColor);
+    CONNECTION_STYLE_READ_COLOR(obj, NormalColor);
+    CONNECTION_STYLE_READ_COLOR(obj, SelectedColor);
+    CONNECTION_STYLE_READ_COLOR(obj, SelectedHaloColor);
+    CONNECTION_STYLE_READ_COLOR(obj, HoveredColor);
 
-  CONNECTION_STYLE_READ_FLOAT(obj, LineWidth);
-  CONNECTION_STYLE_READ_FLOAT(obj, ConstructionLineWidth);
-  CONNECTION_STYLE_READ_FLOAT(obj, PointDiameter);
+    CONNECTION_STYLE_READ_FLOAT(obj, LineWidth);
+    CONNECTION_STYLE_READ_FLOAT(obj, ConstructionLineWidth);
+    CONNECTION_STYLE_READ_FLOAT(obj, PointDiameter);
 
-  CONNECTION_STYLE_READ_BOOL(obj, UseDataDefinedColors);
+    CONNECTION_STYLE_READ_BOOL(obj, UseDataDefinedColors);
 }
 
-
-QJsonObject
-ConnectionStyle::
-toJson() const
+QJsonObject ConnectionStyle::toJson() const
 {
-  QJsonObject obj;
+    QJsonObject obj;
 
-  CONNECTION_STYLE_WRITE_COLOR(obj, ConstructionColor);
-  CONNECTION_STYLE_WRITE_COLOR(obj, NormalColor);
-  CONNECTION_STYLE_WRITE_COLOR(obj, SelectedColor);
-  CONNECTION_STYLE_WRITE_COLOR(obj, SelectedHaloColor);
-  CONNECTION_STYLE_WRITE_COLOR(obj, HoveredColor);
+    CONNECTION_STYLE_WRITE_COLOR(obj, ConstructionColor);
+    CONNECTION_STYLE_WRITE_COLOR(obj, NormalColor);
+    CONNECTION_STYLE_WRITE_COLOR(obj, SelectedColor);
+    CONNECTION_STYLE_WRITE_COLOR(obj, SelectedHaloColor);
+    CONNECTION_STYLE_WRITE_COLOR(obj, HoveredColor);
 
-  CONNECTION_STYLE_WRITE_FLOAT(obj, LineWidth);
-  CONNECTION_STYLE_WRITE_FLOAT(obj, ConstructionLineWidth);
-  CONNECTION_STYLE_WRITE_FLOAT(obj, PointDiameter);
+    CONNECTION_STYLE_WRITE_FLOAT(obj, LineWidth);
+    CONNECTION_STYLE_WRITE_FLOAT(obj, ConstructionLineWidth);
+    CONNECTION_STYLE_WRITE_FLOAT(obj, PointDiameter);
 
-  CONNECTION_STYLE_WRITE_BOOL(obj, UseDataDefinedColors);
+    CONNECTION_STYLE_WRITE_BOOL(obj, UseDataDefinedColors);
 
-  QJsonObject root;
-  root["ConnectionStyle"] = obj;
+    QJsonObject root;
+    root["ConnectionStyle"] = obj;
 
-  return root;
+    return root;
 }
 
-
-QColor
-ConnectionStyle::
-constructionColor() const
+QColor ConnectionStyle::constructionColor() const
 {
-  return ConstructionColor;
+    return ConstructionColor;
 }
 
-
-QColor
-ConnectionStyle::
-normalColor() const
+QColor ConnectionStyle::normalColor() const
 {
-  return NormalColor;
+    return NormalColor;
 }
 
-
-QColor
-ConnectionStyle::
-normalColor(QString typeId) const
+QColor ConnectionStyle::normalColor(QString typeId) const
 {
-  std::size_t hash = qHash(typeId);
+    std::size_t hash = qHash(typeId);
 
-  std::size_t const hue_range = 0xFF;
+    std::size_t const hue_range = 0xFF;
 
-  std::mt19937 gen(static_cast<unsigned int>(hash));
-  std::uniform_int_distribution<int> distrib(0, hue_range);
+    std::mt19937 gen(static_cast<unsigned int>(hash));
+    std::uniform_int_distribution<int> distrib(0, hue_range);
 
-  int hue = distrib(gen);
-  int sat = 120 + hash % 129;
+    int hue = distrib(gen);
+    int sat = 120 + hash % 129;
 
-  return QColor::fromHsl(hue,
-                         sat,
-                         160);
+    return QColor::fromHsl(hue, sat, 160);
 }
 
-
-QColor
-ConnectionStyle::
-selectedColor() const
+QColor ConnectionStyle::selectedColor() const
 {
-  return SelectedColor;
+    return SelectedColor;
 }
 
-
-QColor
-ConnectionStyle::
-selectedHaloColor() const
+QColor ConnectionStyle::selectedHaloColor() const
 {
-  return SelectedHaloColor;
+    return SelectedHaloColor;
 }
 
-
-QColor
-ConnectionStyle::
-hoveredColor() const
+QColor ConnectionStyle::hoveredColor() const
 {
-  return HoveredColor;
+    return HoveredColor;
 }
 
-
-float
-ConnectionStyle::
-lineWidth() const
+float ConnectionStyle::lineWidth() const
 {
-  return LineWidth;
+    return LineWidth;
 }
 
-
-float
-ConnectionStyle::
-constructionLineWidth() const
+float ConnectionStyle::constructionLineWidth() const
 {
-  return ConstructionLineWidth;
+    return ConstructionLineWidth;
 }
 
-
-float
-ConnectionStyle::
-pointDiameter() const
+float ConnectionStyle::pointDiameter() const
 {
-  return PointDiameter;
+    return PointDiameter;
 }
 
-
-bool
-ConnectionStyle::
-useDataDefinedColors() const
+bool ConnectionStyle::useDataDefinedColors() const
 {
-  return UseDataDefinedColors;
+    return UseDataDefinedColors;
 }

--- a/src/DataFlowGraphModel.cpp
+++ b/src/DataFlowGraphModel.cpp
@@ -3,631 +3,497 @@
 
 #include <QJsonArray>
 
-namespace QtNodes
-{
+namespace QtNodes {
 
-
-DataFlowGraphModel::
-DataFlowGraphModel(std::shared_ptr<NodeDelegateModelRegistry> registry)
-  : _registry(std::move(registry))
-  , _nextNodeId{0}
+DataFlowGraphModel::DataFlowGraphModel(std::shared_ptr<NodeDelegateModelRegistry> registry)
+    : _registry(std::move(registry))
+    , _nextNodeId{0}
 {}
 
-
-std::unordered_set<NodeId>
-DataFlowGraphModel::
-allNodeIds() const
+std::unordered_set<NodeId> DataFlowGraphModel::allNodeIds() const
 {
-  std::unordered_set<NodeId> nodeIds;
-  for_each(_models.begin(), _models.end(),
-           [&nodeIds](auto const& p)
-           {
-             nodeIds.insert(p.first);
+    std::unordered_set<NodeId> nodeIds;
+    for_each(_models.begin(), _models.end(), [&nodeIds](auto const &p) { nodeIds.insert(p.first); });
 
-           });
-
-  return nodeIds;
+    return nodeIds;
 }
 
-
-std::unordered_set<ConnectionId>
-DataFlowGraphModel::
-allConnectionIds(NodeId const nodeId) const
+std::unordered_set<ConnectionId> DataFlowGraphModel::allConnectionIds(NodeId const nodeId) const
 {
-  std::unordered_set<ConnectionId> result;
+    std::unordered_set<ConnectionId> result;
 
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&nodeId](ConnectionId const & cid)
-               {
-                  return cid.inNodeId == nodeId ||
-                         cid.outNodeId == nodeId;
-               });
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&nodeId](ConnectionId const &cid) {
+                     return cid.inNodeId == nodeId || cid.outNodeId == nodeId;
+                 });
 
-  return result;
-}
-
-
-std::unordered_set<ConnectionId>
-DataFlowGraphModel::
-connections(NodeId    nodeId,
-            PortType  portType,
-            PortIndex portIndex) const
-{
-  std::unordered_set<ConnectionId> result;
-
-  std::copy_if(_connectivity.begin(),
-               _connectivity.end(),
-               std::inserter(result, std::end(result)),
-               [&portType, &portIndex, &nodeId](ConnectionId const & cid)
-               {
-                  return (getNodeId(portType, cid) == nodeId &&
-                          getPortIndex(portType, cid) == portIndex);
-               });
-
-  return result;
-}
-
-
-bool
-DataFlowGraphModel::
-connectionExists(ConnectionId const connectionId) const
-{
-  return (_connectivity.find(connectionId) != _connectivity.end());
-}
-
-
-NodeId
-DataFlowGraphModel::
-addNode(QString const nodeType)
-{
-  std::unique_ptr<NodeDelegateModel> model = _registry->create(nodeType);
-
-  if (model)
-  {
-    NodeId newId = newNodeId();
-
-    connect(model.get(), &NodeDelegateModel::dataUpdated,
-            [newId, this](PortIndex const portIndex)
-            { onOutPortDataUpdated(newId, portIndex); });
-
-    connect(model.get(),
-            &NodeDelegateModel::portsAboutToBeDeleted,
-            this,
-            [newId, this](PortType const portType,
-                          PortIndex const first,
-                          PortIndex const last)
-            { portsAboutToBeDeleted(newId, portType, first, last);});
-
-    connect(model.get(),
-            &NodeDelegateModel::portsDeleted,
-            this,
-            &DataFlowGraphModel::portsDeleted);
-
-    connect(model.get(),
-            &NodeDelegateModel::portsAboutToBeInserted,
-            this,
-            [newId, this](PortType const portType,
-                          PortIndex const first,
-                          PortIndex const last)
-            { portsAboutToBeInserted(newId, portType, first, last);});
-
-    connect(model.get(),
-            &NodeDelegateModel::portsInserted,
-            this,
-            &DataFlowGraphModel::portsInserted);
-
-
-    _models[newId] = std::move(model);
-
-    Q_EMIT nodeCreated(newId);
-
-    return newId;
-  }
-
-  return InvalidNodeId;
-}
-
-
-bool
-DataFlowGraphModel::
-connectionPossible(ConnectionId const connectionId) const
-{
-  auto getDataType =
-    [&](PortType const portType)
-    {
-      return portData(getNodeId(portType, connectionId),
-                      portType,
-                      getPortIndex(portType, connectionId),
-                      PortRole::DataType).value<NodeDataType>();
-
-    };
-
-  auto portVacant =
-    [&](PortType const portType)
-    {
-      NodeId const nodeId = getNodeId(portType, connectionId);
-      PortIndex const portIndex = getPortIndex(portType, connectionId);
-      auto const connected = connections(nodeId, portType, portIndex);
-
-      auto policy = portData(nodeId,
-                             portType,
-                             portIndex,
-                             PortRole::ConnectionPolicyRole).value<ConnectionPolicy>();
-
-      return connected.empty() || (policy == ConnectionPolicy::Many);
-    };
-
-  return getDataType(PortType::Out).id == getDataType(PortType::In).id &&
-         portVacant(PortType::Out) && portVacant(PortType::In);
-}
-
-
-void
-DataFlowGraphModel::
-addConnection(ConnectionId const connectionId)
-{
-  _connectivity.insert(connectionId);
-
-  Q_EMIT connectionCreated(connectionId);
-
-  QVariant const portDataToPropagate = portData(connectionId.outNodeId,
-                                                PortType::Out,
-                                                connectionId.outPortIndex,
-                                                PortRole::Data);
-
-  setPortData(connectionId.inNodeId,
-              PortType::In,
-              connectionId.inPortIndex,
-              portDataToPropagate,
-              PortRole::Data);
-}
-
-
-bool
-DataFlowGraphModel::
-nodeExists(NodeId const nodeId) const
-{
-  return (_models.find(nodeId) != _models.end());
-}
-
-
-QVariant
-DataFlowGraphModel::
-nodeData(NodeId nodeId, NodeRole role) const
-{
-  QVariant result;
-
-  auto it = _models.find(nodeId);
-  if (it == _models.end())
     return result;
+}
 
-  auto& model = it->second;
+std::unordered_set<ConnectionId> DataFlowGraphModel::connections(NodeId nodeId,
+                                                                 PortType portType,
+                                                                 PortIndex portIndex) const
+{
+    std::unordered_set<ConnectionId> result;
 
-  switch (role)
-  {
+    std::copy_if(_connectivity.begin(),
+                 _connectivity.end(),
+                 std::inserter(result, std::end(result)),
+                 [&portType, &portIndex, &nodeId](ConnectionId const &cid) {
+                     return (getNodeId(portType, cid) == nodeId
+                             && getPortIndex(portType, cid) == portIndex);
+                 });
+
+    return result;
+}
+
+bool DataFlowGraphModel::connectionExists(ConnectionId const connectionId) const
+{
+    return (_connectivity.find(connectionId) != _connectivity.end());
+}
+
+NodeId DataFlowGraphModel::addNode(QString const nodeType)
+{
+    std::unique_ptr<NodeDelegateModel> model = _registry->create(nodeType);
+
+    if (model) {
+        NodeId newId = newNodeId();
+
+        connect(model.get(),
+                &NodeDelegateModel::dataUpdated,
+                [newId, this](PortIndex const portIndex) {
+                    onOutPortDataUpdated(newId, portIndex);
+                });
+
+        connect(model.get(),
+                &NodeDelegateModel::portsAboutToBeDeleted,
+                this,
+                [newId, this](PortType const portType, PortIndex const first, PortIndex const last) {
+                    portsAboutToBeDeleted(newId, portType, first, last);
+                });
+
+        connect(model.get(),
+                &NodeDelegateModel::portsDeleted,
+                this,
+                &DataFlowGraphModel::portsDeleted);
+
+        connect(model.get(),
+                &NodeDelegateModel::portsAboutToBeInserted,
+                this,
+                [newId, this](PortType const portType, PortIndex const first, PortIndex const last) {
+                    portsAboutToBeInserted(newId, portType, first, last);
+                });
+
+        connect(model.get(),
+                &NodeDelegateModel::portsInserted,
+                this,
+                &DataFlowGraphModel::portsInserted);
+
+        _models[newId] = std::move(model);
+
+        Q_EMIT nodeCreated(newId);
+
+        return newId;
+    }
+
+    return InvalidNodeId;
+}
+
+bool DataFlowGraphModel::connectionPossible(ConnectionId const connectionId) const
+{
+    auto getDataType = [&](PortType const portType) {
+        return portData(getNodeId(portType, connectionId),
+                        portType,
+                        getPortIndex(portType, connectionId),
+                        PortRole::DataType)
+            .value<NodeDataType>();
+    };
+
+    auto portVacant = [&](PortType const portType) {
+        NodeId const nodeId = getNodeId(portType, connectionId);
+        PortIndex const portIndex = getPortIndex(portType, connectionId);
+        auto const connected = connections(nodeId, portType, portIndex);
+
+        auto policy = portData(nodeId, portType, portIndex, PortRole::ConnectionPolicyRole)
+                          .value<ConnectionPolicy>();
+
+        return connected.empty() || (policy == ConnectionPolicy::Many);
+    };
+
+    return getDataType(PortType::Out).id == getDataType(PortType::In).id
+           && portVacant(PortType::Out) && portVacant(PortType::In);
+}
+
+void DataFlowGraphModel::addConnection(ConnectionId const connectionId)
+{
+    _connectivity.insert(connectionId);
+
+    Q_EMIT connectionCreated(connectionId);
+
+    QVariant const portDataToPropagate = portData(connectionId.outNodeId,
+                                                  PortType::Out,
+                                                  connectionId.outPortIndex,
+                                                  PortRole::Data);
+
+    setPortData(connectionId.inNodeId,
+                PortType::In,
+                connectionId.inPortIndex,
+                portDataToPropagate,
+                PortRole::Data);
+}
+
+bool DataFlowGraphModel::nodeExists(NodeId const nodeId) const
+{
+    return (_models.find(nodeId) != _models.end());
+}
+
+QVariant DataFlowGraphModel::nodeData(NodeId nodeId, NodeRole role) const
+{
+    QVariant result;
+
+    auto it = _models.find(nodeId);
+    if (it == _models.end())
+        return result;
+
+    auto &model = it->second;
+
+    switch (role) {
     case NodeRole::Type:
-      result = model->name();
-      break;
+        result = model->name();
+        break;
 
     case NodeRole::Position:
-      result = _nodeGeometryData[nodeId].pos;
-      break;
+        result = _nodeGeometryData[nodeId].pos;
+        break;
 
     case NodeRole::Size:
-      result = _nodeGeometryData[nodeId].size;
-      break;
+        result = _nodeGeometryData[nodeId].size;
+        break;
 
     case NodeRole::CaptionVisible:
-      result = model->captionVisible();
-      break;
+        result = model->captionVisible();
+        break;
 
     case NodeRole::Caption:
-      result = model->caption();
-      break;
+        result = model->caption();
+        break;
 
-    case NodeRole::Style:
-    {
-      auto style = StyleCollection::nodeStyle();
-      result = style.toJson().toVariantMap();
-    }
-    break;
+    case NodeRole::Style: {
+        auto style = StyleCollection::nodeStyle();
+        result = style.toJson().toVariantMap();
+    } break;
 
-    case NodeRole::InternalData:
-    {
-      QJsonObject nodeJson;
+    case NodeRole::InternalData: {
+        QJsonObject nodeJson;
 
-      nodeJson["internal-data"] = _models.at(nodeId)->save();
+        nodeJson["internal-data"] = _models.at(nodeId)->save();
 
-      result = nodeJson.toVariantMap();
-      break;
+        result = nodeJson.toVariantMap();
+        break;
     }
 
     case NodeRole::InPortCount:
-      result = model->nPorts(PortType::In);
-      break;
+        result = model->nPorts(PortType::In);
+        break;
 
     case NodeRole::OutPortCount:
-      result = model->nPorts(PortType::Out);
-      break;
+        result = model->nPorts(PortType::Out);
+        break;
 
-    case NodeRole::Widget:
-    {
-      auto w = model->embeddedWidget();
-      result = QVariant::fromValue(w);
+    case NodeRole::Widget: {
+        auto w = model->embeddedWidget();
+        result = QVariant::fromValue(w);
+    } break;
     }
-    break;
-  }
 
-  return result;
+    return result;
 }
 
-
-NodeFlags
-DataFlowGraphModel::
-nodeFlags(NodeId nodeId) const
+NodeFlags DataFlowGraphModel::nodeFlags(NodeId nodeId) const
 {
-  auto it = _models.find(nodeId);
+    auto it = _models.find(nodeId);
 
-  if (it != _models.end() && it->second->resizable())
-    return NodeFlag::Resizable;
+    if (it != _models.end() && it->second->resizable())
+        return NodeFlag::Resizable;
 
-  return NodeFlag::NoFlags;
+    return NodeFlag::NoFlags;
 }
 
-
-bool
-DataFlowGraphModel::
-setNodeData(NodeId   nodeId,
-            NodeRole role,
-            QVariant value)
+bool DataFlowGraphModel::setNodeData(NodeId nodeId, NodeRole role, QVariant value)
 {
-  Q_UNUSED(nodeId);
-  Q_UNUSED(role);
-  Q_UNUSED(value);
+    Q_UNUSED(nodeId);
+    Q_UNUSED(role);
+    Q_UNUSED(value);
 
-  bool result = false;
+    bool result = false;
 
-  switch (role)
-  {
+    switch (role) {
     case NodeRole::Type:
-      break;
-    case NodeRole::Position:
-    {
-      _nodeGeometryData[nodeId].pos = value.value<QPointF>();
+        break;
+    case NodeRole::Position: {
+        _nodeGeometryData[nodeId].pos = value.value<QPointF>();
 
-      Q_EMIT nodePositionUpdated(nodeId);
+        Q_EMIT nodePositionUpdated(nodeId);
 
-      result = true;
-    }
-    break;
+        result = true;
+    } break;
 
-    case NodeRole::Size:
-    {
-      _nodeGeometryData[nodeId].size = value.value<QSize>();
-      result = true;
-    }
-    break;
+    case NodeRole::Size: {
+        _nodeGeometryData[nodeId].size = value.value<QSize>();
+        result = true;
+    } break;
 
     case NodeRole::CaptionVisible:
-      break;
+        break;
 
     case NodeRole::Caption:
-      break;
+        break;
 
     case NodeRole::Style:
-      break;
+        break;
 
     case NodeRole::InternalData:
-      break;
+        break;
 
     case NodeRole::InPortCount:
-      break;
+        break;
 
     case NodeRole::OutPortCount:
-      break;
+        break;
 
     case NodeRole::Widget:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-QVariant
-DataFlowGraphModel::
-portData(NodeId    nodeId,
-         PortType  portType,
-         PortIndex portIndex,
-         PortRole  role) const
+QVariant DataFlowGraphModel::portData(NodeId nodeId,
+                                      PortType portType,
+                                      PortIndex portIndex,
+                                      PortRole role) const
 {
-  QVariant result;
+    QVariant result;
 
-  auto it = _models.find(nodeId);
-  if (it == _models.end())
-    return result;
+    auto it = _models.find(nodeId);
+    if (it == _models.end())
+        return result;
 
-  auto& model = it->second;
+    auto &model = it->second;
 
-  switch (role)
-  {
+    switch (role) {
     case PortRole::Data:
-      if (portType == PortType::Out)
-        result = QVariant::fromValue(model->outData(portIndex));
-      break;
+        if (portType == PortType::Out)
+            result = QVariant::fromValue(model->outData(portIndex));
+        break;
 
     case PortRole::DataType:
-      result = QVariant::fromValue(model->dataType(portType, portIndex));
-      break;
+        result = QVariant::fromValue(model->dataType(portType, portIndex));
+        break;
 
     case PortRole::ConnectionPolicyRole:
-      result =
-        QVariant::fromValue(model->portConnectionPolicy(portType,
-                                                        portIndex));
-      break;
+        result = QVariant::fromValue(model->portConnectionPolicy(portType, portIndex));
+        break;
 
     case PortRole::CaptionVisible:
-      result = model->portCaptionVisible(portType, portIndex);
-      break;
+        result = model->portCaptionVisible(portType, portIndex);
+        break;
 
     case PortRole::Caption:
-      result = model->portCaption(portType, portIndex);
+        result = model->portCaption(portType, portIndex);
 
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-bool
-DataFlowGraphModel::
-setPortData(NodeId          nodeId,
-            PortType        portType,
-            PortIndex       portIndex,
-            QVariant const& value,
-            PortRole        role)
+bool DataFlowGraphModel::setPortData(
+    NodeId nodeId, PortType portType, PortIndex portIndex, QVariant const &value, PortRole role)
 {
-  Q_UNUSED(nodeId);
+    Q_UNUSED(nodeId);
 
+    QVariant result;
 
-  QVariant result;
+    auto it = _models.find(nodeId);
+    if (it == _models.end())
+        return false;
 
-  auto it = _models.find(nodeId);
-  if (it == _models.end())
-    return false;
+    auto &model = it->second;
 
-  auto& model = it->second;
-
-  switch (role)
-  {
+    switch (role) {
     case PortRole::Data:
-      if (portType == PortType::In)
-      {
-        model->setInData(value.value<std::shared_ptr<NodeData>>(),
-                         portIndex);
+        if (portType == PortType::In) {
+            model->setInData(value.value<std::shared_ptr<NodeData>>(), portIndex);
 
-        // Triggers repainting on the scene.
-        Q_EMIT inPortDataWasSet(nodeId,
-                                portType,
-                                portIndex);
-      }
-      break;
+            // Triggers repainting on the scene.
+            Q_EMIT inPortDataWasSet(nodeId, portType, portIndex);
+        }
+        break;
 
     default:
-      break;
-  }
+        break;
+    }
 
-
-  return false;
+    return false;
 }
 
-
-bool
-DataFlowGraphModel::
-deleteConnection(ConnectionId const connectionId)
+bool DataFlowGraphModel::deleteConnection(ConnectionId const connectionId)
 {
-  bool disconnected = false;
+    bool disconnected = false;
 
-  auto it = _connectivity.find(connectionId);
+    auto it = _connectivity.find(connectionId);
 
-  if (it != _connectivity.end())
-  {
-    disconnected = true;
+    if (it != _connectivity.end()) {
+        disconnected = true;
 
-    _connectivity.erase(it);
-  }
+        _connectivity.erase(it);
+    }
 
-  if (disconnected)
-  {
-    Q_EMIT connectionDeleted(connectionId);
+    if (disconnected) {
+        Q_EMIT connectionDeleted(connectionId);
 
-    propagateEmptyDataTo(getNodeId(PortType::In, connectionId),
-                         getPortIndex(PortType::In, connectionId));
+        propagateEmptyDataTo(getNodeId(PortType::In, connectionId),
+                             getPortIndex(PortType::In, connectionId));
+    }
 
-  }
-
-  return disconnected;
+    return disconnected;
 }
 
-
-bool
-DataFlowGraphModel::
-deleteNode(NodeId const nodeId)
+bool DataFlowGraphModel::deleteNode(NodeId const nodeId)
 {
-  // Delete connections to this node first.
-  auto connectionIds = allConnectionIds(nodeId);
-  for (auto& cId : connectionIds)
-  {
-    deleteConnection(cId);
-  }
+    // Delete connections to this node first.
+    auto connectionIds = allConnectionIds(nodeId);
+    for (auto &cId : connectionIds) {
+        deleteConnection(cId);
+    }
 
-  _nodeGeometryData.erase(nodeId);
-  _models.erase(nodeId);
+    _nodeGeometryData.erase(nodeId);
+    _models.erase(nodeId);
 
-  Q_EMIT nodeDeleted(nodeId);
+    Q_EMIT nodeDeleted(nodeId);
 
-  return true;
+    return true;
 }
 
-
-QJsonObject
-DataFlowGraphModel::
-saveNode(NodeId const nodeId) const
+QJsonObject DataFlowGraphModel::saveNode(NodeId const nodeId) const
 {
-  QJsonObject nodeJson;
+    QJsonObject nodeJson;
 
-  nodeJson["id"] = static_cast<qint64>(nodeId);
+    nodeJson["id"] = static_cast<qint64>(nodeId);
 
-  nodeJson["internal-data"] = _models.at(nodeId)->save();
+    nodeJson["internal-data"] = _models.at(nodeId)->save();
 
-  {
-    QPointF const pos =
-      nodeData(nodeId, NodeRole::Position).value<QPointF>();
+    {
+        QPointF const pos = nodeData(nodeId, NodeRole::Position).value<QPointF>();
 
-    QJsonObject posJson;
-    posJson["x"] = pos.x();
-    posJson["y"] = pos.y();
-    nodeJson["position"] = posJson;
-  }
+        QJsonObject posJson;
+        posJson["x"] = pos.x();
+        posJson["y"] = pos.y();
+        nodeJson["position"] = posJson;
+    }
 
-  return nodeJson;
+    return nodeJson;
 }
 
-
-QJsonObject
-DataFlowGraphModel::
-save() const
+QJsonObject DataFlowGraphModel::save() const
 {
-  QJsonObject sceneJson;
+    QJsonObject sceneJson;
 
-  QJsonArray nodesJsonArray;
-  for (auto const nodeId : allNodeIds())
-  {
-    nodesJsonArray.append(saveNode(nodeId));
-  }
-  sceneJson["nodes"] = nodesJsonArray;
+    QJsonArray nodesJsonArray;
+    for (auto const nodeId : allNodeIds()) {
+        nodesJsonArray.append(saveNode(nodeId));
+    }
+    sceneJson["nodes"] = nodesJsonArray;
 
+    QJsonArray connJsonArray;
+    for (auto const &cid : _connectivity) {
+        connJsonArray.append(toJson(cid));
+    }
+    sceneJson["connections"] = connJsonArray;
 
-  QJsonArray connJsonArray;
-  for (auto const & cid : _connectivity)
-  {
-    connJsonArray.append(toJson(cid));
-  }
-  sceneJson["connections"] = connJsonArray;
-
-  return sceneJson;
+    return sceneJson;
 }
 
-
-void
-DataFlowGraphModel::
-loadNode(QJsonObject const & nodeJson)
+void DataFlowGraphModel::loadNode(QJsonObject const &nodeJson)
 {
-  // Possibility of the id clash when reading it from json and not generating a
-  // new value.
-  // 1. When restoring a scene from a file.
-  // Conflict is not possible because the scene must be cleared by the time of
-  // loading.
-  // 2. When undoing the deletion command.  Conflict is not possible
-  // because all the new ids were created past the removed nodes.
-  NodeId restoredNodeId = nodeJson["id"].toInt();
+    // Possibility of the id clash when reading it from json and not generating a
+    // new value.
+    // 1. When restoring a scene from a file.
+    // Conflict is not possible because the scene must be cleared by the time of
+    // loading.
+    // 2. When undoing the deletion command.  Conflict is not possible
+    // because all the new ids were created past the removed nodes.
+    NodeId restoredNodeId = nodeJson["id"].toInt();
 
-  _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
+    _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
 
+    QJsonObject const internalDataJson = nodeJson["internal-data"].toObject();
 
-  QJsonObject const internalDataJson = nodeJson["internal-data"].toObject();
+    QString delegateModelName = internalDataJson["model-name"].toString();
 
-  QString delegateModelName = internalDataJson["model-name"].toString();
+    std::unique_ptr<NodeDelegateModel> model = _registry->create(delegateModelName);
 
-  std::unique_ptr<NodeDelegateModel> model = _registry->create(delegateModelName);
+    if (model) {
+        connect(model.get(),
+                &NodeDelegateModel::dataUpdated,
+                [restoredNodeId, this](PortIndex const portIndex) {
+                    onOutPortDataUpdated(restoredNodeId, portIndex);
+                });
 
-  if (model)
-  {
-    connect(model.get(), &NodeDelegateModel::dataUpdated,
-            [restoredNodeId, this](PortIndex const portIndex)
-            { onOutPortDataUpdated(restoredNodeId, portIndex); });
+        _models[restoredNodeId] = std::move(model);
 
-    _models[restoredNodeId] = std::move(model);
+        Q_EMIT nodeCreated(restoredNodeId);
 
-    Q_EMIT nodeCreated(restoredNodeId);
+        QJsonObject posJson = nodeJson["position"].toObject();
+        QPointF const pos(posJson["x"].toDouble(), posJson["y"].toDouble());
 
-    QJsonObject posJson = nodeJson["position"].toObject();
-    QPointF const pos(posJson["x"].toDouble(),
-                      posJson["y"].toDouble());
+        setNodeData(restoredNodeId, NodeRole::Position, pos);
 
-    setNodeData(restoredNodeId,
-                NodeRole::Position,
-                pos);
-
-    _models[restoredNodeId]->load(internalDataJson);
-  }
+        _models[restoredNodeId]->load(internalDataJson);
+    }
 }
 
-
-void
-DataFlowGraphModel::
-load(QJsonObject const &jsonDocument)
+void DataFlowGraphModel::load(QJsonObject const &jsonDocument)
 {
-  QJsonArray nodesJsonArray = jsonDocument["nodes"].toArray();
+    QJsonArray nodesJsonArray = jsonDocument["nodes"].toArray();
 
-  for (QJsonValueRef nodeJson : nodesJsonArray)
-  {
-    loadNode(nodeJson.toObject());
-  }
+    for (QJsonValueRef nodeJson : nodesJsonArray) {
+        loadNode(nodeJson.toObject());
+    }
 
-  QJsonArray connectionJsonArray = jsonDocument["connections"].toArray();
+    QJsonArray connectionJsonArray = jsonDocument["connections"].toArray();
 
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
+    for (QJsonValueRef connection : connectionJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-    ConnectionId connId = fromJson(connJson);
+        ConnectionId connId = fromJson(connJson);
 
-    // Restore the connection
-    addConnection(connId);
-  }
+        // Restore the connection
+        addConnection(connId);
+    }
 }
 
-
-
-void
-DataFlowGraphModel::
-onOutPortDataUpdated(NodeId const    nodeId,
-                     PortIndex const portIndex)
+void DataFlowGraphModel::onOutPortDataUpdated(NodeId const nodeId, PortIndex const portIndex)
 {
-  std::unordered_set<ConnectionId> const& connected =
-    connections(nodeId, PortType::Out, portIndex);
+    std::unordered_set<ConnectionId> const &connected = connections(nodeId,
+                                                                    PortType::Out,
+                                                                    portIndex);
 
-  QVariant const portDataToPropagate =
-    portData(nodeId, PortType::Out, portIndex, PortRole::Data);
+    QVariant const portDataToPropagate = portData(nodeId, PortType::Out, portIndex, PortRole::Data);
 
-  for (auto const& cn : connected)
-  {
-    setPortData(cn.inNodeId, PortType::In,
-                cn.inPortIndex, portDataToPropagate,
-                PortRole::Data);
-
-  }
+    for (auto const &cn : connected) {
+        setPortData(cn.inNodeId, PortType::In, cn.inPortIndex, portDataToPropagate, PortRole::Data);
+    }
 }
 
-
-void
-DataFlowGraphModel::
-propagateEmptyDataTo(NodeId const    nodeId,
-                     PortIndex const portIndex)
+void DataFlowGraphModel::propagateEmptyDataTo(NodeId const nodeId, PortIndex const portIndex)
 {
-  QVariant emptyData{};
+    QVariant emptyData{};
 
-  setPortData(nodeId,
-              PortType::In,
-              portIndex,
-              emptyData,
-              PortRole::Data);
+    setPortData(nodeId, PortType::In, portIndex, emptyData, PortRole::Data);
 }
 
-
-}
-
+} // namespace QtNodes

--- a/src/DataFlowGraphicsScene.cpp
+++ b/src/DataFlowGraphicsScene.cpp
@@ -25,198 +25,159 @@
 #include <stdexcept>
 #include <utility>
 
+namespace QtNodes {
 
-namespace QtNodes
+DataFlowGraphicsScene::DataFlowGraphicsScene(DataFlowGraphModel &graphModel, QObject *parent)
+    : BasicGraphicsScene(graphModel, parent)
+    , _graphModel(graphModel)
 {
-
-
-DataFlowGraphicsScene::
-DataFlowGraphicsScene(DataFlowGraphModel& graphModel,
-                      QObject*            parent)
-  : BasicGraphicsScene(graphModel, parent)
-  , _graphModel(graphModel)
-{
-  connect(&_graphModel, &DataFlowGraphModel::inPortDataWasSet,
-          [this](NodeId const nodeId, PortType const, PortIndex const)
-          {
-            onNodeUpdated(nodeId);
-          });
+    connect(&_graphModel,
+            &DataFlowGraphModel::inPortDataWasSet,
+            [this](NodeId const nodeId, PortType const, PortIndex const) { onNodeUpdated(nodeId); });
 }
-
 
 // TODO constructor for an empyt scene?
 
-
-std::vector<NodeId>
-DataFlowGraphicsScene::
-selectedNodes() const
+std::vector<NodeId> DataFlowGraphicsScene::selectedNodes() const
 {
-  QList<QGraphicsItem*> graphicsItems = selectedItems();
+    QList<QGraphicsItem *> graphicsItems = selectedItems();
 
-  std::vector<NodeId> result;
-  result.reserve(graphicsItems.size());
+    std::vector<NodeId> result;
+    result.reserve(graphicsItems.size());
 
-  for (QGraphicsItem* item : graphicsItems)
-  {
-    auto ngo = qgraphicsitem_cast<NodeGraphicsObject*>(item);
+    for (QGraphicsItem *item : graphicsItems) {
+        auto ngo = qgraphicsitem_cast<NodeGraphicsObject *>(item);
 
-    if (ngo != nullptr)
-    {
-      result.push_back(ngo->nodeId());
+        if (ngo != nullptr) {
+            result.push_back(ngo->nodeId());
+        }
     }
-  }
 
-  return result;
+    return result;
 }
 
-
-QMenu*
-DataFlowGraphicsScene::
-createSceneMenu(QPointF const scenePos)
+QMenu *DataFlowGraphicsScene::createSceneMenu(QPointF const scenePos)
 {
-  QMenu* modelMenu = new QMenu();
+    QMenu *modelMenu = new QMenu();
 
-  // Add filterbox to the context menu
-  auto* txtBox = new QLineEdit(modelMenu);
-  txtBox->setPlaceholderText(QStringLiteral("Filter"));
-  txtBox->setClearButtonEnabled(true);
+    // Add filterbox to the context menu
+    auto *txtBox = new QLineEdit(modelMenu);
+    txtBox->setPlaceholderText(QStringLiteral("Filter"));
+    txtBox->setClearButtonEnabled(true);
 
-  auto* txtBoxAction = new QWidgetAction(modelMenu);
-  txtBoxAction->setDefaultWidget(txtBox);
+    auto *txtBoxAction = new QWidgetAction(modelMenu);
+    txtBoxAction->setDefaultWidget(txtBox);
 
-  // 1.
-  modelMenu->addAction(txtBoxAction);
+    // 1.
+    modelMenu->addAction(txtBoxAction);
 
-  // Add result treeview to the context menu
-  QTreeWidget* treeView = new QTreeWidget(modelMenu);
-  treeView->header()->close();
+    // Add result treeview to the context menu
+    QTreeWidget *treeView = new QTreeWidget(modelMenu);
+    treeView->header()->close();
 
-  auto* treeViewAction = new QWidgetAction(modelMenu);
-  treeViewAction->setDefaultWidget(treeView);
+    auto *treeViewAction = new QWidgetAction(modelMenu);
+    treeViewAction->setDefaultWidget(treeView);
 
-  // 2.
-  modelMenu->addAction(treeViewAction);
+    // 2.
+    modelMenu->addAction(treeViewAction);
 
-  auto registry = _graphModel.dataModelRegistry();
+    auto registry = _graphModel.dataModelRegistry();
 
-  for (auto const& cat : registry->categories())
-  {
-    auto item = new QTreeWidgetItem(treeView);
-    item->setText(0, cat);
-    item->setFlags(item->flags() & ~Qt::ItemIsSelectable);
-  }
+    for (auto const &cat : registry->categories()) {
+        auto item = new QTreeWidgetItem(treeView);
+        item->setText(0, cat);
+        item->setFlags(item->flags() & ~Qt::ItemIsSelectable);
+    }
 
-  for (auto const& assoc : registry->registeredModelsCategoryAssociation())
-  {
-    QList<QTreeWidgetItem*> parent = treeView->findItems(assoc.second, 
-                                                         Qt::MatchExactly);
+    for (auto const &assoc : registry->registeredModelsCategoryAssociation()) {
+        QList<QTreeWidgetItem *> parent = treeView->findItems(assoc.second, Qt::MatchExactly);
 
-    if (parent.count() <= 0)
-      continue;
+        if (parent.count() <= 0)
+            continue;
 
-    auto item = new QTreeWidgetItem(parent.first());
-    item->setText(0, assoc.first);
-  }
+        auto item = new QTreeWidgetItem(parent.first());
+        item->setText(0, assoc.first);
+    }
 
-  treeView->expandAll();
+    treeView->expandAll();
 
-  connect(treeView, &QTreeWidget::itemClicked,
-          [this,
-           modelMenu,
-           scenePos](QTreeWidgetItem* item, int)
-          {
-            if(!(item->flags() & (Qt::ItemIsSelectable)))
-            {
-              return;
-            }
+    connect(treeView,
+            &QTreeWidget::itemClicked,
+            [this, modelMenu, scenePos](QTreeWidgetItem *item, int) {
+                if (!(item->flags() & (Qt::ItemIsSelectable))) {
+                    return;
+                }
 
-            NodeId nodeId = this->_graphModel.addNode(item->text(0));
+                NodeId nodeId = this->_graphModel.addNode(item->text(0));
 
-            if (nodeId != InvalidNodeId)
-            {
-              _graphModel.setNodeData(nodeId,
-                                      NodeRole::Position,
-                                      scenePos);
-            }
+                if (nodeId != InvalidNodeId) {
+                    _graphModel.setNodeData(nodeId, NodeRole::Position, scenePos);
+                }
 
-            modelMenu->close();
-          });
+                modelMenu->close();
+            });
 
-  //Setup filtering
-  connect(txtBox, &QLineEdit::textChanged,
-          [treeView](const QString& text)
-          {
-            QTreeWidgetItemIterator it(treeView, QTreeWidgetItemIterator::NoChildren);
-            while (*it)
-            {
-              auto modelName = (*it)->data(0, Qt::UserRole).toString();
-              const bool match = (modelName.contains(text, Qt::CaseInsensitive));
-              (*it)->setHidden(!match);
+    //Setup filtering
+    connect(txtBox, &QLineEdit::textChanged, [treeView](const QString &text) {
+        QTreeWidgetItemIterator it(treeView, QTreeWidgetItemIterator::NoChildren);
+        while (*it) {
+            auto modelName = (*it)->data(0, Qt::UserRole).toString();
+            const bool match = (modelName.contains(text, Qt::CaseInsensitive));
+            (*it)->setHidden(!match);
 
-              ++it;
-            }
-          });
+            ++it;
+        }
+    });
 
-  // make sure the text box gets focus so the user doesn't have to click on it
-  txtBox->setFocus();
+    // make sure the text box gets focus so the user doesn't have to click on it
+    txtBox->setFocus();
 
-  // QMenu's instance auto-destruction
-  modelMenu->setAttribute(Qt::WA_DeleteOnClose);
+    // QMenu's instance auto-destruction
+    modelMenu->setAttribute(Qt::WA_DeleteOnClose);
 
-  return modelMenu;
+    return modelMenu;
 }
 
-
-void
-DataFlowGraphicsScene::
-save() const
+void DataFlowGraphicsScene::save() const
 {
-  QString fileName =
-    QFileDialog::getSaveFileName(nullptr,
-                                 tr("Open Flow Scene"),
-                                 QDir::homePath(),
-                                 tr("Flow Scene Files (*.flow)"));
+    QString fileName = QFileDialog::getSaveFileName(nullptr,
+                                                    tr("Open Flow Scene"),
+                                                    QDir::homePath(),
+                                                    tr("Flow Scene Files (*.flow)"));
 
-  if (!fileName.isEmpty())
-  {
-    if (!fileName.endsWith("flow", Qt::CaseInsensitive))
-      fileName += ".flow";
+    if (!fileName.isEmpty()) {
+        if (!fileName.endsWith("flow", Qt::CaseInsensitive))
+            fileName += ".flow";
+
+        QFile file(fileName);
+        if (file.open(QIODevice::WriteOnly)) {
+            file.write(QJsonDocument(_graphModel.save()).toJson());
+        }
+    }
+}
+
+void DataFlowGraphicsScene::load()
+{
+    QString fileName = QFileDialog::getOpenFileName(nullptr,
+                                                    tr("Open Flow Scene"),
+                                                    QDir::homePath(),
+                                                    tr("Flow Scene Files (*.flow)"));
+
+    if (!QFileInfo::exists(fileName))
+        return;
 
     QFile file(fileName);
-    if (file.open(QIODevice::WriteOnly))
-    {
-      file.write(QJsonDocument(_graphModel.save()).toJson());
-    }
-  }
+
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+
+    clearScene();
+
+    QByteArray const wholeFile = file.readAll();
+
+    _graphModel.load(QJsonDocument::fromJson(wholeFile).object());
+
+    Q_EMIT sceneLoaded();
 }
 
-
-void
-DataFlowGraphicsScene::
-load()
-{
-  QString fileName =
-    QFileDialog::getOpenFileName(nullptr,
-                                 tr("Open Flow Scene"),
-                                 QDir::homePath(),
-                                 tr("Flow Scene Files (*.flow)"));
-
-  if (!QFileInfo::exists(fileName))
-    return;
-
-  QFile file(fileName);
-
-  if (!file.open(QIODevice::ReadOnly))
-    return;
-
-  clearScene();
-
-  QByteArray const wholeFile = file.readAll();
-
-  _graphModel.load(QJsonDocument::fromJson(wholeFile).object());
-
-  Q_EMIT sceneLoaded();
-}
-
-
-}
+} // namespace QtNodes

--- a/src/DefaultHorizontalNodeGeometry.cpp
+++ b/src/DefaultHorizontalNodeGeometry.cpp
@@ -3,318 +3,237 @@
 #include "AbstractGraphModel.hpp"
 #include "NodeData.hpp"
 
-#include <QRect>
 #include <QPoint>
+#include <QRect>
 #include <QWidget>
 
+namespace QtNodes {
 
-namespace QtNodes
+DefaultHorizontalNodeGeometry::DefaultHorizontalNodeGeometry(AbstractGraphModel &graphModel)
+    : AbstractNodeGeometry(graphModel)
+    , _portSize(20)
+    , _portSpasing(10)
+    , _fontMetrics(QFont())
+    , _boldFontMetrics(QFont())
 {
+    QFont f;
+    f.setBold(true);
+    _boldFontMetrics = QFontMetrics(f);
 
-
-DefaultHorizontalNodeGeometry::
-DefaultHorizontalNodeGeometry(AbstractGraphModel & graphModel)
-  : AbstractNodeGeometry(graphModel)
-  , _portSize(20)
-  , _portSpasing(10)
-  , _fontMetrics(QFont())
-  , _boldFontMetrics(QFont())
-{
-  QFont f;
-  f.setBold(true);
-  _boldFontMetrics = QFontMetrics(f);
-
-  _portSize = _fontMetrics.height();
+    _portSize = _fontMetrics.height();
 }
 
-
-QSize
-DefaultHorizontalNodeGeometry::
-size(NodeId const nodeId) const
+QSize DefaultHorizontalNodeGeometry::size(NodeId const nodeId) const
 {
-  return _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+    return _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
 }
 
-
-void 
-DefaultHorizontalNodeGeometry::
-recomputeSize(NodeId const nodeId) const
+void DefaultHorizontalNodeGeometry::recomputeSize(NodeId const nodeId) const
 {
-  unsigned int height = maxVerticalPortsExtent(nodeId);
+    unsigned int height = maxVerticalPortsExtent(nodeId);
 
-  if (auto w = _graphModel.nodeData<QWidget*>(nodeId, NodeRole::Widget))
-  {
-    height = std::max(height, static_cast<unsigned int>(w->height()));
-  }
-
-  QRectF const capRect = captionRect(nodeId);
-
-  height += capRect.height();
-
-  height += _portSpasing; // space above caption
-  height += _portSpasing; // space below caption
-
-  unsigned int inPortWidth = maxPortsTextAdvance(nodeId, PortType::In);
-  unsigned int outPortWidth = maxPortsTextAdvance(nodeId, PortType::Out);
-
-  unsigned int width = inPortWidth + outPortWidth + 4 * _portSpasing;
-
-  if (auto w = _graphModel.nodeData<QWidget*>(nodeId, NodeRole::Widget))
-  {
-    width += w->width();
-  }
-
-  width = std::max(width, static_cast<unsigned int>(capRect.width()));
-
-  QSize size(width, height);
-
-  _graphModel.setNodeData(nodeId, NodeRole::Size, size);
-}
-
-
-QPointF 
-DefaultHorizontalNodeGeometry::
-portPosition(NodeId const    nodeId,
-             PortType const  portType,
-             PortIndex const portIndex) const
-{
-  unsigned int const step = _portSize + _portSpasing;
-
-  QPointF result;
-
-  double totalHeight = 0.0;
-
-  totalHeight += captionRect(nodeId).height();
-  totalHeight += _portSpasing;
-
-  totalHeight += step * portIndex;
-  totalHeight += step / 2.0;
-
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
-
-  switch (portType)
-  {
-    case PortType::In:
-    {
-      double x = 0.0;
-
-      result = QPointF(x, totalHeight);
-      break;
+    if (auto w = _graphModel.nodeData<QWidget *>(nodeId, NodeRole::Widget)) {
+        height = std::max(height, static_cast<unsigned int>(w->height()));
     }
 
-    case PortType::Out:
-    {
-      double x = size.width();
+    QRectF const capRect = captionRect(nodeId);
 
-      result = QPointF(x, totalHeight);
-      break;
+    height += capRect.height();
+
+    height += _portSpasing; // space above caption
+    height += _portSpasing; // space below caption
+
+    unsigned int inPortWidth = maxPortsTextAdvance(nodeId, PortType::In);
+    unsigned int outPortWidth = maxPortsTextAdvance(nodeId, PortType::Out);
+
+    unsigned int width = inPortWidth + outPortWidth + 4 * _portSpasing;
+
+    if (auto w = _graphModel.nodeData<QWidget *>(nodeId, NodeRole::Widget)) {
+        width += w->width();
+    }
+
+    width = std::max(width, static_cast<unsigned int>(capRect.width()));
+
+    QSize size(width, height);
+
+    _graphModel.setNodeData(nodeId, NodeRole::Size, size);
+}
+
+QPointF DefaultHorizontalNodeGeometry::portPosition(NodeId const nodeId,
+                                                    PortType const portType,
+                                                    PortIndex const portIndex) const
+{
+    unsigned int const step = _portSize + _portSpasing;
+
+    QPointF result;
+
+    double totalHeight = 0.0;
+
+    totalHeight += captionRect(nodeId).height();
+    totalHeight += _portSpasing;
+
+    totalHeight += step * portIndex;
+    totalHeight += step / 2.0;
+
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+
+    switch (portType) {
+    case PortType::In: {
+        double x = 0.0;
+
+        result = QPointF(x, totalHeight);
+        break;
+    }
+
+    case PortType::Out: {
+        double x = size.width();
+
+        result = QPointF(x, totalHeight);
+        break;
     }
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-QPointF
-DefaultHorizontalNodeGeometry::
-portTextPosition(NodeId const   nodeId,
-                 PortType const portType,
-                 PortIndex const portIndex) const
+QPointF DefaultHorizontalNodeGeometry::portTextPosition(NodeId const nodeId,
+                                                        PortType const portType,
+                                                        PortIndex const portIndex) const
 {
-  QPointF p = portPosition(nodeId, portType, portIndex);
+    QPointF p = portPosition(nodeId, portType, portIndex);
 
-  QRectF rect = portTextRect(nodeId, portType, portIndex);
+    QRectF rect = portTextRect(nodeId, portType, portIndex);
 
-  p.setY(p.y() + rect.height() / 4.0);
+    p.setY(p.y() + rect.height() / 4.0);
 
-  QSize size = _graphModel.nodeData<QSize>(nodeId,
-                                           NodeRole::Size);
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      p.setX(_portSpasing);
-      break;
+        p.setX(_portSpasing);
+        break;
 
     case PortType::Out:
-      p.setX(size.width() - _portSpasing - rect.width());
-      break;
+        p.setX(size.width() - _portSpasing - rect.width());
+        break;
 
     default:
-      break;
-  }
-
-  return p;
-}
-
-
-
-
-QRectF
-DefaultHorizontalNodeGeometry::
-captionRect(NodeId const nodeId) const
-{
-  if (!_graphModel.nodeData<bool>(nodeId, NodeRole::CaptionVisible))
-    return QRect();
-
-  QString name = _graphModel.nodeData<QString>(nodeId, NodeRole::Caption);
-
-  return _boldFontMetrics.boundingRect(name);
-}
-
-
-QPointF
-DefaultHorizontalNodeGeometry::
-captionPosition(NodeId const nodeId) const
-{
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
-  return QPointF(0.5 * (size.width() - captionRect(nodeId).width()),
-                 0.5 * _portSpasing + captionRect(nodeId).height());
-}
-
-
-QPointF
-DefaultHorizontalNodeGeometry::
-widgetPosition(NodeId const nodeId) const
-{
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
-
-  unsigned int captionHeight = captionRect(nodeId).height();
-
-  if (auto w = _graphModel.nodeData<QWidget*>(nodeId, NodeRole::Widget))
-  {
-    // If the widget wants to use as much vertical space as possible,
-    // place it immediately after the caption.
-    if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag)
-    {
-      return QPointF(2.0 * _portSpasing + maxPortsTextAdvance(nodeId, PortType::In), captionHeight);
+        break;
     }
-    else
-    {
-      return QPointF(2.0 * _portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
-                     (captionHeight + size.height() - w->height()) / 2.0);
+
+    return p;
+}
+
+QRectF DefaultHorizontalNodeGeometry::captionRect(NodeId const nodeId) const
+{
+    if (!_graphModel.nodeData<bool>(nodeId, NodeRole::CaptionVisible))
+        return QRect();
+
+    QString name = _graphModel.nodeData<QString>(nodeId, NodeRole::Caption);
+
+    return _boldFontMetrics.boundingRect(name);
+}
+
+QPointF DefaultHorizontalNodeGeometry::captionPosition(NodeId const nodeId) const
+{
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+    return QPointF(0.5 * (size.width() - captionRect(nodeId).width()),
+                   0.5 * _portSpasing + captionRect(nodeId).height());
+}
+
+QPointF DefaultHorizontalNodeGeometry::widgetPosition(NodeId const nodeId) const
+{
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+
+    unsigned int captionHeight = captionRect(nodeId).height();
+
+    if (auto w = _graphModel.nodeData<QWidget *>(nodeId, NodeRole::Widget)) {
+        // If the widget wants to use as much vertical space as possible,
+        // place it immediately after the caption.
+        if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag) {
+            return QPointF(2.0 * _portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
+                           captionHeight);
+        } else {
+            return QPointF(2.0 * _portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
+                           (captionHeight + size.height() - w->height()) / 2.0);
+        }
     }
-  }
-  return QPointF();
-
+    return QPointF();
 }
 
-
-QRect 
-DefaultHorizontalNodeGeometry::
-resizeHandleRect(NodeId const nodeId) const
+QRect DefaultHorizontalNodeGeometry::resizeHandleRect(NodeId const nodeId) const
 {
-  QSize size = _graphModel.nodeData<QSize>(nodeId,
-                                           NodeRole::Size);
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
 
-  unsigned int rectSize = 7;
+    unsigned int rectSize = 7;
 
-  return QRect(size.width() - _portSpasing,
-               size.height() - _portSpasing,
-               rectSize,
-               rectSize);
+    return QRect(size.width() - _portSpasing, size.height() - _portSpasing, rectSize, rectSize);
 }
 
-
-QRectF
-DefaultHorizontalNodeGeometry::
-portTextRect(NodeId const   nodeId,
-             PortType const portType,
-             PortIndex const portIndex) const
+QRectF DefaultHorizontalNodeGeometry::portTextRect(NodeId const nodeId,
+                                                   PortType const portType,
+                                                   PortIndex const portIndex) const
 {
-  QString s;
-  if (_graphModel.portData<bool>(nodeId,
-                                 portType,
-                                 portIndex,
-                                 PortRole::CaptionVisible))
-  {
-    s = _graphModel.portData<QString>(nodeId,
-                                portType,
-                                portIndex,
-                                PortRole::Caption);
-  }
-  else
-  {
-    auto portData = _graphModel.portData(nodeId, 
-                                   portType,
-                                   portIndex,
-                                   PortRole::DataType);
+    QString s;
+    if (_graphModel.portData<bool>(nodeId, portType, portIndex, PortRole::CaptionVisible)) {
+        s = _graphModel.portData<QString>(nodeId, portType, portIndex, PortRole::Caption);
+    } else {
+        auto portData = _graphModel.portData(nodeId, portType, portIndex, PortRole::DataType);
 
-    s = portData.value<NodeDataType>().name;
-  }
-
-  return _fontMetrics.boundingRect(s);
-}
-
-
-unsigned int
-DefaultHorizontalNodeGeometry::
-maxVerticalPortsExtent(NodeId const nodeId) const
-{
-  PortCount nInPorts =
-    _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
-
-  PortCount nOutPorts =
-    _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
-
-  unsigned int maxNumOfEntries = std::max(nInPorts, nOutPorts);
-  unsigned int step = _portSize + _portSpasing;
-
-  return step * maxNumOfEntries;
-
-}
-
-
-unsigned int
-DefaultHorizontalNodeGeometry::
-maxPortsTextAdvance(NodeId const   nodeId,
-                    PortType const portType) const
-{
-  unsigned int width = 0;
-
-  size_t const n =
-    _graphModel.nodeData(nodeId,
-                         (portType == PortType::Out) ?
-                         NodeRole::OutPortCount :
-                         NodeRole::InPortCount).toUInt();
-
-  for (PortIndex portIndex = 0ul; portIndex < n; ++portIndex)
-  {
-    QString name;
-
-    if (_graphModel.portData<bool>(nodeId,
-                                   portType,
-                                   portIndex,
-                                   PortRole::CaptionVisible))
-    {
-      name = _graphModel.portData<QString>(nodeId,
-                                           portType,
-                                           portIndex,
-                                           PortRole::Caption);
+        s = portData.value<NodeDataType>().name;
     }
-    else
-    {
-      NodeDataType portData = 
-        _graphModel.portData<NodeDataType>(nodeId, portType,
-                                           portIndex, PortRole::DataType);
 
-      name = portData.name;
-    }
+    return _fontMetrics.boundingRect(s);
+}
+
+unsigned int DefaultHorizontalNodeGeometry::maxVerticalPortsExtent(NodeId const nodeId) const
+{
+    PortCount nInPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
+
+    PortCount nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+
+    unsigned int maxNumOfEntries = std::max(nInPorts, nOutPorts);
+    unsigned int step = _portSize + _portSpasing;
+
+    return step * maxNumOfEntries;
+}
+
+unsigned int DefaultHorizontalNodeGeometry::maxPortsTextAdvance(NodeId const nodeId,
+                                                                PortType const portType) const
+{
+    unsigned int width = 0;
+
+    size_t const n = _graphModel
+                         .nodeData(nodeId,
+                                   (portType == PortType::Out) ? NodeRole::OutPortCount
+                                                               : NodeRole::InPortCount)
+                         .toUInt();
+
+    for (PortIndex portIndex = 0ul; portIndex < n; ++portIndex) {
+        QString name;
+
+        if (_graphModel.portData<bool>(nodeId, portType, portIndex, PortRole::CaptionVisible)) {
+            name = _graphModel.portData<QString>(nodeId, portType, portIndex, PortRole::Caption);
+        } else {
+            NodeDataType portData = _graphModel.portData<NodeDataType>(nodeId,
+                                                                       portType,
+                                                                       portIndex,
+                                                                       PortRole::DataType);
+
+            name = portData.name;
+        }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    width = std::max(unsigned(_fontMetrics.horizontalAdvance(name)),
-                     width);
+        width = std::max(unsigned(_fontMetrics.horizontalAdvance(name)), width);
 #else
-    width = std::max(unsigned(_fontMetrics.width(name)),
-                     width);
+        width = std::max(unsigned(_fontMetrics.width(name)), width);
 #endif
-  }
+    }
 
-  return width;
+    return width;
 }
 
-
-}
+} // namespace QtNodes

--- a/src/DefaultHorizontalNodeGeometry.hpp
+++ b/src/DefaultHorizontalNodeGeometry.hpp
@@ -4,59 +4,55 @@
 
 #include <QtGui/QFontMetrics>
 
-
-namespace QtNodes
-{
+namespace QtNodes {
 
 class AbstractGraphModel;
 class BasicGraphicsScene;
 
-
 class NODE_EDITOR_PUBLIC DefaultHorizontalNodeGeometry : public AbstractNodeGeometry
 {
 public:
-  DefaultHorizontalNodeGeometry(AbstractGraphModel & graphModel);
+    DefaultHorizontalNodeGeometry(AbstractGraphModel &graphModel);
 
 public:
-  QSize size(NodeId const nodeId) const override;
+    QSize size(NodeId const nodeId) const override;
 
-  void recomputeSize(NodeId const nodeId) const override;
+    void recomputeSize(NodeId const nodeId) const override;
 
-  QPointF portPosition(NodeId const    nodeId,
-                       PortType const  portType,
-                       PortIndex const index) const override;
+    QPointF portPosition(NodeId const nodeId,
+                         PortType const portType,
+                         PortIndex const index) const override;
 
-  QPointF portTextPosition(NodeId const nodeId,
-                           PortType const portType,
-                           PortIndex const PortIndex) const override;
-  QPointF captionPosition(NodeId const nodeId) const override;
+    QPointF portTextPosition(NodeId const nodeId,
+                             PortType const portType,
+                             PortIndex const PortIndex) const override;
+    QPointF captionPosition(NodeId const nodeId) const override;
 
-  QRectF captionRect(NodeId const nodeId) const override;
+    QRectF captionRect(NodeId const nodeId) const override;
 
-  QPointF widgetPosition(NodeId const nodeId) const override;
+    QPointF widgetPosition(NodeId const nodeId) const override;
 
-  QRect resizeHandleRect(NodeId const nodeId) const override;
+    QRect resizeHandleRect(NodeId const nodeId) const override;
+
 private:
+    QRectF portTextRect(NodeId const nodeId,
+                        PortType const portType,
+                        PortIndex const portIndex) const;
 
-  QRectF
-  portTextRect(NodeId const   nodeId,
-               PortType const portType,
-               PortIndex const portIndex) const;
+    /// Finds max number of ports and multiplies by (a port height + interval)
+    unsigned int maxVerticalPortsExtent(NodeId const nodeId) const;
 
-  /// Finds max number of ports and multiplies by (a port height + interval)
-  unsigned int maxVerticalPortsExtent(NodeId const nodeId) const;
+    unsigned int maxPortsTextAdvance(NodeId const nodeId, PortType const portType) const;
 
-  unsigned int maxPortsTextAdvance(NodeId const   nodeId,
-                                   PortType const portType) const;
 private:
-  // Some variables are mutable because we need to change drawing
-  // metrics corresponding to fontMetrics but this doesn't change
-  // constness of the Node.
+    // Some variables are mutable because we need to change drawing
+    // metrics corresponding to fontMetrics but this doesn't change
+    // constness of the Node.
 
-  mutable unsigned int _portSize;
-  unsigned int _portSpasing;
-  mutable QFontMetrics _fontMetrics;
-  mutable QFontMetrics _boldFontMetrics;
+    mutable unsigned int _portSize;
+    unsigned int _portSpasing;
+    mutable QFontMetrics _fontMetrics;
+    mutable QFontMetrics _boldFontMetrics;
 };
 
-}
+} // namespace QtNodes

--- a/src/DefaultNodePainter.cpp
+++ b/src/DefaultNodePainter.cpp
@@ -13,350 +13,261 @@
 #include "NodeState.hpp"
 #include "StyleCollection.hpp"
 
+namespace QtNodes {
 
-namespace QtNodes
+void DefaultNodePainter::paint(QPainter *painter, NodeGraphicsObject &ngo) const
 {
+    // TODO?
+    //AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
+    //geometry.recomputeSizeIfFontChanged(painter->font());
 
-void
-DefaultNodePainter::
-paint(QPainter * painter,
-      NodeGraphicsObject & ngo) const
-{
-  // TODO?
-  //AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
-  //geometry.recomputeSizeIfFontChanged(painter->font());
+    drawNodeRect(painter, ngo);
 
-  drawNodeRect(painter, ngo);
+    drawConnectionPoints(painter, ngo);
 
-  drawConnectionPoints(painter, ngo);
+    drawFilledConnectionPoints(painter, ngo);
 
-  drawFilledConnectionPoints(painter, ngo);
+    drawNodeCaption(painter, ngo);
 
-  drawNodeCaption(painter, ngo);
+    drawEntryLabels(painter, ngo);
 
-  drawEntryLabels(painter, ngo);
-
-  drawResizeRect(painter, ngo);
+    drawResizeRect(painter, ngo);
 }
 
-
-void
-DefaultNodePainter::
-drawNodeRect(QPainter * painter,
-             NodeGraphicsObject &ngo) const
+void DefaultNodePainter::drawNodeRect(QPainter *painter, NodeGraphicsObject &ngo) const
 {
-  AbstractGraphModel &model = ngo.graphModel();
+    AbstractGraphModel &model = ngo.graphModel();
 
-  NodeId const nodeId = ngo.nodeId();
+    NodeId const nodeId = ngo.nodeId();
 
-  AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
+    AbstractNodeGeometry &geometry = ngo.nodeScene()->nodeGeometry();
 
-  QSize size = geometry.size(nodeId);
+    QSize size = geometry.size(nodeId);
 
-  QJsonDocument json =
-    QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
+    QJsonDocument json = QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
 
-  NodeStyle nodeStyle(json.object());
+    NodeStyle nodeStyle(json.object());
 
-  auto color = ngo.isSelected() ?
-               nodeStyle.SelectedBoundaryColor :
-               nodeStyle.NormalBoundaryColor;
+    auto color = ngo.isSelected() ? nodeStyle.SelectedBoundaryColor : nodeStyle.NormalBoundaryColor;
 
-  if (ngo.nodeState().hovered())
-  {
-    QPen p(color, nodeStyle.HoveredPenWidth);
-    painter->setPen(p);
-  }
-  else
-  {
-    QPen p(color, nodeStyle.PenWidth);
-    painter->setPen(p);
-  }
-
-  QLinearGradient gradient(QPointF(0.0, 0.0),
-                           QPointF(2.0, size.height()));
-
-  gradient.setColorAt(0.0,  nodeStyle.GradientColor0);
-  gradient.setColorAt(0.10, nodeStyle.GradientColor1);
-  gradient.setColorAt(0.90, nodeStyle.GradientColor2);
-  gradient.setColorAt(1.0,  nodeStyle.GradientColor3);
-
-  painter->setBrush(gradient);
-
-  QRectF boundary(0, 0, size.width(), size.height());
-
-  double const radius = 3.0;
-
-  painter->drawRoundedRect(boundary, radius, radius);
-}
-
-
-void
-DefaultNodePainter::
-drawConnectionPoints(QPainter * painter,
-                     NodeGraphicsObject &ngo) const
-{
-  AbstractGraphModel &model = ngo.graphModel();
-  NodeId const nodeId     = ngo.nodeId();
-  AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
-
-  QJsonDocument json =
-    QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
-  NodeStyle nodeStyle(json.object());
-
-  auto const &connectionStyle = StyleCollection::connectionStyle();
-
-  float diameter       = nodeStyle.ConnectionPointDiameter;
-  auto reducedDiameter = diameter * 0.6;
-
-  for (PortType portType: {PortType::Out, PortType::In})
-  {
-    size_t const n =
-      model.nodeData(nodeId,
-                     (portType == PortType::Out) ?
-                     NodeRole::OutPortCount :
-                     NodeRole::InPortCount).toUInt();
-
-    for (PortIndex portIndex = 0; portIndex < n; ++portIndex)
-    {
-      QPointF p = geometry.portPosition(nodeId, portType, portIndex);
-
-      auto const &dataType =
-        model.portData(nodeId,
-                       portType,
-                       portIndex,
-                       PortRole::DataType).value<NodeDataType>();
-
-      double r = 1.0;
-
-      NodeState const &state = ngo.nodeState();
-
-      if (auto const * cgo = state.connectionForReaction())
-      {
-        PortType requiredPort =
-          cgo->connectionState().requiredPort();
-
-        if (requiredPort == portType)
-        {
-
-          ConnectionId possibleConnectionId =
-            makeCompleteConnectionId(cgo->connectionId(),
-                                     nodeId,
-                                     portIndex);
-
-          bool const possible = model.connectionPossible(possibleConnectionId);
-
-          auto cp = cgo->sceneTransform().map(cgo->endPoint(requiredPort));
-          cp = ngo.sceneTransform().inverted().map(cp);
-
-          auto diff   = cp - p;
-          double dist = std::sqrt(QPointF::dotProduct(diff, diff));
-
-          if (possible)
-          {
-            double const thres = 40.0;
-            r = (dist < thres) ?
-                (2.0 - dist / thres ) :
-                1.0;
-          }
-          else
-          {
-            double const thres = 80.0;
-            r = (dist < thres) ?
-                (dist / thres) :
-                1.0;
-          }
-        }
-      }
-
-      if (connectionStyle.useDataDefinedColors())
-      {
-        painter->setBrush(connectionStyle.normalColor(dataType.id));
-      }
-      else
-      {
-        painter->setBrush(nodeStyle.ConnectionPointColor);
-      }
-
-      painter->drawEllipse(p,
-                           reducedDiameter * r,
-                           reducedDiameter * r);
+    if (ngo.nodeState().hovered()) {
+        QPen p(color, nodeStyle.HoveredPenWidth);
+        painter->setPen(p);
+    } else {
+        QPen p(color, nodeStyle.PenWidth);
+        painter->setPen(p);
     }
-  }
 
-  if (ngo.nodeState().connectionForReaction())
-  {
-    ngo.nodeState().resetConnectionForReaction();
-  }
+    QLinearGradient gradient(QPointF(0.0, 0.0), QPointF(2.0, size.height()));
+
+    gradient.setColorAt(0.0, nodeStyle.GradientColor0);
+    gradient.setColorAt(0.10, nodeStyle.GradientColor1);
+    gradient.setColorAt(0.90, nodeStyle.GradientColor2);
+    gradient.setColorAt(1.0, nodeStyle.GradientColor3);
+
+    painter->setBrush(gradient);
+
+    QRectF boundary(0, 0, size.width(), size.height());
+
+    double const radius = 3.0;
+
+    painter->drawRoundedRect(boundary, radius, radius);
 }
 
-
-void
-DefaultNodePainter::
-drawFilledConnectionPoints(QPainter * painter,
-                           NodeGraphicsObject &ngo) const
+void DefaultNodePainter::drawConnectionPoints(QPainter *painter, NodeGraphicsObject &ngo) const
 {
-  AbstractGraphModel &model = ngo.graphModel();
-  NodeId const nodeId     = ngo.nodeId();
-  AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
+    AbstractGraphModel &model = ngo.graphModel();
+    NodeId const nodeId = ngo.nodeId();
+    AbstractNodeGeometry &geometry = ngo.nodeScene()->nodeGeometry();
 
-  QJsonDocument json =
-    QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
-  NodeStyle nodeStyle(json.object());
+    QJsonDocument json = QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
+    NodeStyle nodeStyle(json.object());
 
-  auto diameter = nodeStyle.ConnectionPointDiameter;
+    auto const &connectionStyle = StyleCollection::connectionStyle();
 
-  for (PortType portType: {PortType::Out, PortType::In})
-  {
-    size_t const n =
-      model.nodeData(nodeId,
-                     (portType == PortType::Out) ?
-                     NodeRole::OutPortCount :
-                     NodeRole::InPortCount).toUInt();
+    float diameter = nodeStyle.ConnectionPointDiameter;
+    auto reducedDiameter = diameter * 0.6;
 
-    for (PortIndex portIndex = 0; portIndex < n; ++portIndex)
-    {
-      QPointF p = geometry.portPosition(nodeId, portType, portIndex);
+    for (PortType portType : {PortType::Out, PortType::In}) {
+        size_t const n = model
+                             .nodeData(nodeId,
+                                       (portType == PortType::Out) ? NodeRole::OutPortCount
+                                                                   : NodeRole::InPortCount)
+                             .toUInt();
 
-      auto const &connected =
-        model.connections(nodeId, portType, portIndex);
+        for (PortIndex portIndex = 0; portIndex < n; ++portIndex) {
+            QPointF p = geometry.portPosition(nodeId, portType, portIndex);
 
-      if (!connected.empty())
-      {
-        auto const &dataType =
-          model.portData(nodeId,
-                         portType,
-                         portIndex,
-                         PortRole::DataType).value<NodeDataType>();
+            auto const &dataType = model.portData(nodeId, portType, portIndex, PortRole::DataType)
+                                       .value<NodeDataType>();
 
-        auto const &connectionStyle = StyleCollection::connectionStyle();
-        if (connectionStyle.useDataDefinedColors())
-        {
-          QColor const c = connectionStyle.normalColor(dataType.id);
-          painter->setPen(c);
-          painter->setBrush(c);
+            double r = 1.0;
+
+            NodeState const &state = ngo.nodeState();
+
+            if (auto const *cgo = state.connectionForReaction()) {
+                PortType requiredPort = cgo->connectionState().requiredPort();
+
+                if (requiredPort == portType) {
+                    ConnectionId possibleConnectionId = makeCompleteConnectionId(cgo->connectionId(),
+                                                                                 nodeId,
+                                                                                 portIndex);
+
+                    bool const possible = model.connectionPossible(possibleConnectionId);
+
+                    auto cp = cgo->sceneTransform().map(cgo->endPoint(requiredPort));
+                    cp = ngo.sceneTransform().inverted().map(cp);
+
+                    auto diff = cp - p;
+                    double dist = std::sqrt(QPointF::dotProduct(diff, diff));
+
+                    if (possible) {
+                        double const thres = 40.0;
+                        r = (dist < thres) ? (2.0 - dist / thres) : 1.0;
+                    } else {
+                        double const thres = 80.0;
+                        r = (dist < thres) ? (dist / thres) : 1.0;
+                    }
+                }
+            }
+
+            if (connectionStyle.useDataDefinedColors()) {
+                painter->setBrush(connectionStyle.normalColor(dataType.id));
+            } else {
+                painter->setBrush(nodeStyle.ConnectionPointColor);
+            }
+
+            painter->drawEllipse(p, reducedDiameter * r, reducedDiameter * r);
         }
-        else
-        {
-          painter->setPen(nodeStyle.FilledConnectionPointColor);
-          painter->setBrush(nodeStyle.FilledConnectionPointColor);
+    }
+
+    if (ngo.nodeState().connectionForReaction()) {
+        ngo.nodeState().resetConnectionForReaction();
+    }
+}
+
+void DefaultNodePainter::drawFilledConnectionPoints(QPainter *painter, NodeGraphicsObject &ngo) const
+{
+    AbstractGraphModel &model = ngo.graphModel();
+    NodeId const nodeId = ngo.nodeId();
+    AbstractNodeGeometry &geometry = ngo.nodeScene()->nodeGeometry();
+
+    QJsonDocument json = QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
+    NodeStyle nodeStyle(json.object());
+
+    auto diameter = nodeStyle.ConnectionPointDiameter;
+
+    for (PortType portType : {PortType::Out, PortType::In}) {
+        size_t const n = model
+                             .nodeData(nodeId,
+                                       (portType == PortType::Out) ? NodeRole::OutPortCount
+                                                                   : NodeRole::InPortCount)
+                             .toUInt();
+
+        for (PortIndex portIndex = 0; portIndex < n; ++portIndex) {
+            QPointF p = geometry.portPosition(nodeId, portType, portIndex);
+
+            auto const &connected = model.connections(nodeId, portType, portIndex);
+
+            if (!connected.empty()) {
+                auto const &dataType = model
+                                           .portData(nodeId, portType, portIndex, PortRole::DataType)
+                                           .value<NodeDataType>();
+
+                auto const &connectionStyle = StyleCollection::connectionStyle();
+                if (connectionStyle.useDataDefinedColors()) {
+                    QColor const c = connectionStyle.normalColor(dataType.id);
+                    painter->setPen(c);
+                    painter->setBrush(c);
+                } else {
+                    painter->setPen(nodeStyle.FilledConnectionPointColor);
+                    painter->setBrush(nodeStyle.FilledConnectionPointColor);
+                }
+
+                painter->drawEllipse(p, diameter * 0.4, diameter * 0.4);
+            }
         }
-
-        painter->drawEllipse(p,
-                             diameter * 0.4,
-                             diameter * 0.4);
-      }
     }
-  }
 }
 
-
-void
-DefaultNodePainter::
-drawNodeCaption(QPainter * painter,
-                NodeGraphicsObject &ngo) const
+void DefaultNodePainter::drawNodeCaption(QPainter *painter, NodeGraphicsObject &ngo) const
 {
-  AbstractGraphModel & model = ngo.graphModel();
-  NodeId const nodeId     = ngo.nodeId();
-  AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
+    AbstractGraphModel &model = ngo.graphModel();
+    NodeId const nodeId = ngo.nodeId();
+    AbstractNodeGeometry &geometry = ngo.nodeScene()->nodeGeometry();
 
-  if (!model.nodeData(nodeId, NodeRole::CaptionVisible).toBool())
-    return;
+    if (!model.nodeData(nodeId, NodeRole::CaptionVisible).toBool())
+        return;
 
-  QString const name = model.nodeData(nodeId, NodeRole::Caption).toString();
+    QString const name = model.nodeData(nodeId, NodeRole::Caption).toString();
 
-  QFont f = painter->font();
-  f.setBold(true);
+    QFont f = painter->font();
+    f.setBold(true);
 
-  QPointF position = geometry.captionPosition(nodeId);
+    QPointF position = geometry.captionPosition(nodeId);
 
-  QJsonDocument json =
-    QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
-  NodeStyle nodeStyle(json.object());
+    QJsonDocument json = QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
+    NodeStyle nodeStyle(json.object());
 
-  painter->setFont(f);
-  painter->setPen(nodeStyle.FontColor);
-  painter->drawText(position, name);
+    painter->setFont(f);
+    painter->setPen(nodeStyle.FontColor);
+    painter->drawText(position, name);
 
-  f.setBold(false);
-  painter->setFont(f);
+    f.setBold(false);
+    painter->setFont(f);
 }
 
-
-void
-DefaultNodePainter::
-drawEntryLabels(QPainter * painter,
-                NodeGraphicsObject &ngo) const
+void DefaultNodePainter::drawEntryLabels(QPainter *painter, NodeGraphicsObject &ngo) const
 {
-  AbstractGraphModel &model = ngo.graphModel();
-  NodeId const nodeId     = ngo.nodeId();
-  AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
+    AbstractGraphModel &model = ngo.graphModel();
+    NodeId const nodeId = ngo.nodeId();
+    AbstractNodeGeometry &geometry = ngo.nodeScene()->nodeGeometry();
 
-  QJsonDocument json =
-    QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
-  NodeStyle nodeStyle(json.object());
+    QJsonDocument json = QJsonDocument::fromVariant(model.nodeData(nodeId, NodeRole::Style));
+    NodeStyle nodeStyle(json.object());
 
-  for (PortType portType: {PortType::Out, PortType::In})
-  {
-    unsigned int n =
-      model.nodeData<unsigned int>(nodeId,
-                                   (portType == PortType::Out) ?
-                                   NodeRole::OutPortCount :
-                                   NodeRole::InPortCount);
+    for (PortType portType : {PortType::Out, PortType::In}) {
+        unsigned int n = model.nodeData<unsigned int>(nodeId,
+                                                      (portType == PortType::Out)
+                                                          ? NodeRole::OutPortCount
+                                                          : NodeRole::InPortCount);
 
-    for (PortIndex portIndex = 0; portIndex < n; ++portIndex)
-    {
-      auto const &connected =
-        model.connections(nodeId, portType, portIndex);
+        for (PortIndex portIndex = 0; portIndex < n; ++portIndex) {
+            auto const &connected = model.connections(nodeId, portType, portIndex);
 
-      QPointF p = geometry.portTextPosition(nodeId, portType, portIndex);
+            QPointF p = geometry.portTextPosition(nodeId, portType, portIndex);
 
-      if (connected.empty())
-        painter->setPen(nodeStyle.FontColorFaded);
-      else
-        painter->setPen(nodeStyle.FontColor);
+            if (connected.empty())
+                painter->setPen(nodeStyle.FontColorFaded);
+            else
+                painter->setPen(nodeStyle.FontColor);
 
-      QString s;
+            QString s;
 
-      if (model.portData<bool>(nodeId, portType, portIndex, PortRole::CaptionVisible))
-      {
-        s = model.portData<QString>(nodeId,
-                                    portType,
-                                    portIndex,
-                                    PortRole::Caption);
-      }
-      else
-      {
-        auto portData = model.portData(nodeId, 
-                                       portType,
-                                       portIndex,
-                                       PortRole::DataType);
+            if (model.portData<bool>(nodeId, portType, portIndex, PortRole::CaptionVisible)) {
+                s = model.portData<QString>(nodeId, portType, portIndex, PortRole::Caption);
+            } else {
+                auto portData = model.portData(nodeId, portType, portIndex, PortRole::DataType);
 
-        s = portData.value<NodeDataType>().name;
-      }
+                s = portData.value<NodeDataType>().name;
+            }
 
-      painter->drawText(p, s);
+            painter->drawText(p, s);
+        }
     }
-  }
 }
 
-
-void
-DefaultNodePainter::
-drawResizeRect(QPainter * painter,
-               NodeGraphicsObject &ngo) const
+void DefaultNodePainter::drawResizeRect(QPainter *painter, NodeGraphicsObject &ngo) const
 {
-  AbstractGraphModel &model = ngo.graphModel();
-  NodeId const nodeId     = ngo.nodeId();
-  AbstractNodeGeometry & geometry = ngo.nodeScene()->nodeGeometry();
+    AbstractGraphModel &model = ngo.graphModel();
+    NodeId const nodeId = ngo.nodeId();
+    AbstractNodeGeometry &geometry = ngo.nodeScene()->nodeGeometry();
 
-  if (model.nodeFlags(nodeId) & NodeFlag::Resizable)
-  {
-    painter->setBrush(Qt::gray);
+    if (model.nodeFlags(nodeId) & NodeFlag::Resizable) {
+        painter->setBrush(Qt::gray);
 
-    painter->drawEllipse(geometry.resizeHandleRect(nodeId));
-  }
+        painter->drawEllipse(geometry.resizeHandleRect(nodeId));
+    }
 }
 
-
-}
+} // namespace QtNodes

--- a/src/DefaultVerticalNodeGeometry.cpp
+++ b/src/DefaultVerticalNodeGeometry.cpp
@@ -3,388 +3,288 @@
 #include "AbstractGraphModel.hpp"
 #include "NodeData.hpp"
 
-#include <QRect>
 #include <QPoint>
+#include <QRect>
 #include <QWidget>
 
+namespace QtNodes {
 
-namespace QtNodes
+DefaultVerticalNodeGeometry::DefaultVerticalNodeGeometry(AbstractGraphModel &graphModel)
+    : AbstractNodeGeometry(graphModel)
+    , _portSize(20)
+    , _portSpasing(10)
+    , _fontMetrics(QFont())
+    , _boldFontMetrics(QFont())
 {
+    QFont f;
+    f.setBold(true);
+    _boldFontMetrics = QFontMetrics(f);
 
-
-DefaultVerticalNodeGeometry::
-DefaultVerticalNodeGeometry(AbstractGraphModel & graphModel)
-  : AbstractNodeGeometry(graphModel)
-  , _portSize(20)
-  , _portSpasing(10)
-  , _fontMetrics(QFont())
-  , _boldFontMetrics(QFont())
-{
-  QFont f;
-  f.setBold(true);
-  _boldFontMetrics = QFontMetrics(f);
-
-  _portSize = _fontMetrics.height();
+    _portSize = _fontMetrics.height();
 }
 
-
-QSize
-DefaultVerticalNodeGeometry::
-size(NodeId const nodeId) const
+QSize DefaultVerticalNodeGeometry::size(NodeId const nodeId) const
 {
-  return _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+    return _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
 }
 
-
-void 
-DefaultVerticalNodeGeometry::
-recomputeSize(NodeId const nodeId) const
+void DefaultVerticalNodeGeometry::recomputeSize(NodeId const nodeId) const
 {
-  unsigned int height = _portSpasing; // maxHorizontalPortsExtent(nodeId);
+    unsigned int height = _portSpasing; // maxHorizontalPortsExtent(nodeId);
 
-  if (auto w = _graphModel.nodeData<QWidget*>(nodeId, NodeRole::Widget))
-  {
-    height = std::max(height, static_cast<unsigned int>(w->height()));
-  }
-
-  QRectF const capRect = captionRect(nodeId);
-
-  height += capRect.height();
-
-  height += _portSpasing;
-  height += _portSpasing;
-
-  PortCount nInPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
-  PortCount nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
-
-  // Adding double step (top and bottom) to reserve space for port captions.
-
-  height += portCaptionsHeight(nodeId, PortType::In);
-  height += portCaptionsHeight(nodeId, PortType::Out);
-
-  unsigned int inPortWidth = maxPortsTextAdvance(nodeId, PortType::In);
-  unsigned int outPortWidth = maxPortsTextAdvance(nodeId, PortType::Out);
-
-  unsigned int width = std::max(inPortWidth *  nInPorts + _portSpasing * (nInPorts - 1),
-                                outPortWidth * nOutPorts + _portSpasing * (nOutPorts - 1));
-
-  if (auto w = _graphModel.nodeData<QWidget*>(nodeId, NodeRole::Widget))
-  {
-    width = std::max(width, static_cast<unsigned int>(w->width()));
-  }
-
-  width = std::max(width, static_cast<unsigned int>(capRect.width()));
-
-  width += _portSpasing;
-  width += _portSpasing;
-
-  QSize size(width, height);
-
-  _graphModel.setNodeData(nodeId, NodeRole::Size, size);
-}
-
-
-QPointF 
-DefaultVerticalNodeGeometry::
-portPosition(NodeId const    nodeId,
-             PortType const  portType,
-             PortIndex const portIndex) const
-{
-  QPointF result;
-
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
-
-  switch (portType)
-  {
-    case PortType::In:
-    {
-      unsigned int inPortWidth = maxPortsTextAdvance(nodeId, PortType::In) +
-                                 _portSpasing;
-
-      PortCount nInPorts =
-        _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
-
-      double x = (size.width() - (nInPorts - 1) * inPortWidth) / 2.0 + portIndex * inPortWidth;
-
-      double y = 0.0;
-
-      result = QPointF(x, y);
-
-      break;
+    if (auto w = _graphModel.nodeData<QWidget *>(nodeId, NodeRole::Widget)) {
+        height = std::max(height, static_cast<unsigned int>(w->height()));
     }
 
-    case PortType::Out:
-    {
-      unsigned int outPortWidth = maxPortsTextAdvance(nodeId, PortType::Out) +
-                                  _portSpasing;
-      PortCount nOutPorts =
-        _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+    QRectF const capRect = captionRect(nodeId);
 
-      double x = (size.width() - (nOutPorts - 1) * outPortWidth) / 2.0 + portIndex * outPortWidth;
+    height += capRect.height();
 
-      double y = size.height();
+    height += _portSpasing;
+    height += _portSpasing;
 
-      result = QPointF(x, y);
+    PortCount nInPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
+    PortCount nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
 
-      break;
+    // Adding double step (top and bottom) to reserve space for port captions.
+
+    height += portCaptionsHeight(nodeId, PortType::In);
+    height += portCaptionsHeight(nodeId, PortType::Out);
+
+    unsigned int inPortWidth = maxPortsTextAdvance(nodeId, PortType::In);
+    unsigned int outPortWidth = maxPortsTextAdvance(nodeId, PortType::Out);
+
+    unsigned int width = std::max(inPortWidth * nInPorts + _portSpasing * (nInPorts - 1),
+                                  outPortWidth * nOutPorts + _portSpasing * (nOutPorts - 1));
+
+    if (auto w = _graphModel.nodeData<QWidget *>(nodeId, NodeRole::Widget)) {
+        width = std::max(width, static_cast<unsigned int>(w->width()));
+    }
+
+    width = std::max(width, static_cast<unsigned int>(capRect.width()));
+
+    width += _portSpasing;
+    width += _portSpasing;
+
+    QSize size(width, height);
+
+    _graphModel.setNodeData(nodeId, NodeRole::Size, size);
+}
+
+QPointF DefaultVerticalNodeGeometry::portPosition(NodeId const nodeId,
+                                                  PortType const portType,
+                                                  PortIndex const portIndex) const
+{
+    QPointF result;
+
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+
+    switch (portType) {
+    case PortType::In: {
+        unsigned int inPortWidth = maxPortsTextAdvance(nodeId, PortType::In) + _portSpasing;
+
+        PortCount nInPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
+
+        double x = (size.width() - (nInPorts - 1) * inPortWidth) / 2.0 + portIndex * inPortWidth;
+
+        double y = 0.0;
+
+        result = QPointF(x, y);
+
+        break;
+    }
+
+    case PortType::Out: {
+        unsigned int outPortWidth = maxPortsTextAdvance(nodeId, PortType::Out) + _portSpasing;
+        PortCount nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+
+        double x = (size.width() - (nOutPorts - 1) * outPortWidth) / 2.0 + portIndex * outPortWidth;
+
+        double y = size.height();
+
+        result = QPointF(x, y);
+
+        break;
     }
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-QPointF
-DefaultVerticalNodeGeometry::
-portTextPosition(NodeId const   nodeId,
-                 PortType const portType,
-                 PortIndex const portIndex) const
+QPointF DefaultVerticalNodeGeometry::portTextPosition(NodeId const nodeId,
+                                                      PortType const portType,
+                                                      PortIndex const portIndex) const
 {
-  QPointF p = portPosition(nodeId, portType, portIndex);
+    QPointF p = portPosition(nodeId, portType, portIndex);
 
-  QRectF rect = portTextRect(nodeId, portType, portIndex);
+    QRectF rect = portTextRect(nodeId, portType, portIndex);
 
-  p.setX(p.x() - rect.width() / 2.0);
+    p.setX(p.x() - rect.width() / 2.0);
 
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
 
-  switch (portType)
-  {
+    switch (portType) {
     case PortType::In:
-      p.setY(5.0 + rect.height());
-      break;
+        p.setY(5.0 + rect.height());
+        break;
 
     case PortType::Out:
-      p.setY(size.height() - 5.0);
-      break;
+        p.setY(size.height() - 5.0);
+        break;
 
     default:
-      break;
-  }
-
-  return p;
-}
-
-
-QRectF
-DefaultVerticalNodeGeometry::
-captionRect(NodeId const nodeId) const
-{
-  if (!_graphModel.nodeData<bool>(nodeId, NodeRole::CaptionVisible))
-    return QRect();
-
-  QString name = _graphModel.nodeData<QString>(nodeId, NodeRole::Caption);
-
-  return _boldFontMetrics.boundingRect(name);
-}
-
-
-QPointF
-DefaultVerticalNodeGeometry::
-captionPosition(NodeId const nodeId) const
-{
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
-
-  unsigned int step = portCaptionsHeight(nodeId, PortType::In);
-
-  auto rect = captionRect(nodeId);
-
-  return QPointF(0.5 * (size.width() - rect.width()),
-                 step + rect.height());
-}
-
-
-QPointF
-DefaultVerticalNodeGeometry::
-widgetPosition(NodeId const nodeId) const
-{
-  QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
-
-  unsigned int captionHeight = captionRect(nodeId).height();
-
-  if (auto w = _graphModel.nodeData<QWidget*>(nodeId, NodeRole::Widget))
-  {
-    // If the widget wants to use as much vertical space as possible,
-    // place it immediately after the caption.
-    if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag)
-    {
-      return QPointF(_portSpasing + maxPortsTextAdvance(nodeId, PortType::In), captionHeight);
+        break;
     }
-    else
-    {
-      return QPointF(_portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
-                     (captionHeight + size.height() - w->height()) / 2.0);
+
+    return p;
+}
+
+QRectF DefaultVerticalNodeGeometry::captionRect(NodeId const nodeId) const
+{
+    if (!_graphModel.nodeData<bool>(nodeId, NodeRole::CaptionVisible))
+        return QRect();
+
+    QString name = _graphModel.nodeData<QString>(nodeId, NodeRole::Caption);
+
+    return _boldFontMetrics.boundingRect(name);
+}
+
+QPointF DefaultVerticalNodeGeometry::captionPosition(NodeId const nodeId) const
+{
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+
+    unsigned int step = portCaptionsHeight(nodeId, PortType::In);
+
+    auto rect = captionRect(nodeId);
+
+    return QPointF(0.5 * (size.width() - rect.width()), step + rect.height());
+}
+
+QPointF DefaultVerticalNodeGeometry::widgetPosition(NodeId const nodeId) const
+{
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
+
+    unsigned int captionHeight = captionRect(nodeId).height();
+
+    if (auto w = _graphModel.nodeData<QWidget *>(nodeId, NodeRole::Widget)) {
+        // If the widget wants to use as much vertical space as possible,
+        // place it immediately after the caption.
+        if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag) {
+            return QPointF(_portSpasing + maxPortsTextAdvance(nodeId, PortType::In), captionHeight);
+        } else {
+            return QPointF(_portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
+                           (captionHeight + size.height() - w->height()) / 2.0);
+        }
     }
-  }
-  return QPointF();
+    return QPointF();
 }
 
-
-QRect 
-DefaultVerticalNodeGeometry::
-resizeHandleRect(NodeId const nodeId) const
+QRect DefaultVerticalNodeGeometry::resizeHandleRect(NodeId const nodeId) const
 {
-  QSize size = _graphModel.nodeData<QSize>(nodeId, 
-                                           NodeRole::Size);
+    QSize size = _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);
 
-  unsigned int rectSize = 7;
+    unsigned int rectSize = 7;
 
-  return QRect(size.width() - rectSize,
-               size.height() - rectSize,
-               rectSize,
-               rectSize);
+    return QRect(size.width() - rectSize, size.height() - rectSize, rectSize, rectSize);
 }
 
-
-QRectF
-DefaultVerticalNodeGeometry::
-portTextRect(NodeId const   nodeId,
-             PortType const portType,
-             PortIndex const portIndex) const
+QRectF DefaultVerticalNodeGeometry::portTextRect(NodeId const nodeId,
+                                                 PortType const portType,
+                                                 PortIndex const portIndex) const
 {
-  QString s;
-  if (_graphModel.portData<bool>(nodeId,
-                                 portType,
-                                 portIndex,
-                                 PortRole::CaptionVisible))
-  {
-    s = _graphModel.portData<QString>(nodeId,
-                                portType,
-                                portIndex,
-                                PortRole::Caption);
-  }
-  else
-  {
-    auto portData = _graphModel.portData(nodeId, 
-                                   portType,
-                                   portIndex,
-                                   PortRole::DataType);
+    QString s;
+    if (_graphModel.portData<bool>(nodeId, portType, portIndex, PortRole::CaptionVisible)) {
+        s = _graphModel.portData<QString>(nodeId, portType, portIndex, PortRole::Caption);
+    } else {
+        auto portData = _graphModel.portData(nodeId, portType, portIndex, PortRole::DataType);
 
-    s = portData.value<NodeDataType>().name;
-  }
-
-  return _fontMetrics.boundingRect(s);
-}
-
-
-unsigned int
-DefaultVerticalNodeGeometry::
-maxHorizontalPortsExtent(NodeId const nodeId) const
-{
-  PortCount nInPorts =
-    _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
-
-  PortCount nOutPorts =
-    _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
-
-  unsigned int maxNumOfEntries = std::max(nInPorts, nOutPorts);
-  unsigned int step = _portSize + _portSpasing;
-
-  return step * maxNumOfEntries;
-}
-
-
-unsigned int
-DefaultVerticalNodeGeometry::
-maxPortsTextAdvance(NodeId const   nodeId,
-                    PortType const portType) const
-{
-  unsigned int width = 0;
-
-  size_t const n =
-    _graphModel.nodeData(nodeId,
-                         (portType == PortType::Out) ?
-                         NodeRole::OutPortCount :
-                         NodeRole::InPortCount).toUInt();
-
-  for (PortIndex portIndex = 0ul; portIndex < n; ++portIndex)
-  {
-    QString name;
-
-    if (_graphModel.portData<bool>(nodeId,
-                                   portType,
-                                   portIndex,
-                                   PortRole::CaptionVisible))
-    {
-      name = _graphModel.portData<QString>(nodeId,
-                                           portType,
-                                           portIndex,
-                                           PortRole::Caption);
+        s = portData.value<NodeDataType>().name;
     }
-    else
-    {
-      NodeDataType portData = 
-        _graphModel.portData<NodeDataType>(nodeId, portType,
-                                           portIndex, PortRole::DataType);
 
-      name = portData.name;
-    }
+    return _fontMetrics.boundingRect(s);
+}
+
+unsigned int DefaultVerticalNodeGeometry::maxHorizontalPortsExtent(NodeId const nodeId) const
+{
+    PortCount nInPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
+
+    PortCount nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+
+    unsigned int maxNumOfEntries = std::max(nInPorts, nOutPorts);
+    unsigned int step = _portSize + _portSpasing;
+
+    return step * maxNumOfEntries;
+}
+
+unsigned int DefaultVerticalNodeGeometry::maxPortsTextAdvance(NodeId const nodeId,
+                                                              PortType const portType) const
+{
+    unsigned int width = 0;
+
+    size_t const n = _graphModel
+                         .nodeData(nodeId,
+                                   (portType == PortType::Out) ? NodeRole::OutPortCount
+                                                               : NodeRole::InPortCount)
+                         .toUInt();
+
+    for (PortIndex portIndex = 0ul; portIndex < n; ++portIndex) {
+        QString name;
+
+        if (_graphModel.portData<bool>(nodeId, portType, portIndex, PortRole::CaptionVisible)) {
+            name = _graphModel.portData<QString>(nodeId, portType, portIndex, PortRole::Caption);
+        } else {
+            NodeDataType portData = _graphModel.portData<NodeDataType>(nodeId,
+                                                                       portType,
+                                                                       portIndex,
+                                                                       PortRole::DataType);
+
+            name = portData.name;
+        }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    width = std::max(unsigned(_fontMetrics.horizontalAdvance(name)),
-                     width);
+        width = std::max(unsigned(_fontMetrics.horizontalAdvance(name)), width);
 #else
-    width = std::max(unsigned(_fontMetrics.width(name)),
-                     width);
+        width = std::max(unsigned(_fontMetrics.width(name)), width);
 #endif
-  }
-
-  return width;
-}
-
-
-unsigned int
-DefaultVerticalNodeGeometry::
-portCaptionsHeight(NodeId const   nodeId,
-                   PortType const portType) const
-{
-  unsigned int h = 0;
-
-  switch (portType)
-  {
-    case PortType::In:
-    {
-      PortCount nInPorts =
-        _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
-      for (PortIndex i = 0; i < nInPorts; ++i)
-      {
-        if (_graphModel.portData<bool>(nodeId,
-                                       PortType::In,
-                                       i,
-                                       PortRole::CaptionVisible))
-        {
-          h += _portSpasing;
-          break;
-        }
-      }
     }
 
-    case PortType::Out:
-    {
-      PortCount nOutPorts =
-        _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
-      for (PortIndex i = 0; i < nOutPorts; ++i)
-      {
-        if (_graphModel.portData<bool>(nodeId,
-                                       PortType::Out,
-                                       i,
-                                       PortRole::CaptionVisible))
-        {
-          h += _portSpasing;
-          break;
+    return width;
+}
+
+unsigned int DefaultVerticalNodeGeometry::portCaptionsHeight(NodeId const nodeId,
+                                                             PortType const portType) const
+{
+    unsigned int h = 0;
+
+    switch (portType) {
+    case PortType::In: {
+        PortCount nInPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::InPortCount);
+        for (PortIndex i = 0; i < nInPorts; ++i) {
+            if (_graphModel.portData<bool>(nodeId, PortType::In, i, PortRole::CaptionVisible)) {
+                h += _portSpasing;
+                break;
+            }
         }
-      }
+    }
+
+    case PortType::Out: {
+        PortCount nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+        for (PortIndex i = 0; i < nOutPorts; ++i) {
+            if (_graphModel.portData<bool>(nodeId, PortType::Out, i, PortRole::CaptionVisible)) {
+                h += _portSpasing;
+                break;
+            }
+        }
     }
 
     default:
-      break;
-  }
+        break;
+    }
 
-  return h;
+    return h;
 }
 
-
-}
+} // namespace QtNodes

--- a/src/DefaultVerticalNodeGeometry.hpp
+++ b/src/DefaultVerticalNodeGeometry.hpp
@@ -4,61 +4,57 @@
 
 #include <QtGui/QFontMetrics>
 
-
-namespace QtNodes
-{
+namespace QtNodes {
 
 class AbstractGraphModel;
 class BasicGraphicsScene;
 
-
 class NODE_EDITOR_PUBLIC DefaultVerticalNodeGeometry : public AbstractNodeGeometry
 {
 public:
-  DefaultVerticalNodeGeometry(AbstractGraphModel & graphModel);
+    DefaultVerticalNodeGeometry(AbstractGraphModel &graphModel);
 
 public:
-  QSize size(NodeId const nodeId) const override;
+    QSize size(NodeId const nodeId) const override;
 
-  void recomputeSize(NodeId const nodeId) const override;
+    void recomputeSize(NodeId const nodeId) const override;
 
-  QPointF portPosition(NodeId const    nodeId,
-                       PortType const  portType,
-                       PortIndex const index) const override;
+    QPointF portPosition(NodeId const nodeId,
+                         PortType const portType,
+                         PortIndex const index) const override;
 
-  QPointF portTextPosition(NodeId const nodeId,
-                           PortType const portType,
-                           PortIndex const PortIndex) const override;
+    QPointF portTextPosition(NodeId const nodeId,
+                             PortType const portType,
+                             PortIndex const PortIndex) const override;
 
-  QPointF captionPosition(NodeId const nodeId) const override;
+    QPointF captionPosition(NodeId const nodeId) const override;
 
-  QRectF captionRect(NodeId const nodeId) const override;
+    QRectF captionRect(NodeId const nodeId) const override;
 
-  QPointF widgetPosition(NodeId const nodeId) const override;
+    QPointF widgetPosition(NodeId const nodeId) const override;
 
-  QRect resizeHandleRect(NodeId const nodeId) const override;
+    QRect resizeHandleRect(NodeId const nodeId) const override;
+
 private:
-  QRectF
-  portTextRect(NodeId const   nodeId,
-               PortType const portType,
-               PortIndex const portIndex) const;
-  /// Finds
-  unsigned int maxHorizontalPortsExtent(NodeId const nodeId) const;
+    QRectF portTextRect(NodeId const nodeId,
+                        PortType const portType,
+                        PortIndex const portIndex) const;
+    /// Finds
+    unsigned int maxHorizontalPortsExtent(NodeId const nodeId) const;
 
-  unsigned int maxPortsTextAdvance(NodeId const   nodeId,
-                                   PortType const portType) const;
+    unsigned int maxPortsTextAdvance(NodeId const nodeId, PortType const portType) const;
 
-  unsigned int portCaptionsHeight(NodeId const   nodeId,
-                                  PortType const portType) const;
+    unsigned int portCaptionsHeight(NodeId const nodeId, PortType const portType) const;
+
 private:
-  // Some variables are mutable because we need to change drawing
-  // metrics corresponding to fontMetrics but this doesn't change
-  // constness of the Node.
+    // Some variables are mutable because we need to change drawing
+    // metrics corresponding to fontMetrics but this doesn't change
+    // constness of the Node.
 
-  mutable unsigned int _portSize;
-  unsigned int _portSpasing;
-  mutable QFontMetrics _fontMetrics;
-  mutable QFontMetrics _boldFontMetrics;
+    mutable unsigned int _portSize;
+    unsigned int _portSpasing;
+    mutable QFontMetrics _fontMetrics;
+    mutable QFontMetrics _boldFontMetrics;
 };
 
-}
+} // namespace QtNodes

--- a/src/GraphicsView.cpp
+++ b/src/GraphicsView.cpp
@@ -8,448 +8,356 @@
 
 #include <QtWidgets/QGraphicsScene>
 
-#include <QtGui/QPen>
 #include <QtGui/QBrush>
+#include <QtGui/QPen>
 
 #include <QtWidgets/QMenu>
 
-#include <QtCore/QRectF>
-#include <QtCore/QPointF>
 #include <QtCore/QDebug>
+#include <QtCore/QPointF>
+#include <QtCore/QRectF>
 
 #include <QtOpenGL>
 #include <QtWidgets>
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
-using QtNodes::GraphicsView;
 using QtNodes::BasicGraphicsScene;
+using QtNodes::GraphicsView;
 
-GraphicsView::
-GraphicsView(QWidget* parent)
-  : QGraphicsView(parent)
-  , _clearSelectionAction(Q_NULLPTR)
-  , _deleteSelectionAction(Q_NULLPTR)
-  , _duplicateSelectionAction(Q_NULLPTR)
+GraphicsView::GraphicsView(QWidget *parent)
+    : QGraphicsView(parent)
+    , _clearSelectionAction(Q_NULLPTR)
+    , _deleteSelectionAction(Q_NULLPTR)
+    , _duplicateSelectionAction(Q_NULLPTR)
 {
-  setDragMode(QGraphicsView::ScrollHandDrag);
-  setRenderHint(QPainter::Antialiasing);
+    setDragMode(QGraphicsView::ScrollHandDrag);
+    setRenderHint(QPainter::Antialiasing);
 
-  auto const & flowViewStyle = StyleCollection::flowViewStyle();
+    auto const &flowViewStyle = StyleCollection::flowViewStyle();
 
-  setBackgroundBrush(flowViewStyle.BackgroundColor);
+    setBackgroundBrush(flowViewStyle.BackgroundColor);
 
-  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-  setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+    setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
 
-  setCacheMode(QGraphicsView::CacheBackground);
-  setViewportUpdateMode(QGraphicsView::BoundingRectViewportUpdate);
+    setCacheMode(QGraphicsView::CacheBackground);
+    setViewportUpdateMode(QGraphicsView::BoundingRectViewportUpdate);
 
-  setScaleRange(0.3, 2);
+    setScaleRange(0.3, 2);
 
-  // Sets the scene rect to its maximum possible ranges to avoid autu scene range
-  // re-calculation when expanding the all QGraphicsItems common rect.
-  int maxSize = 32767;
-  setSceneRect(-maxSize, -maxSize, (maxSize * 2), (maxSize * 2));
+    // Sets the scene rect to its maximum possible ranges to avoid autu scene range
+    // re-calculation when expanding the all QGraphicsItems common rect.
+    int maxSize = 32767;
+    setSceneRect(-maxSize, -maxSize, (maxSize * 2), (maxSize * 2));
 }
 
-
-GraphicsView::
-GraphicsView(BasicGraphicsScene* scene, QWidget* parent)
-  : GraphicsView(parent)
+GraphicsView::GraphicsView(BasicGraphicsScene *scene, QWidget *parent)
+    : GraphicsView(parent)
 {
-  setScene(scene);
+    setScene(scene);
 }
 
-
-QAction*
-GraphicsView::
-clearSelectionAction() const
+QAction *GraphicsView::clearSelectionAction() const
 {
-  return _clearSelectionAction;
+    return _clearSelectionAction;
 }
 
-
-QAction*
-GraphicsView::
-deleteSelectionAction() const
+QAction *GraphicsView::deleteSelectionAction() const
 {
-  return _deleteSelectionAction;
+    return _deleteSelectionAction;
 }
 
-
-void
-GraphicsView::
-setScene(BasicGraphicsScene* scene)
+void GraphicsView::setScene(BasicGraphicsScene *scene)
 {
-  QGraphicsView::setScene(scene);
+    QGraphicsView::setScene(scene);
 
-  {
-    // setup actions
-    delete _clearSelectionAction;
-    _clearSelectionAction = new QAction(QStringLiteral("Clear Selection"), this);
-    _clearSelectionAction->setShortcut(Qt::Key_Escape);
-
-    connect(_clearSelectionAction,
-            &QAction::triggered,
-            scene,
-            &QGraphicsScene::clearSelection);
-
-    addAction(_clearSelectionAction);
-  }
-
-
-  {
-    delete _deleteSelectionAction;
-    _deleteSelectionAction = new QAction(QStringLiteral("Delete Selection"), this);
-    _deleteSelectionAction->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
-    _deleteSelectionAction->setShortcut(QKeySequence(QKeySequence::Delete));
-    connect(_deleteSelectionAction,
-            &QAction::triggered,
-            this,
-            &GraphicsView::onDeleteSelectedObjects);
-
-    addAction(_deleteSelectionAction);
-  }
-
-  {
-    delete _duplicateSelectionAction;
-    _duplicateSelectionAction = new QAction(QStringLiteral("Duplicate Selection"), this);
-    _duplicateSelectionAction->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
-    _duplicateSelectionAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_D));
-    connect(_duplicateSelectionAction,
-            &QAction::triggered,
-            this,
-            &GraphicsView::onDuplicateSelectedObjects);
-
-    addAction(_duplicateSelectionAction);
-  }
-
-
-  auto undoAction = scene->undoStack().createUndoAction(this, tr("&Undo"));
-  undoAction->setShortcuts(QKeySequence::Undo);
-  addAction(undoAction);
-
-  auto redoAction = scene->undoStack().createRedoAction(this, tr("&Redo"));
-  redoAction->setShortcuts(QKeySequence::Redo);
-  addAction(redoAction);
-}
-
-
-void
-GraphicsView::
-centerScene()
-{
-  if (scene())
-  {
-    scene()->setSceneRect(QRectF());
-
-    QRectF sceneRect = scene()->sceneRect();
-
-    if (sceneRect.width() > this->rect().width() ||
-        sceneRect.height() > this->rect().height())
     {
-      fitInView(sceneRect, Qt::KeepAspectRatio);
+        // setup actions
+        delete _clearSelectionAction;
+        _clearSelectionAction = new QAction(QStringLiteral("Clear Selection"), this);
+        _clearSelectionAction->setShortcut(Qt::Key_Escape);
+
+        connect(_clearSelectionAction, &QAction::triggered, scene, &QGraphicsScene::clearSelection);
+
+        addAction(_clearSelectionAction);
     }
 
-    centerOn(sceneRect.center());
-  }
-}
-
-
-void
-GraphicsView::
-contextMenuEvent(QContextMenuEvent* event)
-{
-  if (itemAt(event->pos()))
-  {
-    QGraphicsView::contextMenuEvent(event);
-    return;
-  }
-
-  auto const scenePos = mapToScene(event->pos());
-
-  QMenu* menu = nodeScene()->createSceneMenu(scenePos);
-
-  if (menu)
-  {
-    menu->exec(event->globalPos());
-  }
-}
-
-
-void
-GraphicsView::
-wheelEvent(QWheelEvent* event)
-{
-  QPoint delta = event->angleDelta();
-
-  if (delta.y() == 0)
-  {
-    event->ignore();
-    return;
-  }
-
-  double const d = delta.y() / std::abs(delta.y());
-
-  if (d > 0.0)
-    scaleUp();
-  else
-    scaleDown();
-}
-
-
-double
-GraphicsView::
-getScale() const
-{
-  return transform().m11();
-}
-
-
-void
-GraphicsView::
-setScaleRange(double minimum, double maximum)
-{
-  if (maximum < minimum) std::swap(minimum, maximum);
-  minimum = std::max(0.0, minimum);
-  maximum = std::max(0.0, maximum);
-
-  _scaleRange = { minimum, maximum };
-
-  setupScale(transform().m11());
-}
-
-
-void
-GraphicsView::
-setScaleRange(ScaleRange range)
-{
-  setScaleRange(range.minimum, range.maximum);
-}
-
-
-void
-GraphicsView::
-scaleUp()
-{
-  double const step   = 1.2;
-  double const factor = std::pow(step, 1.0);
-
-  if (_scaleRange.maximum > 0)
-  {
-    QTransform t = transform();
-    t.scale(factor, factor);
-    if (t.m11() >= _scaleRange.maximum)
     {
-      setupScale(t.m11());
-      return;
+        delete _deleteSelectionAction;
+        _deleteSelectionAction = new QAction(QStringLiteral("Delete Selection"), this);
+        _deleteSelectionAction->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
+        _deleteSelectionAction->setShortcut(QKeySequence(QKeySequence::Delete));
+        connect(_deleteSelectionAction,
+                &QAction::triggered,
+                this,
+                &GraphicsView::onDeleteSelectedObjects);
+
+        addAction(_deleteSelectionAction);
     }
-  }
 
-  scale(factor, factor);
-  Q_EMIT scaleChanged(transform().m11());
-}
-
-
-void
-GraphicsView::
-scaleDown()
-{
-  double const step   = 1.2;
-  double const factor = std::pow(step, -1.0);
-
-  if (_scaleRange.minimum > 0)
-  {
-    QTransform t = transform();
-    t.scale(factor, factor);
-    if (t.m11() <= _scaleRange.minimum)
     {
-      setupScale(t.m11());
-      return;
+        delete _duplicateSelectionAction;
+        _duplicateSelectionAction = new QAction(QStringLiteral("Duplicate Selection"), this);
+        _duplicateSelectionAction->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
+        _duplicateSelectionAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_D));
+        connect(_duplicateSelectionAction,
+                &QAction::triggered,
+                this,
+                &GraphicsView::onDuplicateSelectedObjects);
+
+        addAction(_duplicateSelectionAction);
     }
-  }
 
-  scale(factor, factor);
-  Q_EMIT scaleChanged(transform().m11());
+    auto undoAction = scene->undoStack().createUndoAction(this, tr("&Undo"));
+    undoAction->setShortcuts(QKeySequence::Undo);
+    addAction(undoAction);
+
+    auto redoAction = scene->undoStack().createRedoAction(this, tr("&Redo"));
+    redoAction->setShortcuts(QKeySequence::Redo);
+    addAction(redoAction);
 }
 
-
-void
-GraphicsView::
-setupScale(double scale)
+void GraphicsView::centerScene()
 {
-  scale = std::max(_scaleRange.minimum, std::min(_scaleRange.maximum, scale));
+    if (scene()) {
+        scene()->setSceneRect(QRectF());
 
-  if (scale <= 0)
-    return;
+        QRectF sceneRect = scene()->sceneRect();
 
-  if (scale == transform().m11())
-    return;
+        if (sceneRect.width() > this->rect().width() || sceneRect.height() > this->rect().height()) {
+            fitInView(sceneRect, Qt::KeepAspectRatio);
+        }
 
-  QTransform matrix;
-  matrix.scale(scale, scale);
-  setTransform(matrix, false);
-
-  Q_EMIT scaleChanged(scale);
+        centerOn(sceneRect.center());
+    }
 }
 
-
-void
-GraphicsView::
-onDeleteSelectedObjects()
+void GraphicsView::contextMenuEvent(QContextMenuEvent *event)
 {
-  nodeScene()->undoStack().push(new DeleteCommand(nodeScene()));
+    if (itemAt(event->pos())) {
+        QGraphicsView::contextMenuEvent(event);
+        return;
+    }
+
+    auto const scenePos = mapToScene(event->pos());
+
+    QMenu *menu = nodeScene()->createSceneMenu(scenePos);
+
+    if (menu) {
+        menu->exec(event->globalPos());
+    }
 }
 
-
-void
-GraphicsView::
-onDuplicateSelectedObjects()
+void GraphicsView::wheelEvent(QWheelEvent *event)
 {
-  QPoint origin = mapFromGlobal(QCursor::pos());
+    QPoint delta = event->angleDelta();
 
-  QRect const viewRect = rect();
-  if (!viewRect.contains(origin))
-    origin = viewRect.center();
+    if (delta.y() == 0) {
+        event->ignore();
+        return;
+    }
 
-  QPointF relativeOrigin = mapToScene(origin);
+    double const d = delta.y() / std::abs(delta.y());
 
-  nodeScene()->undoStack().push(new DuplicateCommand(nodeScene(), relativeOrigin));
+    if (d > 0.0)
+        scaleUp();
+    else
+        scaleDown();
 }
 
-
-void
-GraphicsView::
-keyPressEvent(QKeyEvent* event)
+double GraphicsView::getScale() const
 {
-  switch (event->key())
-  {
+    return transform().m11();
+}
+
+void GraphicsView::setScaleRange(double minimum, double maximum)
+{
+    if (maximum < minimum)
+        std::swap(minimum, maximum);
+    minimum = std::max(0.0, minimum);
+    maximum = std::max(0.0, maximum);
+
+    _scaleRange = {minimum, maximum};
+
+    setupScale(transform().m11());
+}
+
+void GraphicsView::setScaleRange(ScaleRange range)
+{
+    setScaleRange(range.minimum, range.maximum);
+}
+
+void GraphicsView::scaleUp()
+{
+    double const step = 1.2;
+    double const factor = std::pow(step, 1.0);
+
+    if (_scaleRange.maximum > 0) {
+        QTransform t = transform();
+        t.scale(factor, factor);
+        if (t.m11() >= _scaleRange.maximum) {
+            setupScale(t.m11());
+            return;
+        }
+    }
+
+    scale(factor, factor);
+    Q_EMIT scaleChanged(transform().m11());
+}
+
+void GraphicsView::scaleDown()
+{
+    double const step = 1.2;
+    double const factor = std::pow(step, -1.0);
+
+    if (_scaleRange.minimum > 0) {
+        QTransform t = transform();
+        t.scale(factor, factor);
+        if (t.m11() <= _scaleRange.minimum) {
+            setupScale(t.m11());
+            return;
+        }
+    }
+
+    scale(factor, factor);
+    Q_EMIT scaleChanged(transform().m11());
+}
+
+void GraphicsView::setupScale(double scale)
+{
+    scale = std::max(_scaleRange.minimum, std::min(_scaleRange.maximum, scale));
+
+    if (scale <= 0)
+        return;
+
+    if (scale == transform().m11())
+        return;
+
+    QTransform matrix;
+    matrix.scale(scale, scale);
+    setTransform(matrix, false);
+
+    Q_EMIT scaleChanged(scale);
+}
+
+void GraphicsView::onDeleteSelectedObjects()
+{
+    nodeScene()->undoStack().push(new DeleteCommand(nodeScene()));
+}
+
+void GraphicsView::onDuplicateSelectedObjects()
+{
+    QPoint origin = mapFromGlobal(QCursor::pos());
+
+    QRect const viewRect = rect();
+    if (!viewRect.contains(origin))
+        origin = viewRect.center();
+
+    QPointF relativeOrigin = mapToScene(origin);
+
+    nodeScene()->undoStack().push(new DuplicateCommand(nodeScene(), relativeOrigin));
+}
+
+void GraphicsView::keyPressEvent(QKeyEvent *event)
+{
+    switch (event->key()) {
     case Qt::Key_Shift:
-      setDragMode(QGraphicsView::RubberBandDrag);
-      break;
+        setDragMode(QGraphicsView::RubberBandDrag);
+        break;
 
     default:
-      break;
-  }
+        break;
+    }
 
-  QGraphicsView::keyPressEvent(event);
+    QGraphicsView::keyPressEvent(event);
 }
 
-
-void
-GraphicsView::
-keyReleaseEvent(QKeyEvent* event)
+void GraphicsView::keyReleaseEvent(QKeyEvent *event)
 {
-  switch (event->key())
-  {
+    switch (event->key()) {
     case Qt::Key_Shift:
-      setDragMode(QGraphicsView::ScrollHandDrag);
-      break;
+        setDragMode(QGraphicsView::ScrollHandDrag);
+        break;
 
     default:
-      break;
-  }
-  QGraphicsView::keyReleaseEvent(event);
-}
-
-
-void
-GraphicsView::
-mousePressEvent(QMouseEvent* event)
-{
-  QGraphicsView::mousePressEvent(event);
-  if (event->button() == Qt::LeftButton)
-  {
-    _clickPos = mapToScene(event->pos());
-  }
-}
-
-
-void
-GraphicsView::
-mouseMoveEvent(QMouseEvent* event)
-{
-  QGraphicsView::mouseMoveEvent(event);
-  if (scene()->mouseGrabberItem() == nullptr && event->buttons() == Qt::LeftButton)
-  {
-    // Make sure shift is not being pressed
-    if ((event->modifiers() & Qt::ShiftModifier) == 0)
-    {
-      QPointF difference = _clickPos - mapToScene(event->pos());
-      setSceneRect(sceneRect().translated(difference.x(), difference.y()));
+        break;
     }
-  }
+    QGraphicsView::keyReleaseEvent(event);
 }
 
-
-void
-GraphicsView::
-drawBackground(QPainter* painter, const QRectF & r)
+void GraphicsView::mousePressEvent(QMouseEvent *event)
 {
-  QGraphicsView::drawBackground(painter, r);
+    QGraphicsView::mousePressEvent(event);
+    if (event->button() == Qt::LeftButton) {
+        _clickPos = mapToScene(event->pos());
+    }
+}
 
-  auto drawGrid =
-    [&](double gridStep)
-    {
-      QRect windowRect = rect();
-      QPointF tl       = mapToScene(windowRect.topLeft());
-      QPointF br       = mapToScene(windowRect.bottomRight());
+void GraphicsView::mouseMoveEvent(QMouseEvent *event)
+{
+    QGraphicsView::mouseMoveEvent(event);
+    if (scene()->mouseGrabberItem() == nullptr && event->buttons() == Qt::LeftButton) {
+        // Make sure shift is not being pressed
+        if ((event->modifiers() & Qt::ShiftModifier) == 0) {
+            QPointF difference = _clickPos - mapToScene(event->pos());
+            setSceneRect(sceneRect().translated(difference.x(), difference.y()));
+        }
+    }
+}
 
-      double left   = std::floor(tl.x() / gridStep - 0.5);
-      double right  = std::floor(br.x() / gridStep + 1.0);
-      double bottom = std::floor(tl.y() / gridStep - 0.5);
-      double top    = std::floor(br.y() / gridStep + 1.0);
+void GraphicsView::drawBackground(QPainter *painter, const QRectF &r)
+{
+    QGraphicsView::drawBackground(painter, r);
 
-      // vertical lines
-      for (int xi = int(left); xi <= int(right); ++xi)
-      {
-        QLineF line(xi * gridStep, bottom * gridStep,
-                    xi * gridStep, top * gridStep);
+    auto drawGrid = [&](double gridStep) {
+        QRect windowRect = rect();
+        QPointF tl = mapToScene(windowRect.topLeft());
+        QPointF br = mapToScene(windowRect.bottomRight());
 
-        painter->drawLine(line);
-      }
+        double left = std::floor(tl.x() / gridStep - 0.5);
+        double right = std::floor(br.x() / gridStep + 1.0);
+        double bottom = std::floor(tl.y() / gridStep - 0.5);
+        double top = std::floor(br.y() / gridStep + 1.0);
 
-      // horizontal lines
-      for (int yi = int(bottom); yi <= int(top); ++yi)
-      {
-        QLineF line(left * gridStep, yi * gridStep,
-                    right * gridStep, yi * gridStep);
-        painter->drawLine(line);
-      }
+        // vertical lines
+        for (int xi = int(left); xi <= int(right); ++xi) {
+            QLineF line(xi * gridStep, bottom * gridStep, xi * gridStep, top * gridStep);
+
+            painter->drawLine(line);
+        }
+
+        // horizontal lines
+        for (int yi = int(bottom); yi <= int(top); ++yi) {
+            QLineF line(left * gridStep, yi * gridStep, right * gridStep, yi * gridStep);
+            painter->drawLine(line);
+        }
     };
 
-  auto const & flowViewStyle = StyleCollection::flowViewStyle();
+    auto const &flowViewStyle = StyleCollection::flowViewStyle();
 
-  QPen pfine(flowViewStyle.FineGridColor, 1.0);
+    QPen pfine(flowViewStyle.FineGridColor, 1.0);
 
-  painter->setPen(pfine);
-  drawGrid(15);
+    painter->setPen(pfine);
+    drawGrid(15);
 
-  QPen p(flowViewStyle.CoarseGridColor, 1.0);
+    QPen p(flowViewStyle.CoarseGridColor, 1.0);
 
-  painter->setPen(p);
-  drawGrid(150);
+    painter->setPen(p);
+    drawGrid(150);
 }
 
-
-void
-GraphicsView::
-showEvent(QShowEvent* event)
+void GraphicsView::showEvent(QShowEvent *event)
 {
-  QGraphicsView::showEvent(event);
+    QGraphicsView::showEvent(event);
 
-  centerScene();
+    centerScene();
 }
 
-
-BasicGraphicsScene*
-GraphicsView::
-nodeScene()
+BasicGraphicsScene *GraphicsView::nodeScene()
 {
-  return dynamic_cast<BasicGraphicsScene*>(scene());
+    return dynamic_cast<BasicGraphicsScene *>(scene());
 }
-

--- a/src/GraphicsViewStyle.cpp
+++ b/src/GraphicsViewStyle.cpp
@@ -1,102 +1,94 @@
 #include "GraphicsViewStyle.hpp"
 
 #include <QtCore/QFile>
+#include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonValueRef>
-#include <QtCore/QJsonArray>
 
 #include "StyleCollection.hpp"
 
 using QtNodes::GraphicsViewStyle;
 
-inline void
-initResources() { Q_INIT_RESOURCE(resources); }
-
-GraphicsViewStyle::
-GraphicsViewStyle()
+inline void initResources()
 {
-  // Explicit resources inialization for preventing the static initialization
-  // order fiasco: https://isocpp.org/wiki/faq/ctors#static-init-order
-  initResources();
-
-  // This configuration is stored inside the compiled unit and is loaded statically
-  loadJsonFile(":DefaultStyle.json");
+    Q_INIT_RESOURCE(resources);
 }
 
-
-GraphicsViewStyle::
-GraphicsViewStyle(QString jsonText)
+GraphicsViewStyle::GraphicsViewStyle()
 {
-  loadJsonText(jsonText);
+    // Explicit resources inialization for preventing the static initialization
+    // order fiasco: https://isocpp.org/wiki/faq/ctors#static-init-order
+    initResources();
+
+    // This configuration is stored inside the compiled unit and is loaded statically
+    loadJsonFile(":DefaultStyle.json");
 }
 
-
-void
-GraphicsViewStyle::
-setStyle(QString jsonText)
+GraphicsViewStyle::GraphicsViewStyle(QString jsonText)
 {
-  GraphicsViewStyle style(jsonText);
-
-  StyleCollection::setGraphicsViewStyle(style);
+    loadJsonText(jsonText);
 }
 
+void GraphicsViewStyle::setStyle(QString jsonText)
+{
+    GraphicsViewStyle style(jsonText);
+
+    StyleCollection::setGraphicsViewStyle(style);
+}
 
 #ifdef STYLE_DEBUG
-  #define FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(v, variable) { \
-    if (v.type() == QJsonValue::Undefined || \
-        v.type() == QJsonValue::Null) \
-    qWarning () << "Undefined value for parameter:" << #variable; \
-}
+#define FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(v, variable) \
+    { \
+        if (v.type() == QJsonValue::Undefined || v.type() == QJsonValue::Null) \
+            qWarning() << "Undefined value for parameter:" << #variable; \
+    }
 #else
-  #define FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
+#define FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
 #endif
 
-#define FLOW_VIEW_STYLE_READ_COLOR(values, variable)  { \
-    auto valueRef = values[#variable]; \
-    FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    if (valueRef.isArray()) { \
-      auto colorArray = valueRef.toArray(); \
-      std::vector<int> rgb; rgb.reserve(3); \
-      for (auto it = colorArray.begin(); it != colorArray.end(); ++it) { \
-        rgb.push_back((*it).toInt()); \
-      } \
-      variable = QColor(rgb[0], rgb[1], rgb[2]); \
-    } else { \
-      variable = QColor(valueRef.toString()); \
-    } \
-}
+#define FLOW_VIEW_STYLE_READ_COLOR(values, variable) \
+    { \
+        auto valueRef = values[#variable]; \
+        FLOW_VIEW_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+        if (valueRef.isArray()) { \
+            auto colorArray = valueRef.toArray(); \
+            std::vector<int> rgb; \
+            rgb.reserve(3); \
+            for (auto it = colorArray.begin(); it != colorArray.end(); ++it) { \
+                rgb.push_back((*it).toInt()); \
+            } \
+            variable = QColor(rgb[0], rgb[1], rgb[2]); \
+        } else { \
+            variable = QColor(valueRef.toString()); \
+        } \
+    }
 
-#define FLOW_VIEW_STYLE_WRITE_COLOR(values, variable)  { \
-    values[#variable] = variable.name(); \
-}
+#define FLOW_VIEW_STYLE_WRITE_COLOR(values, variable) \
+    { \
+        values[#variable] = variable.name(); \
+    }
 
-
-void
-GraphicsViewStyle::
-loadJson(QJsonObject const & json)
+void GraphicsViewStyle::loadJson(QJsonObject const &json)
 {
-  QJsonValue nodeStyleValues = json["GraphicsViewStyle"];
+    QJsonValue nodeStyleValues = json["GraphicsViewStyle"];
 
-  QJsonObject obj = nodeStyleValues.toObject();
+    QJsonObject obj = nodeStyleValues.toObject();
 
-  FLOW_VIEW_STYLE_READ_COLOR(obj, BackgroundColor);
-  FLOW_VIEW_STYLE_READ_COLOR(obj, FineGridColor);
-  FLOW_VIEW_STYLE_READ_COLOR(obj, CoarseGridColor);
+    FLOW_VIEW_STYLE_READ_COLOR(obj, BackgroundColor);
+    FLOW_VIEW_STYLE_READ_COLOR(obj, FineGridColor);
+    FLOW_VIEW_STYLE_READ_COLOR(obj, CoarseGridColor);
 }
 
-
-QJsonObject
-GraphicsViewStyle::
-toJson() const
+QJsonObject GraphicsViewStyle::toJson() const
 {
-  QJsonObject obj;
+    QJsonObject obj;
 
-  FLOW_VIEW_STYLE_WRITE_COLOR(obj, BackgroundColor);
-  FLOW_VIEW_STYLE_WRITE_COLOR(obj, FineGridColor);
-  FLOW_VIEW_STYLE_WRITE_COLOR(obj, CoarseGridColor);
+    FLOW_VIEW_STYLE_WRITE_COLOR(obj, BackgroundColor);
+    FLOW_VIEW_STYLE_WRITE_COLOR(obj, FineGridColor);
+    FLOW_VIEW_STYLE_WRITE_COLOR(obj, CoarseGridColor);
 
-  QJsonObject root;
-  root["GraphicsViewStyle"] = obj;
+    QJsonObject root;
+    root["GraphicsViewStyle"] = obj;
 
-  return root;
+    return root;
 }

--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -11,180 +11,142 @@
 
 #include <QUndoStack>
 
+namespace QtNodes {
 
-namespace QtNodes
-{
-
-NodeConnectionInteraction::
-NodeConnectionInteraction(NodeGraphicsObject & ngo,
-                          ConnectionGraphicsObject & cgo,
-                          BasicGraphicsScene & scene)
-  : _ngo(ngo)
-  , _cgo(cgo)
-  , _scene(scene)
+NodeConnectionInteraction::NodeConnectionInteraction(NodeGraphicsObject &ngo,
+                                                     ConnectionGraphicsObject &cgo,
+                                                     BasicGraphicsScene &scene)
+    : _ngo(ngo)
+    , _cgo(cgo)
+    , _scene(scene)
 {}
 
-
-bool
-NodeConnectionInteraction::
-canConnect(PortIndex * portIndex) const
+bool NodeConnectionInteraction::canConnect(PortIndex *portIndex) const
 {
-  // 1. Connection requires a port.
+    // 1. Connection requires a port.
 
-  PortType requiredPort = _cgo.connectionState().requiredPort();
+    PortType requiredPort = _cgo.connectionState().requiredPort();
 
-  if (requiredPort == PortType::None)
-  {
-    return false;
-  }
+    if (requiredPort == PortType::None) {
+        return false;
+    }
 
-  NodeId connectedNodeId =
-    getNodeId(oppositePort(requiredPort), 
-              _cgo.connectionId());
+    NodeId connectedNodeId = getNodeId(oppositePort(requiredPort), _cgo.connectionId());
 
-  // 2. Forbid connecting the node to itself.
+    // 2. Forbid connecting the node to itself.
 
-  if (_ngo.nodeId() == connectedNodeId)
-    return false;
+    if (_ngo.nodeId() == connectedNodeId)
+        return false;
 
-  // 3. Connection loose end is above the node port.
+    // 3. Connection loose end is above the node port.
 
-  QPointF connectionPoint =
-    _cgo.sceneTransform().map(_cgo.endPoint(requiredPort));
+    QPointF connectionPoint = _cgo.sceneTransform().map(_cgo.endPoint(requiredPort));
 
-  *portIndex = nodePortIndexUnderScenePoint(requiredPort,
-                                            connectionPoint);
+    *portIndex = nodePortIndexUnderScenePoint(requiredPort, connectionPoint);
 
-  if (*portIndex == InvalidPortIndex)
-  {
-    return false;
-  }
+    if (*portIndex == InvalidPortIndex) {
+        return false;
+    }
 
-  // 4. Model allows connection.
+    // 4. Model allows connection.
 
-  AbstractGraphModel & model = _ngo.nodeScene()->graphModel();
+    AbstractGraphModel &model = _ngo.nodeScene()->graphModel();
 
-  ConnectionId connectionId =
-    makeCompleteConnectionId(_cgo.connectionId(), // incomplete
-                             _ngo.nodeId(), // missing node id
-                             *portIndex); // missing port index
+    ConnectionId connectionId = makeCompleteConnectionId(_cgo.connectionId(), // incomplete
+                                                         _ngo.nodeId(),       // missing node id
+                                                         *portIndex);         // missing port index
 
-  return model.connectionPossible(connectionId);
+    return model.connectionPossible(connectionId);
 }
 
-
-bool
-NodeConnectionInteraction::
-tryConnect() const
+bool NodeConnectionInteraction::tryConnect() const
 {
-  // 1. Check conditions from 'canConnect'.
+    // 1. Check conditions from 'canConnect'.
 
-  PortIndex targetPortIndex = InvalidPortIndex;
-  if (!canConnect(&targetPortIndex))
-  {
-    return false;
-  }
+    PortIndex targetPortIndex = InvalidPortIndex;
+    if (!canConnect(&targetPortIndex)) {
+        return false;
+    }
 
-  // 2. Create new connection.
+    // 2. Create new connection.
 
-  ConnectionId incompleteConnectionId = _cgo.connectionId();
+    ConnectionId incompleteConnectionId = _cgo.connectionId();
 
-  ConnectionId newConnectionId =
-    makeCompleteConnectionId(incompleteConnectionId,
-                             _ngo.nodeId(),
-                             targetPortIndex);
+    ConnectionId newConnectionId = makeCompleteConnectionId(incompleteConnectionId,
+                                                            _ngo.nodeId(),
+                                                            targetPortIndex);
 
-  _ngo.nodeScene()->resetDraftConnection();
+    _ngo.nodeScene()->resetDraftConnection();
 
-  _ngo.nodeScene()->undoStack().push(new ConnectCommand(_ngo.nodeScene(),
-                                                        newConnectionId));
+    _ngo.nodeScene()->undoStack().push(new ConnectCommand(_ngo.nodeScene(), newConnectionId));
 
-  return true;
+    return true;
 }
 
-
-bool
-NodeConnectionInteraction::
-disconnect(PortType portToDisconnect) const
+bool NodeConnectionInteraction::disconnect(PortType portToDisconnect) const
 {
-  ConnectionId connectionId = _cgo.connectionId();
+    ConnectionId connectionId = _cgo.connectionId();
 
-  _scene.undoStack().push(new DisconnectCommand(&_scene,
-                                                connectionId));
+    _scene.undoStack().push(new DisconnectCommand(&_scene, connectionId));
 
-  AbstractNodeGeometry & geometry = _scene.nodeGeometry();
+    AbstractNodeGeometry &geometry = _scene.nodeGeometry();
 
-  QPointF scenePos =
-    geometry.portScenePosition(_ngo.nodeId(),
-                               portToDisconnect,
-                               getPortIndex(portToDisconnect,
-                                            connectionId),
-                               _ngo.sceneTransform());
+    QPointF scenePos = geometry.portScenePosition(_ngo.nodeId(),
+                                                  portToDisconnect,
+                                                  getPortIndex(portToDisconnect, connectionId),
+                                                  _ngo.sceneTransform());
 
-  // Converted to "draft" connection with the new incomplete id.
-  ConnectionId incompleteConnectionId =
-    makeIncompleteConnectionId(connectionId, portToDisconnect);
+    // Converted to "draft" connection with the new incomplete id.
+    ConnectionId incompleteConnectionId = makeIncompleteConnectionId(connectionId, portToDisconnect);
 
-  // Grabs the mouse
-  auto const & draftConnection =
-    _scene.makeDraftConnection(incompleteConnectionId);
+    // Grabs the mouse
+    auto const &draftConnection = _scene.makeDraftConnection(incompleteConnectionId);
 
-  QPointF const looseEndPos = draftConnection->mapFromScene(scenePos);
-  draftConnection->setEndPoint(portToDisconnect, looseEndPos);
+    QPointF const looseEndPos = draftConnection->mapFromScene(scenePos);
+    draftConnection->setEndPoint(portToDisconnect, looseEndPos);
 
-  // Repaint connection points.
-  NodeId connectedNodeId =
-    getNodeId(oppositePort(portToDisconnect), connectionId);
-  _scene.nodeGraphicsObject(connectedNodeId)->update();
+    // Repaint connection points.
+    NodeId connectedNodeId = getNodeId(oppositePort(portToDisconnect), connectionId);
+    _scene.nodeGraphicsObject(connectedNodeId)->update();
 
-  NodeId disconnectedNodeId =
-    getNodeId(portToDisconnect, connectionId);
-  _scene.nodeGraphicsObject(disconnectedNodeId)->update();
+    NodeId disconnectedNodeId = getNodeId(portToDisconnect, connectionId);
+    _scene.nodeGraphicsObject(disconnectedNodeId)->update();
 
-  return true;
+    return true;
 }
-
 
 // ------------------ util functions below
 
-PortType
-NodeConnectionInteraction::
-connectionRequiredPort() const
+PortType NodeConnectionInteraction::connectionRequiredPort() const
 {
-  auto const &state = _cgo.connectionState();
+    auto const &state = _cgo.connectionState();
 
-  return state.requiredPort();
+    return state.requiredPort();
 }
 
-
-QPointF
-NodeConnectionInteraction::
-nodePortScenePosition(PortType portType, PortIndex portIndex) const
+QPointF NodeConnectionInteraction::nodePortScenePosition(PortType portType,
+                                                         PortIndex portIndex) const
 {
-  AbstractNodeGeometry & geometry = _scene.nodeGeometry();
+    AbstractNodeGeometry &geometry = _scene.nodeGeometry();
 
-  QPointF p = geometry.portScenePosition(_ngo.nodeId(),
-                                         portType,
-                                         portIndex,
-                                         _ngo.sceneTransform());
+    QPointF p = geometry.portScenePosition(_ngo.nodeId(),
+                                           portType,
+                                           portIndex,
+                                           _ngo.sceneTransform());
 
-  return p;
+    return p;
 }
 
-
-PortIndex
-NodeConnectionInteraction::
-nodePortIndexUnderScenePoint(PortType portType,
-                             QPointF const & scenePoint) const
+PortIndex NodeConnectionInteraction::nodePortIndexUnderScenePoint(PortType portType,
+                                                                  QPointF const &scenePoint) const
 {
-  AbstractNodeGeometry & geometry = _scene.nodeGeometry();
+    AbstractNodeGeometry &geometry = _scene.nodeGeometry();
 
-  QTransform sceneTransform = _ngo.sceneTransform();
+    QTransform sceneTransform = _ngo.sceneTransform();
 
-  QPointF nodePoint = sceneTransform.inverted().map(scenePoint);
+    QPointF nodePoint = sceneTransform.inverted().map(scenePoint);
 
-  return geometry.checkPortHit(_ngo.nodeId(), portType, nodePoint);
+    return geometry.checkPortHit(_ngo.nodeId(), portType, nodePoint);
 }
 
-
-}
+} // namespace QtNodes

--- a/src/NodeConnectionInteraction.hpp
+++ b/src/NodeConnectionInteraction.hpp
@@ -6,8 +6,7 @@
 
 #include "Definitions.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class ConnectionGraphicsObject;
 class NodeGraphicsObject;
@@ -21,54 +20,49 @@ class BasicGraphicsScene;
 class NodeConnectionInteraction
 {
 public:
-  NodeConnectionInteraction(NodeGraphicsObject & ngo,
-                            ConnectionGraphicsObject & cgo,
-                            BasicGraphicsScene & scene);
+    NodeConnectionInteraction(NodeGraphicsObject &ngo,
+                              ConnectionGraphicsObject &cgo,
+                              BasicGraphicsScene &scene);
 
-  /**
+    /**
    * Can connect when following conditions are met:
    * 1. Connection 'requires' a port.
    * 2. Connection loose end is above the node port.
    * 3. Source and target `nodeId`s are different.
    * 4. GraphModel permits connection.
    */
-  bool canConnect(PortIndex * portIndex) const;
+    bool canConnect(PortIndex *portIndex) const;
 
-  /// Creates a new connectino if possible.
-  /**
+    /// Creates a new connectino if possible.
+    /**
    * 1. Check conditions from 'canConnect'.
    * 2. Creates new connection with `GraphModel::addConnection`.
    * 3. Adjust connection geometry.
    */
-  bool tryConnect() const;
+    bool tryConnect() const;
 
-  
-  /**
+    /**
    * 1. Delete connection with `GraphModel::deleteConnection`.
    * 2. Create a "draft" connection with incomplete `ConnectionId`.
    * 3. Repaint both previously connected nodes.
    */
-  bool disconnect(PortType portToDisconnect) const;
+    bool disconnect(PortType portToDisconnect) const;
 
 private:
+    PortType connectionRequiredPort() const;
 
-  PortType connectionRequiredPort() const;
+    QPointF connectionEndScenePosition(PortType) const;
 
-  QPointF connectionEndScenePosition(PortType) const;
+    QPointF nodePortScenePosition(PortType portType, PortIndex portIndex) const;
 
-  QPointF nodePortScenePosition(PortType  portType,
-                                PortIndex portIndex) const;
-
-  PortIndex nodePortIndexUnderScenePoint(PortType portType,
-                                         QPointF const &p) const;
+    PortIndex nodePortIndexUnderScenePoint(PortType portType, QPointF const &p) const;
 
 private:
+    NodeGraphicsObject &_ngo;
 
-  NodeGraphicsObject & _ngo;
+    ConnectionGraphicsObject &_cgo;
 
-  ConnectionGraphicsObject & _cgo;
-
-  BasicGraphicsScene & _scene;
+    BasicGraphicsScene &_scene;
 };
 
-}
+} // namespace QtNodes

--- a/src/NodeDelegateModel.cpp
+++ b/src/NodeDelegateModel.cpp
@@ -2,72 +2,53 @@
 
 #include "StyleCollection.hpp"
 
-namespace QtNodes
-{
+namespace QtNodes {
 
-NodeDelegateModel::
-NodeDelegateModel()
-  : _nodeStyle(StyleCollection::nodeStyle())
+NodeDelegateModel::NodeDelegateModel()
+    : _nodeStyle(StyleCollection::nodeStyle())
 {
-  // Derived classes can initialize specific style here
+    // Derived classes can initialize specific style here
 }
 
-
-QJsonObject
-NodeDelegateModel::
-save() const
+QJsonObject NodeDelegateModel::save() const
 {
-  QJsonObject modelJson;
+    QJsonObject modelJson;
 
-  modelJson["model-name"] = name();
+    modelJson["model-name"] = name();
 
-  return modelJson;
+    return modelJson;
 }
 
-
-void
-NodeDelegateModel::
-load(QJsonObject const &)
+void NodeDelegateModel::load(QJsonObject const &)
 {
-  //
+    //
 }
 
-
-ConnectionPolicy
-NodeDelegateModel::
-portConnectionPolicy(PortType portType, PortIndex) const
+ConnectionPolicy NodeDelegateModel::portConnectionPolicy(PortType portType, PortIndex) const
 {
-  auto result = ConnectionPolicy::One;
-  switch (portType)
-  {
+    auto result = ConnectionPolicy::One;
+    switch (portType) {
     case PortType::In:
-      result = ConnectionPolicy::One;
-      break;
+        result = ConnectionPolicy::One;
+        break;
     case PortType::Out:
-      result = ConnectionPolicy::Many;
-      break;
+        result = ConnectionPolicy::Many;
+        break;
     case PortType::None:
-      break;
-  }
+        break;
+    }
 
-  return result;
+    return result;
 }
 
-
-NodeStyle const &
-NodeDelegateModel::
-nodeStyle() const
+NodeStyle const &NodeDelegateModel::nodeStyle() const
 {
-  return _nodeStyle;
+    return _nodeStyle;
 }
 
-
-void
-NodeDelegateModel::
-setNodeStyle(NodeStyle const & style)
+void NodeDelegateModel::setNodeStyle(NodeStyle const &style)
 {
-  _nodeStyle = style;
+    _nodeStyle = style;
 }
-
 
 } // namespace QtNodes

--- a/src/NodeDelegateModelRegistry.cpp
+++ b/src/NodeDelegateModelRegistry.cpp
@@ -3,45 +3,34 @@
 #include <QtCore/QFile>
 #include <QtWidgets/QMessageBox>
 
-using QtNodes::NodeDelegateModelRegistry;
-using QtNodes::NodeDelegateModel;
 using QtNodes::NodeDataType;
+using QtNodes::NodeDelegateModel;
+using QtNodes::NodeDelegateModelRegistry;
 
-std::unique_ptr<NodeDelegateModel>
-NodeDelegateModelRegistry::
-create(QString const& modelName)
+std::unique_ptr<NodeDelegateModel> NodeDelegateModelRegistry::create(QString const &modelName)
 {
-  auto it = _registeredItemCreators.find(modelName);
+    auto it = _registeredItemCreators.find(modelName);
 
-  if (it != _registeredItemCreators.end())
-  {
-    return it->second();
-  }
+    if (it != _registeredItemCreators.end()) {
+        return it->second();
+    }
 
-  return nullptr;
+    return nullptr;
 }
-
 
 NodeDelegateModelRegistry::RegisteredModelCreatorsMap const &
-NodeDelegateModelRegistry::
-registeredModelCreators() const
+NodeDelegateModelRegistry::registeredModelCreators() const
 {
-  return _registeredItemCreators;
+    return _registeredItemCreators;
 }
-
 
 NodeDelegateModelRegistry::RegisteredModelsCategoryMap const &
-NodeDelegateModelRegistry::
-registeredModelsCategoryAssociation() const
+NodeDelegateModelRegistry::registeredModelsCategoryAssociation() const
 {
-  return _registeredModelsCategory;
+    return _registeredModelsCategory;
 }
 
-
-NodeDelegateModelRegistry::CategoriesSet const &
-NodeDelegateModelRegistry::
-categories() const
+NodeDelegateModelRegistry::CategoriesSet const &NodeDelegateModelRegistry::categories() const
 {
-  return _categories;
+    return _categories;
 }
-

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -1,10 +1,10 @@
 #include "NodeGraphicsObject.hpp"
 
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
 
-#include <QtWidgets/QtWidgets>
 #include <QtWidgets/QGraphicsEffect>
+#include <QtWidgets/QtWidgets>
 
 #include "AbstractGraphModel.hpp"
 #include "AbstractNodeGeometry.hpp"
@@ -16,443 +16,347 @@
 #include "StyleCollection.hpp"
 #include "UndoCommands.hpp"
 
+namespace QtNodes {
 
-namespace QtNodes
+NodeGraphicsObject::NodeGraphicsObject(BasicGraphicsScene &scene, NodeId nodeId)
+    : _nodeId(nodeId)
+    , _graphModel(scene.graphModel())
+    , _nodeState(*this)
+    , _proxyWidget(nullptr)
 {
+    scene.addItem(this);
 
-NodeGraphicsObject::
-NodeGraphicsObject(BasicGraphicsScene& scene,
-                   NodeId              nodeId)
-  : _nodeId(nodeId)
-  , _graphModel(scene.graphModel())
-  , _nodeState(*this)
-  , _proxyWidget(nullptr)
-{
-  scene.addItem(this);
+    setFlag(QGraphicsItem::ItemDoesntPropagateOpacityToChildren, true);
+    setFlag(QGraphicsItem::ItemIsFocusable, true);
 
-  setFlag(QGraphicsItem::ItemDoesntPropagateOpacityToChildren, true);
-  setFlag(QGraphicsItem::ItemIsFocusable,                      true);
+    setLockedState();
 
-  setLockedState();
+    setCacheMode(QGraphicsItem::DeviceCoordinateCache);
 
-  setCacheMode(QGraphicsItem::DeviceCoordinateCache);
+    QJsonObject nodeStyleJson = _graphModel.nodeData(_nodeId, NodeRole::Style).toJsonObject();
 
-  QJsonObject nodeStyleJson =
-    _graphModel.nodeData(_nodeId, NodeRole::Style).toJsonObject();
+    NodeStyle nodeStyle(nodeStyleJson);
 
-  NodeStyle nodeStyle(nodeStyleJson);
+    {
+        auto effect = new QGraphicsDropShadowEffect;
+        effect->setOffset(4, 4);
+        effect->setBlurRadius(20);
+        effect->setColor(nodeStyle.ShadowColor);
 
-  {
-    auto effect = new QGraphicsDropShadowEffect;
-    effect->setOffset(4, 4);
-    effect->setBlurRadius(20);
-    effect->setColor(nodeStyle.ShadowColor);
+        setGraphicsEffect(effect);
+    }
 
-    setGraphicsEffect(effect);
-  }
+    setOpacity(nodeStyle.Opacity);
 
-  setOpacity(nodeStyle.Opacity);
+    setAcceptHoverEvents(true);
 
-  setAcceptHoverEvents(true);
+    setZValue(0);
 
-  setZValue(0);
+    embedQWidget();
 
-  embedQWidget();
+    nodeScene()->nodeGeometry().recomputeSize(_nodeId);
 
-  nodeScene()->nodeGeometry().recomputeSize(_nodeId);
+    QPointF const pos = _graphModel.nodeData<QPointF>(_nodeId, NodeRole::Position);
 
-  QPointF const pos = _graphModel.nodeData<QPointF>(_nodeId, NodeRole::Position);
+    setPos(pos);
 
-  setPos(pos);
-
-  connect(&_graphModel,
-          &AbstractGraphModel::nodeFlagsUpdated,
-          [this](NodeId const nodeId)
-          {
-            if (_nodeId == nodeId)
-              setLockedState();
-          });
+    connect(&_graphModel, &AbstractGraphModel::nodeFlagsUpdated, [this](NodeId const nodeId) {
+        if (_nodeId == nodeId)
+            setLockedState();
+    });
 }
 
-
-AbstractGraphModel &
-NodeGraphicsObject::
-graphModel() const
+AbstractGraphModel &NodeGraphicsObject::graphModel() const
 {
-  return _graphModel;
+    return _graphModel;
 }
 
-
-BasicGraphicsScene*
-NodeGraphicsObject::
-nodeScene() const
+BasicGraphicsScene *NodeGraphicsObject::nodeScene() const
 {
-  return dynamic_cast<BasicGraphicsScene*>(scene());
+    return dynamic_cast<BasicGraphicsScene *>(scene());
 }
 
-
-void
-NodeGraphicsObject::
-embedQWidget()
+void NodeGraphicsObject::embedQWidget()
 {
-  AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
-  geometry.recomputeSize(_nodeId);
-
-  if (auto w = _graphModel.nodeData(_nodeId,
-                                    NodeRole::Widget).value<QWidget*>())
-  {
-    _proxyWidget = new QGraphicsProxyWidget(this);
-
-    _proxyWidget->setWidget(w);
-
-    _proxyWidget->setPreferredWidth(5);
-
+    AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
     geometry.recomputeSize(_nodeId);
 
-    if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag)
-    {
-      unsigned int widgetHeight =
-        geometry.size(_nodeId).height() - geometry.captionRect(_nodeId).height();
+    if (auto w = _graphModel.nodeData(_nodeId, NodeRole::Widget).value<QWidget *>()) {
+        _proxyWidget = new QGraphicsProxyWidget(this);
 
-      // If the widget wants to use as much vertical space as possible, set
-      // it to have the geom's equivalentWidgetHeight.
-      _proxyWidget->setMinimumHeight(widgetHeight);
+        _proxyWidget->setWidget(w);
+
+        _proxyWidget->setPreferredWidth(5);
+
+        geometry.recomputeSize(_nodeId);
+
+        if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag) {
+            unsigned int widgetHeight = geometry.size(_nodeId).height()
+                                        - geometry.captionRect(_nodeId).height();
+
+            // If the widget wants to use as much vertical space as possible, set
+            // it to have the geom's equivalentWidgetHeight.
+            _proxyWidget->setMinimumHeight(widgetHeight);
+        }
+
+        _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
+
+        //update();
+
+        _proxyWidget->setOpacity(1.0);
+        _proxyWidget->setFlag(QGraphicsItem::ItemIgnoresParentOpacity);
+    }
+}
+
+void NodeGraphicsObject::setLockedState()
+{
+    NodeFlags flags = _graphModel.nodeFlags(_nodeId);
+
+    bool const locked = flags.testFlag(NodeFlag::Locked);
+
+    setFlag(QGraphicsItem::ItemIsMovable, !locked);
+    setFlag(QGraphicsItem::ItemIsSelectable, !locked);
+    setFlag(QGraphicsItem::ItemSendsScenePositionChanges, !locked);
+}
+
+QRectF NodeGraphicsObject::boundingRect() const
+{
+    AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
+    return geometry.boundingRect(_nodeId);
+    //return NodeGeometry(_nodeId, _graphModel, nodeScene()).boundingRect();
+}
+
+void NodeGraphicsObject::setGeometryChanged()
+{
+    prepareGeometryChange();
+}
+
+void NodeGraphicsObject::moveConnections() const
+{
+    auto const &connected = _graphModel.allConnectionIds(_nodeId);
+
+    for (auto &cnId : connected) {
+        auto cgo = nodeScene()->connectionGraphicsObject(cnId);
+
+        if (cgo)
+            cgo->move();
+    }
+}
+
+void NodeGraphicsObject::reactToConnection(ConnectionGraphicsObject const *cgo)
+{
+    _nodeState.storeConnectionForReaction(cgo);
+
+    update();
+}
+
+void NodeGraphicsObject::paint(QPainter *painter, QStyleOptionGraphicsItem const *option, QWidget *)
+{
+    painter->setClipRect(option->exposedRect);
+
+    nodeScene()->nodePainter().paint(painter, *this);
+}
+
+QVariant NodeGraphicsObject::itemChange(GraphicsItemChange change, const QVariant &value)
+{
+    if (change == ItemScenePositionHasChanged && scene()) {
+        moveConnections();
     }
 
-    _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
-
-    //update();
-
-    _proxyWidget->setOpacity(1.0);
-    _proxyWidget->setFlag(QGraphicsItem::ItemIgnoresParentOpacity);
-  }
+    return QGraphicsObject::itemChange(change, value);
 }
 
-
-void
-NodeGraphicsObject::
-setLockedState()
+void NodeGraphicsObject::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-  NodeFlags flags = _graphModel.nodeFlags(_nodeId);
+    //if (_nodeState.locked())
+    //return;
 
-  bool const locked = flags.testFlag(NodeFlag::Locked);
+    AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
 
-  setFlag(QGraphicsItem::ItemIsMovable,                        !locked);
-  setFlag(QGraphicsItem::ItemIsSelectable,                     !locked);
-  setFlag(QGraphicsItem::ItemSendsScenePositionChanges,        !locked);
-}
+    for (PortType portToCheck : {PortType::In, PortType::Out}) {
+        QPointF nodeCoord = sceneTransform().inverted().map(event->scenePos());
 
+        PortIndex const portIndex = geometry.checkPortHit(_nodeId, portToCheck, nodeCoord);
 
-QRectF
-NodeGraphicsObject::
-boundingRect() const
-{
-  AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
-  return geometry.boundingRect(_nodeId);
-  //return NodeGeometry(_nodeId, _graphModel, nodeScene()).boundingRect();
-}
+        if (portIndex != InvalidPortIndex) {
+            auto const &connected = _graphModel.connections(_nodeId, portToCheck, portIndex);
 
+            // Start dragging existing connection.
+            if (!connected.empty() && portToCheck == PortType::In) {
+                auto const &cnId = *connected.begin();
 
-void
-NodeGraphicsObject::
-setGeometryChanged()
-{
-  prepareGeometryChange();
-}
+                // Need ConnectionGraphicsObject
 
+                NodeConnectionInteraction interaction(*this,
+                                                      *nodeScene()->connectionGraphicsObject(cnId),
+                                                      *nodeScene());
 
-void
-NodeGraphicsObject::
-moveConnections() const
-{
-  auto const& connected = _graphModel.allConnectionIds(_nodeId);
-
-  for (auto& cnId : connected)
-  {
-    auto cgo = nodeScene()->connectionGraphicsObject(cnId);
-
-    if (cgo)
-      cgo->move();
-  }
-}
-
-
-void
-NodeGraphicsObject::
-reactToConnection(ConnectionGraphicsObject const* cgo)
-{
-  _nodeState.storeConnectionForReaction(cgo);
-
-  update();
-}
-
-
-void
-NodeGraphicsObject::
-paint(QPainter*                       painter,
-      QStyleOptionGraphicsItem const* option,
-      QWidget*)
-{
-  painter->setClipRect(option->exposedRect);
-
-  nodeScene()->nodePainter().paint(painter, *this);
-}
-
-
-QVariant
-NodeGraphicsObject::
-itemChange(GraphicsItemChange change, const QVariant& value)
-{
-  if (change == ItemScenePositionHasChanged && scene())
-  {
-    moveConnections();
-  }
-
-  return QGraphicsObject::itemChange(change, value);
-}
-
-
-void
-NodeGraphicsObject::
-mousePressEvent(QGraphicsSceneMouseEvent* event)
-{
-  //if (_nodeState.locked())
-  //return;
-
-  AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
-
-  for (PortType portToCheck: {PortType::In, PortType::Out})
-  {
-    QPointF nodeCoord =
-      sceneTransform().inverted().map(event->scenePos());
-
-    PortIndex const portIndex =
-      geometry.checkPortHit(_nodeId, portToCheck, nodeCoord);
-
-    if (portIndex != InvalidPortIndex)
-    {
-      auto const& connected =
-        _graphModel.connections(_nodeId, portToCheck, portIndex);
-
-      // Start dragging existing connection.
-      if (!connected.empty() && portToCheck == PortType::In)
-      {
-        auto const& cnId = *connected.begin();
-
-        // Need ConnectionGraphicsObject
-
-        NodeConnectionInteraction
-          interaction(*this,
-                      *nodeScene()->connectionGraphicsObject(cnId),
-                      *nodeScene());
-
-        if (_graphModel.detachPossible(cnId))
-          interaction.disconnect(portToCheck);
-      }
-      else // initialize new Connection
-      {
-        if (portToCheck == PortType::Out)
-        {
-          auto const outPolicy =
-            _graphModel.portData(_nodeId,
-                                 portToCheck,
-                                 portIndex,
-                                 PortRole::ConnectionPolicyRole).value<ConnectionPolicy>();
-
-          if (!connected.empty() &&
-              outPolicy == ConnectionPolicy::One)
-          {
-            for (auto& cnId : connected)
+                if (_graphModel.detachPossible(cnId))
+                    interaction.disconnect(portToCheck);
+            } else // initialize new Connection
             {
-              _graphModel.deleteConnection(cnId);
+                if (portToCheck == PortType::Out) {
+                    auto const outPolicy = _graphModel
+                                               .portData(_nodeId,
+                                                         portToCheck,
+                                                         portIndex,
+                                                         PortRole::ConnectionPolicyRole)
+                                               .value<ConnectionPolicy>();
+
+                    if (!connected.empty() && outPolicy == ConnectionPolicy::One) {
+                        for (auto &cnId : connected) {
+                            _graphModel.deleteConnection(cnId);
+                        }
+                    }
+                } // if port == out
+
+                ConnectionId const incompleteConnectionId = makeIncompleteConnectionId(_nodeId,
+                                                                                       portToCheck,
+                                                                                       portIndex);
+
+                nodeScene()->makeDraftConnection(incompleteConnectionId);
             }
-          }
-        } // if port == out
-
-        ConnectionId const incompleteConnectionId =
-          makeIncompleteConnectionId(_nodeId,
-                                     portToCheck,
-                                     portIndex);
-
-        nodeScene()->makeDraftConnection(incompleteConnectionId);
-      }
+        }
     }
-  }
 
-  if (_graphModel.nodeFlags(_nodeId) & NodeFlag::Resizable)
-  {
-    auto pos = event->pos();
-    bool const hit = geometry.resizeHandleRect(_nodeId).contains(QPoint(pos.x(), pos.y()));
-    _nodeState.setResizing(hit);
-  }
+    if (_graphModel.nodeFlags(_nodeId) & NodeFlag::Resizable) {
+        auto pos = event->pos();
+        bool const hit = geometry.resizeHandleRect(_nodeId).contains(QPoint(pos.x(), pos.y()));
+        _nodeState.setResizing(hit);
+    }
 
-  QGraphicsObject::mousePressEvent(event);
+    QGraphicsObject::mousePressEvent(event);
 
-  if (isSelected())
-  {
-    Q_EMIT nodeScene()->nodeSelected(_nodeId);
-  }
+    if (isSelected()) {
+        Q_EMIT nodeScene()->nodeSelected(_nodeId);
+    }
 }
 
-
-void
-NodeGraphicsObject::
-mouseMoveEvent(QGraphicsSceneMouseEvent* event)
+void NodeGraphicsObject::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
-  // deselect all other items after this one is selected
-  if (!isSelected())
-  {
-    scene()->clearSelection();
-    setSelected(true);
-  }
-
-  if (_nodeState.resizing())
-  {
-    auto diff = event->pos() - event->lastPos();
-
-    if (auto w = _graphModel.nodeData<QWidget*>(_nodeId, NodeRole::Widget))
-    {
-      prepareGeometryChange();
-
-      auto oldSize = w->size();
-
-      oldSize += QSize(diff.x(), diff.y());
-
-      w->setFixedSize(oldSize);
-
-      AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
-
-      _proxyWidget->setMinimumSize(oldSize);
-      _proxyWidget->setMaximumSize(oldSize);
-      _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
-
-      // Passes the new size to the model.
-      geometry.recomputeSize(_nodeId);
-
-      update();
-
-      moveConnections();
-
-      event->accept();
+    // deselect all other items after this one is selected
+    if (!isSelected()) {
+        scene()->clearSelection();
+        setSelected(true);
     }
-  }
-  else
-  {
-    auto diff = event->pos() - event->lastPos();
 
-    nodeScene()->undoStack().push(new MoveNodeCommand(nodeScene(),
-                                                      _nodeId,
-                                                      diff));
+    if (_nodeState.resizing()) {
+        auto diff = event->pos() - event->lastPos();
+
+        if (auto w = _graphModel.nodeData<QWidget *>(_nodeId, NodeRole::Widget)) {
+            prepareGeometryChange();
+
+            auto oldSize = w->size();
+
+            oldSize += QSize(diff.x(), diff.y());
+
+            w->setFixedSize(oldSize);
+
+            AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
+
+            _proxyWidget->setMinimumSize(oldSize);
+            _proxyWidget->setMaximumSize(oldSize);
+            _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
+
+            // Passes the new size to the model.
+            geometry.recomputeSize(_nodeId);
+
+            update();
+
+            moveConnections();
+
+            event->accept();
+        }
+    } else {
+        auto diff = event->pos() - event->lastPos();
+
+        nodeScene()->undoStack().push(new MoveNodeCommand(nodeScene(), _nodeId, diff));
+
+        event->accept();
+    }
+
+    QRectF r = nodeScene()->sceneRect();
+
+    r = r.united(mapToScene(boundingRect()).boundingRect());
+
+    nodeScene()->setSceneRect(r);
+}
+
+void NodeGraphicsObject::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
+{
+    _nodeState.setResizing(false);
+
+    QGraphicsObject::mouseReleaseEvent(event);
+
+    // position connections precisely after fast node move
+    moveConnections();
+
+    nodeScene()->nodeClicked(_nodeId);
+}
+
+void NodeGraphicsObject::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+{
+    // bring all the colliding nodes to background
+    QList<QGraphicsItem *> overlapItems = collidingItems();
+
+    for (QGraphicsItem *item : overlapItems) {
+        if (item->zValue() > 0.0) {
+            item->setZValue(0.0);
+        }
+    }
+
+    // bring this node forward
+    setZValue(1.0);
+
+    _nodeState.setHovered(true);
+
+    update();
+
+    Q_EMIT nodeScene()->nodeHovered(_nodeId, event->screenPos());
 
     event->accept();
-  }
-
-  QRectF r = nodeScene()->sceneRect();
-
-  r = r.united(mapToScene(boundingRect()).boundingRect());
-
-  nodeScene()->setSceneRect(r);
 }
 
-
-void
-NodeGraphicsObject::
-mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
+void NodeGraphicsObject::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
-  _nodeState.setResizing(false);
+    _nodeState.setHovered(false);
 
-  QGraphicsObject::mouseReleaseEvent(event);
+    setZValue(0.0);
 
-  // position connections precisely after fast node move
-  moveConnections();
+    update();
 
-  nodeScene()->nodeClicked(_nodeId);
+    Q_EMIT nodeScene()->nodeHoverLeft(_nodeId);
+
+    event->accept();
 }
 
-
-void
-NodeGraphicsObject::
-hoverEnterEvent(QGraphicsSceneHoverEvent* event)
+void NodeGraphicsObject::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 {
-  // bring all the colliding nodes to background
-  QList<QGraphicsItem*> overlapItems = collidingItems();
+    auto pos = event->pos();
 
-  for (QGraphicsItem* item : overlapItems)
-  {
-    if (item->zValue() > 0.0)
-    {
-      item->setZValue(0.0);
+    //NodeGeometry geometry(_nodeId, _graphModel, nodeScene());
+    AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
+
+    if ((_graphModel.nodeFlags(_nodeId) | NodeFlag::Resizable)
+        && geometry.resizeHandleRect(_nodeId).contains(QPoint(pos.x(), pos.y()))) {
+        setCursor(QCursor(Qt::SizeFDiagCursor));
+    } else {
+        setCursor(QCursor());
     }
-  }
 
-  // bring this node forward
-  setZValue(1.0);
-
-  _nodeState.setHovered(true);
-
-  update();
-
-  Q_EMIT nodeScene()->nodeHovered(_nodeId, event->screenPos());
-
-  event->accept();
+    event->accept();
 }
 
-
-void
-NodeGraphicsObject::
-hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
+void NodeGraphicsObject::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
-  _nodeState.setHovered(false);
+    QGraphicsItem::mouseDoubleClickEvent(event);
 
-  setZValue(0.0);
-
-  update();
-
-  Q_EMIT nodeScene()->nodeHoverLeft(_nodeId);
-
-  event->accept();
+    Q_EMIT nodeScene()->nodeDoubleClicked(_nodeId);
 }
 
-
-void
-NodeGraphicsObject::
-hoverMoveEvent(QGraphicsSceneHoverEvent* event)
+void NodeGraphicsObject::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 {
-  auto pos = event->pos();
-
-  //NodeGeometry geometry(_nodeId, _graphModel, nodeScene());
-  AbstractNodeGeometry & geometry = nodeScene()->nodeGeometry();
-
-  if ((_graphModel.nodeFlags(_nodeId) | NodeFlag::Resizable) &&
-      geometry.resizeHandleRect(_nodeId).contains(QPoint(pos.x(), pos.y())))
-  {
-    setCursor(QCursor(Qt::SizeFDiagCursor));
-  }
-  else
-  {
-    setCursor(QCursor());
-  }
-
-  event->accept();
+    Q_EMIT nodeScene()->nodeContextMenu(_nodeId, mapToScene(event->pos()));
 }
 
-
-void
-NodeGraphicsObject::
-mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
-{
-  QGraphicsItem::mouseDoubleClickEvent(event);
-
-  Q_EMIT nodeScene()->nodeDoubleClicked(_nodeId);
-}
-
-
-void
-NodeGraphicsObject::
-contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
-{
-  Q_EMIT nodeScene()->nodeContextMenu(_nodeId, mapToScene(event->pos()));
-}
-
-
-}
+} // namespace QtNodes

--- a/src/NodeState.cpp
+++ b/src/NodeState.cpp
@@ -3,59 +3,40 @@
 #include "ConnectionGraphicsObject.hpp"
 #include "NodeGraphicsObject.hpp"
 
+namespace QtNodes {
 
-namespace QtNodes
+NodeState::NodeState(NodeGraphicsObject &ngo)
+    : _ngo(ngo)
+    , _hovered(false)
+    , _resizing(false)
+    , _connectionForReaction{nullptr}
 {
-
-NodeState::
-NodeState(NodeGraphicsObject & ngo)
-  : _ngo(ngo)
-  , _hovered(false)
-  , _resizing(false)
-  , _connectionForReaction{nullptr}
-{
-  Q_UNUSED(_ngo);
+    Q_UNUSED(_ngo);
 }
 
-
-void
-NodeState::
-setResizing(bool resizing)
+void NodeState::setResizing(bool resizing)
 {
-  _resizing = resizing;
+    _resizing = resizing;
 }
 
-
-bool
-NodeState::
-resizing() const
+bool NodeState::resizing() const
 {
-  return _resizing;
+    return _resizing;
 }
 
-
-ConnectionGraphicsObject const *
-NodeState::
-connectionForReaction() const
+ConnectionGraphicsObject const *NodeState::connectionForReaction() const
 {
-  return _connectionForReaction.data();
+    return _connectionForReaction.data();
 }
 
-
-void
-NodeState::
-storeConnectionForReaction(ConnectionGraphicsObject const * cgo)
+void NodeState::storeConnectionForReaction(ConnectionGraphicsObject const *cgo)
 {
-  _connectionForReaction = cgo;
+    _connectionForReaction = cgo;
 }
 
-
-void
-NodeState::
-resetConnectionForReaction()
+void NodeState::resetConnectionForReaction()
 {
-  _connectionForReaction.clear();
+    _connectionForReaction.clear();
 }
 
-
-}
+} // namespace QtNodes

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -12,144 +12,135 @@
 
 using QtNodes::NodeStyle;
 
-inline void initResources() { Q_INIT_RESOURCE(resources); }
-
-NodeStyle::
-NodeStyle()
+inline void initResources()
 {
-  // Explicit resources inialization for preventing the static initialization
-  // order fiasco: https://isocpp.org/wiki/faq/ctors#static-init-order
-  initResources();
-
-  // This configuration is stored inside the compiled unit and is loaded statically
-  loadJsonFile(":DefaultStyle.json");
+    Q_INIT_RESOURCE(resources);
 }
 
-
-NodeStyle::
-NodeStyle(QString jsonText)
+NodeStyle::NodeStyle()
 {
-  loadJsonText(jsonText);
+    // Explicit resources inialization for preventing the static initialization
+    // order fiasco: https://isocpp.org/wiki/faq/ctors#static-init-order
+    initResources();
+
+    // This configuration is stored inside the compiled unit and is loaded statically
+    loadJsonFile(":DefaultStyle.json");
 }
 
-
-NodeStyle::
-NodeStyle(QJsonObject const & json)
+NodeStyle::NodeStyle(QString jsonText)
 {
-  loadJson(json);
+    loadJsonText(jsonText);
 }
 
-
-void
-NodeStyle::
-setNodeStyle(QString jsonText)
+NodeStyle::NodeStyle(QJsonObject const &json)
 {
-  NodeStyle style(jsonText);
-
-  StyleCollection::setNodeStyle(style);
+    loadJson(json);
 }
 
+void NodeStyle::setNodeStyle(QString jsonText)
+{
+    NodeStyle style(jsonText);
+
+    StyleCollection::setNodeStyle(style);
+}
 
 #ifdef STYLE_DEBUG
-  #define NODE_STYLE_CHECK_UNDEFINED_VALUE(v, variable) { \
-    if (v.type() == QJsonValue::Undefined || \
-        v.type() == QJsonValue::Null) \
-    qWarning() << "Undefined value for parameter:" << #variable; \
-}
+#define NODE_STYLE_CHECK_UNDEFINED_VALUE(v, variable) \
+    { \
+        if (v.type() == QJsonValue::Undefined || v.type() == QJsonValue::Null) \
+            qWarning() << "Undefined value for parameter:" << #variable; \
+    }
 #else
-  #define NODE_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
+#define NODE_STYLE_CHECK_UNDEFINED_VALUE(v, variable)
 #endif
 
-#define NODE_STYLE_READ_COLOR(values, variable)  { \
-    auto valueRef = values[#variable]; \
-    NODE_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    if (valueRef.isArray()) { \
-      auto colorArray = valueRef.toArray(); \
-      std::vector<int> rgb; rgb.reserve(3); \
-      for (auto it = colorArray.begin(); it != colorArray.end(); ++it) { \
-        rgb.push_back((*it).toInt()); \
-      } \
-      variable = QColor(rgb[0], rgb[1], rgb[2]); \
-    } else { \
-      variable = QColor(valueRef.toString()); \
-    } \
-}
+#define NODE_STYLE_READ_COLOR(values, variable) \
+    { \
+        auto valueRef = values[#variable]; \
+        NODE_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+        if (valueRef.isArray()) { \
+            auto colorArray = valueRef.toArray(); \
+            std::vector<int> rgb; \
+            rgb.reserve(3); \
+            for (auto it = colorArray.begin(); it != colorArray.end(); ++it) { \
+                rgb.push_back((*it).toInt()); \
+            } \
+            variable = QColor(rgb[0], rgb[1], rgb[2]); \
+        } else { \
+            variable = QColor(valueRef.toString()); \
+        } \
+    }
 
+#define NODE_STYLE_WRITE_COLOR(values, variable) \
+    { \
+        values[#variable] = variable.name(); \
+    }
 
-#define NODE_STYLE_WRITE_COLOR(values, variable)  { \
-    values[#variable] = variable.name(); \
-}
+#define NODE_STYLE_READ_FLOAT(values, variable) \
+    { \
+        auto valueRef = values[#variable]; \
+        NODE_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+        variable = valueRef.toDouble(); \
+    }
 
-#define NODE_STYLE_READ_FLOAT(values, variable)  { \
-    auto valueRef = values[#variable]; \
-    NODE_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
-    variable = valueRef.toDouble(); \
-}
+#define NODE_STYLE_WRITE_FLOAT(values, variable) \
+    { \
+        values[#variable] = variable; \
+    }
 
-#define NODE_STYLE_WRITE_FLOAT(values, variable)  { \
-    values[#variable] = variable; \
-}
-
-
-void
-NodeStyle::
-loadJson(QJsonObject const & json)
+void NodeStyle::loadJson(QJsonObject const &json)
 {
-  QJsonValue nodeStyleValues = json["NodeStyle"];
+    QJsonValue nodeStyleValues = json["NodeStyle"];
 
-  QJsonObject obj = nodeStyleValues.toObject();
+    QJsonObject obj = nodeStyleValues.toObject();
 
-  NODE_STYLE_READ_COLOR(obj, NormalBoundaryColor);
-  NODE_STYLE_READ_COLOR(obj, SelectedBoundaryColor);
-  NODE_STYLE_READ_COLOR(obj, GradientColor0);
-  NODE_STYLE_READ_COLOR(obj, GradientColor1);
-  NODE_STYLE_READ_COLOR(obj, GradientColor2);
-  NODE_STYLE_READ_COLOR(obj, GradientColor3);
-  NODE_STYLE_READ_COLOR(obj, ShadowColor);
-  NODE_STYLE_READ_COLOR(obj, FontColor);
-  NODE_STYLE_READ_COLOR(obj, FontColorFaded);
-  NODE_STYLE_READ_COLOR(obj, ConnectionPointColor);
-  NODE_STYLE_READ_COLOR(obj, FilledConnectionPointColor);
-  NODE_STYLE_READ_COLOR(obj, WarningColor);
-  NODE_STYLE_READ_COLOR(obj, ErrorColor);
+    NODE_STYLE_READ_COLOR(obj, NormalBoundaryColor);
+    NODE_STYLE_READ_COLOR(obj, SelectedBoundaryColor);
+    NODE_STYLE_READ_COLOR(obj, GradientColor0);
+    NODE_STYLE_READ_COLOR(obj, GradientColor1);
+    NODE_STYLE_READ_COLOR(obj, GradientColor2);
+    NODE_STYLE_READ_COLOR(obj, GradientColor3);
+    NODE_STYLE_READ_COLOR(obj, ShadowColor);
+    NODE_STYLE_READ_COLOR(obj, FontColor);
+    NODE_STYLE_READ_COLOR(obj, FontColorFaded);
+    NODE_STYLE_READ_COLOR(obj, ConnectionPointColor);
+    NODE_STYLE_READ_COLOR(obj, FilledConnectionPointColor);
+    NODE_STYLE_READ_COLOR(obj, WarningColor);
+    NODE_STYLE_READ_COLOR(obj, ErrorColor);
 
-  NODE_STYLE_READ_FLOAT(obj, PenWidth);
-  NODE_STYLE_READ_FLOAT(obj, HoveredPenWidth);
-  NODE_STYLE_READ_FLOAT(obj, ConnectionPointDiameter);
+    NODE_STYLE_READ_FLOAT(obj, PenWidth);
+    NODE_STYLE_READ_FLOAT(obj, HoveredPenWidth);
+    NODE_STYLE_READ_FLOAT(obj, ConnectionPointDiameter);
 
-  NODE_STYLE_READ_FLOAT(obj, Opacity);
+    NODE_STYLE_READ_FLOAT(obj, Opacity);
 }
 
-
-QJsonObject
-NodeStyle::
-toJson() const
+QJsonObject NodeStyle::toJson() const
 {
-  QJsonObject obj;
+    QJsonObject obj;
 
-  NODE_STYLE_WRITE_COLOR(obj, NormalBoundaryColor);
-  NODE_STYLE_WRITE_COLOR(obj, SelectedBoundaryColor);
-  NODE_STYLE_WRITE_COLOR(obj, GradientColor0);
-  NODE_STYLE_WRITE_COLOR(obj, GradientColor1);
-  NODE_STYLE_WRITE_COLOR(obj, GradientColor2);
-  NODE_STYLE_WRITE_COLOR(obj, GradientColor3);
-  NODE_STYLE_WRITE_COLOR(obj, ShadowColor);
-  NODE_STYLE_WRITE_COLOR(obj, FontColor);
-  NODE_STYLE_WRITE_COLOR(obj, FontColorFaded);
-  NODE_STYLE_WRITE_COLOR(obj, ConnectionPointColor);
-  NODE_STYLE_WRITE_COLOR(obj, FilledConnectionPointColor);
-  NODE_STYLE_WRITE_COLOR(obj, WarningColor);
-  NODE_STYLE_WRITE_COLOR(obj, ErrorColor);
+    NODE_STYLE_WRITE_COLOR(obj, NormalBoundaryColor);
+    NODE_STYLE_WRITE_COLOR(obj, SelectedBoundaryColor);
+    NODE_STYLE_WRITE_COLOR(obj, GradientColor0);
+    NODE_STYLE_WRITE_COLOR(obj, GradientColor1);
+    NODE_STYLE_WRITE_COLOR(obj, GradientColor2);
+    NODE_STYLE_WRITE_COLOR(obj, GradientColor3);
+    NODE_STYLE_WRITE_COLOR(obj, ShadowColor);
+    NODE_STYLE_WRITE_COLOR(obj, FontColor);
+    NODE_STYLE_WRITE_COLOR(obj, FontColorFaded);
+    NODE_STYLE_WRITE_COLOR(obj, ConnectionPointColor);
+    NODE_STYLE_WRITE_COLOR(obj, FilledConnectionPointColor);
+    NODE_STYLE_WRITE_COLOR(obj, WarningColor);
+    NODE_STYLE_WRITE_COLOR(obj, ErrorColor);
 
-  NODE_STYLE_WRITE_FLOAT(obj, PenWidth);
-  NODE_STYLE_WRITE_FLOAT(obj, HoveredPenWidth);
-  NODE_STYLE_WRITE_FLOAT(obj, ConnectionPointDiameter);
+    NODE_STYLE_WRITE_FLOAT(obj, PenWidth);
+    NODE_STYLE_WRITE_FLOAT(obj, HoveredPenWidth);
+    NODE_STYLE_WRITE_FLOAT(obj, ConnectionPointDiameter);
 
-  NODE_STYLE_WRITE_FLOAT(obj, Opacity);
+    NODE_STYLE_WRITE_FLOAT(obj, Opacity);
 
-  QJsonObject root;
-  root["NodeStyle"] = obj;
+    QJsonObject root;
+    root["NodeStyle"] = obj;
 
-  return root;
+    return root;
 }
-

--- a/src/StyleCollection.cpp
+++ b/src/StyleCollection.cpp
@@ -1,64 +1,43 @@
 #include "StyleCollection.hpp"
 
-using QtNodes::StyleCollection;
-using QtNodes::NodeStyle;
 using QtNodes::ConnectionStyle;
 using QtNodes::GraphicsViewStyle;
+using QtNodes::NodeStyle;
+using QtNodes::StyleCollection;
 
-NodeStyle const &
-StyleCollection::
-nodeStyle()
+NodeStyle const &StyleCollection::nodeStyle()
 {
-  return instance()._nodeStyle;
+    return instance()._nodeStyle;
 }
 
-
-ConnectionStyle const &
-StyleCollection::
-connectionStyle()
+ConnectionStyle const &StyleCollection::connectionStyle()
 {
-  return instance()._connectionStyle;
+    return instance()._connectionStyle;
 }
 
-
-GraphicsViewStyle const &
-StyleCollection::
-flowViewStyle()
+GraphicsViewStyle const &StyleCollection::flowViewStyle()
 {
-  return instance()._flowViewStyle;
+    return instance()._flowViewStyle;
 }
 
-
-void
-StyleCollection::
-setNodeStyle(NodeStyle nodeStyle)
+void StyleCollection::setNodeStyle(NodeStyle nodeStyle)
 {
-  instance()._nodeStyle = nodeStyle;
+    instance()._nodeStyle = nodeStyle;
 }
 
-
-void
-StyleCollection::
-setConnectionStyle(ConnectionStyle connectionStyle)
+void StyleCollection::setConnectionStyle(ConnectionStyle connectionStyle)
 {
-  instance()._connectionStyle = connectionStyle;
+    instance()._connectionStyle = connectionStyle;
 }
 
-
-void
-StyleCollection::
-setGraphicsViewStyle(GraphicsViewStyle flowViewStyle)
+void StyleCollection::setGraphicsViewStyle(GraphicsViewStyle flowViewStyle)
 {
-  instance()._flowViewStyle = flowViewStyle;
+    instance()._flowViewStyle = flowViewStyle;
 }
 
-
-StyleCollection &
-StyleCollection::
-instance()
+StyleCollection &StyleCollection::instance()
 {
-  static StyleCollection collection;
+    static StyleCollection collection;
 
-  return collection;
+    return collection;
 }
-

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -11,402 +11,315 @@
 
 #include <typeinfo>
 
+namespace QtNodes {
 
-namespace QtNodes
+DeleteCommand::DeleteCommand(BasicGraphicsScene *scene)
+    : _scene(scene)
 {
+    auto &graphModel = _scene->graphModel();
 
-DeleteCommand::
-DeleteCommand(BasicGraphicsScene* scene)
-  : _scene(scene)
-{
-  auto & graphModel = _scene->graphModel();
+    QJsonArray connJsonArray;
+    // Delete the selected connections first, ensuring that they won't be
+    // automatically deleted when selected nodes are deleted (deleting a
+    // node deletes some connections as well)
+    for (QGraphicsItem *item : _scene->selectedItems()) {
+        if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject *>(item)) {
+            auto const &cid = c->connectionId();
 
-  QJsonArray connJsonArray;
-  // Delete the selected connections first, ensuring that they won't be
-  // automatically deleted when selected nodes are deleted (deleting a
-  // node deletes some connections as well)
-  for (QGraphicsItem * item : _scene->selectedItems())
-  {
-    if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
-    {
-      auto const& cid = c->connectionId();
-
-      connJsonArray.append(toJson(cid));
+            connJsonArray.append(toJson(cid));
+        }
     }
-  }
 
-  QJsonArray nodesJsonArray;
-  // Delete the nodes; this will delete many of the connections.
-  // Selected connections were already deleted prior to this loop,
-  for (QGraphicsItem * item : _scene->selectedItems())
-  {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
-    {
-      // saving connections attached to the selected nodes
-      for (auto const & cid : graphModel.allConnectionIds(n->nodeId()))
-      {
-        connJsonArray.append(toJson(cid));
-      }
+    QJsonArray nodesJsonArray;
+    // Delete the nodes; this will delete many of the connections.
+    // Selected connections were already deleted prior to this loop,
+    for (QGraphicsItem *item : _scene->selectedItems()) {
+        if (auto n = qgraphicsitem_cast<NodeGraphicsObject *>(item)) {
+            // saving connections attached to the selected nodes
+            for (auto const &cid : graphModel.allConnectionIds(n->nodeId())) {
+                connJsonArray.append(toJson(cid));
+            }
 
-      nodesJsonArray.append(graphModel.saveNode(n->nodeId()));
+            nodesJsonArray.append(graphModel.saveNode(n->nodeId()));
+        }
     }
-  }
 
-  _sceneJson["nodes"] = nodesJsonArray;
-  _sceneJson["connections"] = connJsonArray;
+    _sceneJson["nodes"] = nodesJsonArray;
+    _sceneJson["connections"] = connJsonArray;
 }
 
-
-void
-DeleteCommand::
-undo()
+void DeleteCommand::undo()
 {
-  auto & graphModel = _scene->graphModel();
+    auto &graphModel = _scene->graphModel();
 
-  QJsonArray nodesJsonArray = _sceneJson["nodes"].toArray();
+    QJsonArray nodesJsonArray = _sceneJson["nodes"].toArray();
 
-  for (QJsonValueRef node : nodesJsonArray)
-  {
-    QJsonObject obj = node.toObject();
-    graphModel.loadNode(obj);
-  }
+    for (QJsonValueRef node : nodesJsonArray) {
+        QJsonObject obj = node.toObject();
+        graphModel.loadNode(obj);
+    }
 
-  QJsonArray connectionJsonArray = _sceneJson["connections"].toArray();
+    QJsonArray connectionJsonArray = _sceneJson["connections"].toArray();
 
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
+    for (QJsonValueRef connection : connectionJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-    ConnectionId connId = fromJson(connJson);
+        ConnectionId connId = fromJson(connJson);
 
-    // Restore the connection
-    graphModel.addConnection(connId);
-  }
+        // Restore the connection
+        graphModel.addConnection(connId);
+    }
 }
 
-
-void
-DeleteCommand::
-redo()
+void DeleteCommand::redo()
 {
-  auto & graphModel = _scene->graphModel();
+    auto &graphModel = _scene->graphModel();
 
-  QJsonArray connectionJsonArray = _sceneJson["connections"].toArray();
+    QJsonArray connectionJsonArray = _sceneJson["connections"].toArray();
 
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
+    for (QJsonValueRef connection : connectionJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-    ConnectionId connId = fromJson(connJson);
+        ConnectionId connId = fromJson(connJson);
 
-    graphModel.deleteConnection(connId);
-  }
+        graphModel.deleteConnection(connId);
+    }
 
+    QJsonArray nodesJsonArray = _sceneJson["nodes"].toArray();
 
-  QJsonArray nodesJsonArray = _sceneJson["nodes"].toArray();
-
-  for (QJsonValueRef node : nodesJsonArray)
-  {
-    QJsonObject nodeJson = node.toObject();
-    graphModel.deleteNode(static_cast<NodeId>(nodeJson["id"].toInt()));
-  }
+    for (QJsonValueRef node : nodesJsonArray) {
+        QJsonObject nodeJson = node.toObject();
+        graphModel.deleteNode(static_cast<NodeId>(nodeJson["id"].toInt()));
+    }
 }
-
 
 //-------------------------------------
 
-
-DuplicateCommand::
-DuplicateCommand(BasicGraphicsScene* scene,
-                 QPointF const & mouseScenePos)
-  : _scene(scene)
-  , _mouseScenePos(mouseScenePos)
+DuplicateCommand::DuplicateCommand(BasicGraphicsScene *scene, QPointF const &mouseScenePos)
+    : _scene(scene)
+    , _mouseScenePos(mouseScenePos)
 {
-  auto & graphModel = _scene->graphModel();
+    auto &graphModel = _scene->graphModel();
 
-  std::unordered_set<NodeId> selectedNodes;
+    std::unordered_set<NodeId> selectedNodes;
 
-  QJsonArray nodesJsonArray;
-  // Delete the nodes; this will delete many of the connections.
-  // Selected connections were already deleted prior to this loop,
-  for (QGraphicsItem * item : _scene->selectedItems())
-  {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
-    {
-      nodesJsonArray.append(graphModel.saveNode(n->nodeId()));
+    QJsonArray nodesJsonArray;
+    // Delete the nodes; this will delete many of the connections.
+    // Selected connections were already deleted prior to this loop,
+    for (QGraphicsItem *item : _scene->selectedItems()) {
+        if (auto n = qgraphicsitem_cast<NodeGraphicsObject *>(item)) {
+            nodesJsonArray.append(graphModel.saveNode(n->nodeId()));
 
-      selectedNodes.insert(n->nodeId());
+            selectedNodes.insert(n->nodeId());
+        }
     }
-  }
 
-  QJsonArray connJsonArray;
-  // Delete the selected connections first, ensuring that they won't be
-  // automatically deleted when selected nodes are deleted (deleting a
-  // node deletes some connections as well)
-  for (QGraphicsItem * item : _scene->selectedItems())
-  {
-    if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
-    {
-      auto const& cid = c->connectionId();
+    QJsonArray connJsonArray;
+    // Delete the selected connections first, ensuring that they won't be
+    // automatically deleted when selected nodes are deleted (deleting a
+    // node deletes some connections as well)
+    for (QGraphicsItem *item : _scene->selectedItems()) {
+        if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject *>(item)) {
+            auto const &cid = c->connectionId();
 
-      if (selectedNodes.count(cid.outNodeId) > 0 &&
-          selectedNodes.count(cid.inNodeId) > 0)
-      {
-        connJsonArray.append(toJson(cid));
-      }
+            if (selectedNodes.count(cid.outNodeId) > 0 && selectedNodes.count(cid.inNodeId) > 0) {
+                connJsonArray.append(toJson(cid));
+            }
+        }
     }
-  }
 
-
-  _sceneJson["nodes"] = nodesJsonArray;
-  _sceneJson["connections"] = connJsonArray;
+    _sceneJson["nodes"] = nodesJsonArray;
+    _sceneJson["connections"] = connJsonArray;
 }
 
-
-void
-DuplicateCommand::
-undo()
+void DuplicateCommand::undo()
 {
-  auto & graphModel = _scene->graphModel();
+    auto &graphModel = _scene->graphModel();
 
-  QJsonArray connectionJsonArray = _newSceneJson["connections"].toArray();
+    QJsonArray connectionJsonArray = _newSceneJson["connections"].toArray();
 
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
+    for (QJsonValueRef connection : connectionJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-    ConnectionId connId = fromJson(connJson);
+        ConnectionId connId = fromJson(connJson);
 
-    graphModel.deleteConnection(connId);
-  }
+        graphModel.deleteConnection(connId);
+    }
 
-  QJsonArray nodesJsonArray = _newSceneJson["nodes"].toArray();
+    QJsonArray nodesJsonArray = _newSceneJson["nodes"].toArray();
 
-  for (QJsonValueRef node : nodesJsonArray)
-  {
-    QJsonObject nodeJson = node.toObject();
-    graphModel.deleteNode(static_cast<NodeId>(nodeJson["id"].toInt()));
-  }
+    for (QJsonValueRef node : nodesJsonArray) {
+        QJsonObject nodeJson = node.toObject();
+        graphModel.deleteNode(static_cast<NodeId>(nodeJson["id"].toInt()));
+    }
 }
 
-
-void
-DuplicateCommand::
-redo()
+void DuplicateCommand::redo()
 {
-  _scene->clearSelection();
+    _scene->clearSelection();
 
-  auto & graphModel = _scene->graphModel();
+    auto &graphModel = _scene->graphModel();
 
-  std::unordered_map<NodeId, NodeId> mapNodeIds;
+    std::unordered_map<NodeId, NodeId> mapNodeIds;
 
-  QPointF averagePos;
+    QPointF averagePos;
 
-  QJsonArray nodesJsonArray = _sceneJson["nodes"].toArray();
+    QJsonArray nodesJsonArray = _sceneJson["nodes"].toArray();
 
-  // Cycle below replaces the NodeId with the new generated value
-  // and computes an average position of the old selected node group
+    // Cycle below replaces the NodeId with the new generated value
+    // and computes an average position of the old selected node group
 
-  QJsonArray newNodesJsonArray;
-  for (QJsonValueRef node : nodesJsonArray)
-  {
-    QJsonObject nodeJson = node.toObject();
+    QJsonArray newNodesJsonArray;
+    for (QJsonValueRef node : nodesJsonArray) {
+        QJsonObject nodeJson = node.toObject();
 
-    NodeId oldNodeId = nodeJson["id"].toInt();
+        NodeId oldNodeId = nodeJson["id"].toInt();
 
-    averagePos +=
-      QPointF(nodeJson["position"].toObject()["x"].toDouble(),
-              nodeJson["position"].toObject()["y"].toDouble());
+        averagePos += QPointF(nodeJson["position"].toObject()["x"].toDouble(),
+                              nodeJson["position"].toObject()["y"].toDouble());
 
-    NodeId newNodeId = graphModel.newNodeId();
+        NodeId newNodeId = graphModel.newNodeId();
 
-    mapNodeIds[oldNodeId] = newNodeId;
+        mapNodeIds[oldNodeId] = newNodeId;
 
-    // Replace NodeId in json
-    nodeJson["id"] = static_cast<qint64>(newNodeId);
+        // Replace NodeId in json
+        nodeJson["id"] = static_cast<qint64>(newNodeId);
 
-    newNodesJsonArray.append(nodeJson);
-  }
+        newNodesJsonArray.append(nodeJson);
+    }
 
-  averagePos /= static_cast<double>(nodesJsonArray.size());
+    averagePos /= static_cast<double>(nodesJsonArray.size());
 
+    // The cycle below replaces old NodeIds in connections with the new values
 
-  // The cycle below replaces old NodeIds in connections with the new values
+    QJsonArray connectionJsonArray = _sceneJson["connections"].toArray();
 
-  QJsonArray connectionJsonArray = _sceneJson["connections"].toArray();
+    QJsonArray newConnJsonArray;
+    for (QJsonValueRef connection : connectionJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-  QJsonArray newConnJsonArray;
-  for (QJsonValueRef connection : connectionJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
+        ConnectionId connId = fromJson(connJson);
 
-    ConnectionId connId = fromJson(connJson);
+        ConnectionId newConnId{mapNodeIds[connId.outNodeId],
+                               connId.outPortIndex,
+                               mapNodeIds[connId.inNodeId],
+                               connId.inPortIndex};
 
-    ConnectionId newConnId{mapNodeIds[connId.outNodeId],
-                           connId.outPortIndex,
-                           mapNodeIds[connId.inNodeId],
-                           connId.inPortIndex};
+        newConnJsonArray.append(toJson(newConnId));
+    }
 
+    // Cycle below offsets the new node group to the position of the mouse cursor
+    QPointF const diff = _mouseScenePos - averagePos;
 
-    newConnJsonArray.append(toJson(newConnId));
-  }
+    for (QJsonValueRef node : newNodesJsonArray) {
+        QJsonObject obj = node.toObject();
+        NodeId const id = obj["id"].toInt();
 
-  // Cycle below offsets the new node group to the position of the mouse cursor
-  QPointF const diff = _mouseScenePos - averagePos;
+        QPointF oldPos(obj["position"].toObject()["x"].toDouble(),
+                       obj["position"].toObject()["y"].toDouble());
 
-  for (QJsonValueRef node : newNodesJsonArray)
-  {
-    QJsonObject obj = node.toObject();
-    NodeId const id = obj["id"].toInt();
+        oldPos += diff;
 
-    QPointF oldPos(obj["position"].toObject()["x"].toDouble(),
-                   obj["position"].toObject()["y"].toDouble());
+        QJsonObject posJson;
+        posJson["x"] = oldPos.x();
+        posJson["y"] = oldPos.y();
+        obj["position"] = posJson;
 
-    oldPos += diff;
+        graphModel.loadNode(obj);
 
-    QJsonObject posJson;
-    posJson["x"] = oldPos.x();
-    posJson["y"] = oldPos.y();
-    obj["position"] = posJson;
+        _scene->nodeGraphicsObject(id)->setZValue(1.0);
+    }
 
+    for (QJsonValueRef connection : newConnJsonArray) {
+        QJsonObject connJson = connection.toObject();
 
-    graphModel.loadNode(obj);
+        ConnectionId connId = fromJson(connJson);
 
-    _scene->nodeGraphicsObject(id)->setZValue(1.0);
-  }
+        // Restore the connection
+        graphModel.addConnection(connId);
+    }
 
-  for (QJsonValueRef connection : newConnJsonArray)
-  {
-    QJsonObject connJson = connection.toObject();
-
-    ConnectionId connId = fromJson(connJson);
-
-    // Restore the connection
-    graphModel.addConnection(connId);
-  }
-
-
-  _newSceneJson["nodes"] = newNodesJsonArray;
-  _newSceneJson["connections"] = newConnJsonArray;
+    _newSceneJson["nodes"] = newNodesJsonArray;
+    _newSceneJson["connections"] = newConnJsonArray;
 }
-
 
 //-------------------------------------
 
-
-
-DisconnectCommand::
-DisconnectCommand(BasicGraphicsScene* scene,
-                  ConnectionId const connId)
-  : _scene(scene)
-  , _connId(connId)
+DisconnectCommand::DisconnectCommand(BasicGraphicsScene *scene, ConnectionId const connId)
+    : _scene(scene)
+    , _connId(connId)
 {
-  //
+    //
 }
 
-void
-DisconnectCommand::
-undo()
+void DisconnectCommand::undo()
 {
-  _scene->graphModel().addConnection(_connId);
+    _scene->graphModel().addConnection(_connId);
 }
 
-
-void
-DisconnectCommand::
-redo()
+void DisconnectCommand::redo()
 {
-  _scene->graphModel().deleteConnection(_connId);
+    _scene->graphModel().deleteConnection(_connId);
 }
-
 
 //------
 
-
-ConnectCommand::
-ConnectCommand(BasicGraphicsScene* scene,
-               ConnectionId const connId)
-  : _scene(scene)
-  , _connId(connId)
+ConnectCommand::ConnectCommand(BasicGraphicsScene *scene, ConnectionId const connId)
+    : _scene(scene)
+    , _connId(connId)
 {
-  //
+    //
 }
 
-void
-ConnectCommand::
-undo()
+void ConnectCommand::undo()
 {
-  _scene->graphModel().deleteConnection(_connId);
+    _scene->graphModel().deleteConnection(_connId);
 }
 
-
-void
-ConnectCommand::
-redo()
+void ConnectCommand::redo()
 {
-  _scene->graphModel().addConnection(_connId);
+    _scene->graphModel().addConnection(_connId);
 }
-
 
 //------
 
+MoveNodeCommand::MoveNodeCommand(BasicGraphicsScene *scene, NodeId const nodeId, QPointF const &diff)
+    : _scene(scene)
+    , _nodeId(nodeId)
+    , _diff(diff)
+{}
 
-MoveNodeCommand::
-MoveNodeCommand(BasicGraphicsScene* scene,
-                NodeId const nodeId,
-                QPointF const &diff)
-  : _scene(scene)
-  , _nodeId(nodeId)
-  , _diff(diff)
+void MoveNodeCommand::undo()
 {
+    auto oldPos = _scene->graphModel().nodeData(_nodeId, NodeRole::Position).value<QPointF>();
+
+    oldPos -= _diff;
+
+    _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, oldPos);
 }
 
-void
-MoveNodeCommand::
-undo()
+void MoveNodeCommand::redo()
 {
-  auto oldPos = 
-    _scene->graphModel().nodeData(_nodeId,
-                                  NodeRole::Position).value<QPointF>();
+    auto oldPos = _scene->graphModel().nodeData(_nodeId, NodeRole::Position).value<QPointF>();
 
-  oldPos -= _diff;
+    oldPos += _diff;
 
-  _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, oldPos);
+    _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, oldPos);
 }
 
-
-void
-MoveNodeCommand::
-redo()
+int MoveNodeCommand::id() const
 {
-  auto oldPos = 
-    _scene->graphModel().nodeData(_nodeId,
-                                  NodeRole::Position).value<QPointF>();
-
-  oldPos += _diff;
-
-  _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, oldPos);
+    return static_cast<int>(typeid(MoveNodeCommand).hash_code());
 }
 
-
-int
-MoveNodeCommand::
-id() const
+bool MoveNodeCommand::mergeWith(QUndoCommand const *c)
 {
-  return static_cast<int>(typeid(MoveNodeCommand).hash_code());
-}
+    auto mc = static_cast<MoveNodeCommand const *>(c);
 
+    _diff += mc->_diff;
 
-bool
-MoveNodeCommand::
-mergeWith(QUndoCommand const *c) 
-{
-  auto mc = static_cast<MoveNodeCommand const*>(c);
-
-  _diff += mc->_diff;
-
-  return true;
+    return true;
 }
 
 //
-}
+} // namespace QtNodes

--- a/src/UndoCommands.hpp
+++ b/src/UndoCommands.hpp
@@ -3,31 +3,29 @@
 #include "Definitions.hpp"
 
 #include <QUndoCommand>
-#include <QtCore/QPointF>
 #include <QtCore/QJsonObject>
+#include <QtCore/QPointF>
 
-namespace QtNodes
-{
+namespace QtNodes {
 
 class BasicGraphicsScene;
-
 
 /**
  * Selected scene objects are serialized and then removed from the scene.
  * The deleted elements could be restored in `undo`.
  */
-class DeleteCommand : public QUndoCommand 
+class DeleteCommand : public QUndoCommand
 {
 public:
-  DeleteCommand(BasicGraphicsScene* scene);
+    DeleteCommand(BasicGraphicsScene *scene);
 
-  void undo() override;
-  void redo() override;
+    void undo() override;
+    void redo() override;
+
 private:
-  BasicGraphicsScene* _scene;
-  QJsonObject _sceneJson;
+    BasicGraphicsScene *_scene;
+    QJsonObject _sceneJson;
 };
-
 
 /**
  * A command used in `GraphicsView` when user duplicates the selected objects by
@@ -36,16 +34,15 @@ private:
 class DuplicateCommand : public QUndoCommand
 {
 public:
-  DuplicateCommand(BasicGraphicsScene* scene,
-                   QPointF const & mouseScenePos);
+    DuplicateCommand(BasicGraphicsScene *scene, QPointF const &mouseScenePos);
 
-  /**
+    /**
    * Uses the stored `_newSceneJson` variable with the serialized duplicates to
    * delet nodes and connections.
    */
-  void undo() override;
+    void undo() override;
 
-  /**
+    /**
    * Inserting duplicates is done via serializing the current scene selection and
    * then de-serirializing with on-the-fly substitution of newly generated
    * NodeIds for the inserted objects.
@@ -53,73 +50,66 @@ public:
    * A the same time all the new objects are stored in `_newSceneJson` in order
    * to be able to undo the duplication.
    */
-  void redo() override;
-private:
-  BasicGraphicsScene* _scene;
-  QPointF const & _mouseScenePos;
-  QJsonObject _sceneJson;
-  QJsonObject _newSceneJson;
-};
+    void redo() override;
 
+private:
+    BasicGraphicsScene *_scene;
+    QPointF const &_mouseScenePos;
+    QJsonObject _sceneJson;
+    QJsonObject _newSceneJson;
+};
 
 class DisconnectCommand : public QUndoCommand
 {
 public:
-  DisconnectCommand(BasicGraphicsScene* scene,
-                    ConnectionId const);
+    DisconnectCommand(BasicGraphicsScene *scene, ConnectionId const);
 
-  void undo() override;
-  void redo() override;
+    void undo() override;
+    void redo() override;
 
 private:
-  BasicGraphicsScene* _scene;
+    BasicGraphicsScene *_scene;
 
-  ConnectionId _connId;
+    ConnectionId _connId;
 };
-
 
 class ConnectCommand : public QUndoCommand
 {
 public:
-  ConnectCommand(BasicGraphicsScene* scene,
-                 ConnectionId const);
+    ConnectCommand(BasicGraphicsScene *scene, ConnectionId const);
 
-  void undo() override;
-  void redo() override;
+    void undo() override;
+    void redo() override;
 
 private:
-  BasicGraphicsScene* _scene;
+    BasicGraphicsScene *_scene;
 
-  ConnectionId _connId;
+    ConnectionId _connId;
 };
-
 
 class MoveNodeCommand : public QUndoCommand
 {
 public:
-  MoveNodeCommand(BasicGraphicsScene* scene,
-                  NodeId const nodeId,
-                  QPointF const &diff);
+    MoveNodeCommand(BasicGraphicsScene *scene, NodeId const nodeId, QPointF const &diff);
 
-  void undo() override;
-  void redo() override;
+    void undo() override;
+    void redo() override;
 
-  /**
+    /**
    * A command ID is used in command compression. It must be an integer unique to
    * this command's class, or -1 if the command doesn't support compression.
    */
-  int id() const override;
+    int id() const override;
 
-  /**
+    /**
    * Several sequential movements could be merged into one command.
    */
-  bool mergeWith(QUndoCommand const *c) override;
+    bool mergeWith(QUndoCommand const *c) override;
 
 private:
-  BasicGraphicsScene* _scene;
-  NodeId _nodeId;
-  QPointF _diff;
+    BasicGraphicsScene *_scene;
+    NodeId _nodeId;
+    QPointF _diff;
 };
 
-
-}
+} // namespace QtNodes

--- a/src/locateNode.cpp
+++ b/src/locateNode.cpp
@@ -7,42 +7,36 @@
 
 #include "NodeGraphicsObject.hpp"
 
+namespace QtNodes {
 
-namespace QtNodes
+NodeGraphicsObject *locateNodeAt(QPointF scenePoint,
+                                 QGraphicsScene &scene,
+                                 QTransform const &viewTransform)
 {
+    // items under cursor
+    QList<QGraphicsItem *> items = scene.items(scenePoint,
+                                               Qt::IntersectsItemShape,
+                                               Qt::DescendingOrder,
+                                               viewTransform);
 
-NodeGraphicsObject*
-locateNodeAt(QPointF scenePoint,
-             QGraphicsScene &scene,
-             QTransform const & viewTransform)
-{
-  // items under cursor
-  QList<QGraphicsItem*> items =
-    scene.items(scenePoint,
-                Qt::IntersectsItemShape,
-                Qt::DescendingOrder,
-                viewTransform);
+    // items convertable to NodeGraphicsObject
+    std::vector<QGraphicsItem *> filteredItems;
 
-  // items convertable to NodeGraphicsObject
-  std::vector<QGraphicsItem*> filteredItems;
+    std::copy_if(items.begin(),
+                 items.end(),
+                 std::back_inserter(filteredItems),
+                 [](QGraphicsItem *item) {
+                     return (qgraphicsitem_cast<NodeGraphicsObject *>(item) != nullptr);
+                 });
 
-  std::copy_if(items.begin(),
-               items.end(),
-               std::back_inserter(filteredItems),
-               [](QGraphicsItem * item)
-               {
-                 return (qgraphicsitem_cast<NodeGraphicsObject*>(item) != nullptr);
-               });
+    NodeGraphicsObject *node = nullptr;
 
-  NodeGraphicsObject * node = nullptr;
+    if (!filteredItems.empty()) {
+        QGraphicsItem *graphicsItem = filteredItems.front();
+        node = dynamic_cast<NodeGraphicsObject *>(graphicsItem);
+    }
 
-  if (!filteredItems.empty())
-  {
-    QGraphicsItem* graphicsItem = filteredItems.front();
-    node = dynamic_cast<NodeGraphicsObject*>(graphicsItem);
-  }
-
-  return node;
+    return node;
 }
 
-}
+} // namespace QtNodes

--- a/test/include/ApplicationSetup.hpp
+++ b/test/include/ApplicationSetup.hpp
@@ -4,17 +4,15 @@
 
 #include <QApplication>
 
-
-inline std::unique_ptr<QApplication>
-applicationSetup()
+inline std::unique_ptr<QApplication> applicationSetup()
 {
-  static int    Argc       = 0;
-  static char   ArgvVal    = '\0';
-  static char*  ArgvValPtr = &ArgvVal;
-  static char** Argv       = &ArgvValPtr;
+    static int Argc = 0;
+    static char ArgvVal = '\0';
+    static char *ArgvValPtr = &ArgvVal;
+    static char **Argv = &ArgvValPtr;
 
-  auto app = std::make_unique<QApplication>(Argc, Argv);
-  app->setAttribute(Qt::AA_Use96Dpi, true);
+    auto app = std::make_unique<QApplication>(Argc, Argv);
+    app->setAttribute(Qt::AA_Use96Dpi, true);
 
-  return app;
+    return app;
 }

--- a/test/include/Stringify.hpp
+++ b/test/include/Stringify.hpp
@@ -7,25 +7,16 @@
 
 #include <QtTest>
 
-namespace Catch
-{
-template <>
+namespace Catch {
+template<>
 struct StringMaker<QPointF>
 {
-  static std::string
-  convert(QPointF const& p)
-  {
-    return std::string(QTest::toString(p));
-  }
+    static std::string convert(QPointF const &p) { return std::string(QTest::toString(p)); }
 };
 
-template <>
+template<>
 struct StringMaker<QPoint>
 {
-  static std::string
-  convert(QPoint const& p)
-  {
-    return std::string(QTest::toString(p));
-  }
+    static std::string convert(QPoint const &p) { return std::string(QTest::toString(p)); }
 };
-}
+} // namespace Catch

--- a/test/include/StubNodeDataModel.hpp
+++ b/test/include/StubNodeDataModel.hpp
@@ -7,53 +7,28 @@
 class StubNodeDataModel : public QtNodes::NodeDataModel
 {
 public:
-  QString
-  name() const override
-  {
-    return _name;
-  }
+    QString name() const override { return _name; }
 
-  QString
-  caption() const override
-  {
-    return _caption;
-  }
+    QString caption() const override { return _caption; }
 
-  unsigned int nPorts(QtNodes::PortType) const override { return 0; }
+    unsigned int nPorts(QtNodes::PortType) const override { return 0; }
 
-  QWidget*
-  embeddedWidget() override
-  {
-    return nullptr;
-  }
+    QWidget *embeddedWidget() override { return nullptr; }
 
-  QtNodes::NodeDataType dataType(QtNodes::PortType, QtNodes::PortIndex) const override
-  {
-    return QtNodes::NodeDataType();
-  }
+    QtNodes::NodeDataType dataType(QtNodes::PortType, QtNodes::PortIndex) const override
+    {
+        return QtNodes::NodeDataType();
+    }
 
-  std::shared_ptr<QtNodes::NodeData> outData(QtNodes::PortIndex) override
-  {
-    return nullptr;
-  }
+    std::shared_ptr<QtNodes::NodeData> outData(QtNodes::PortIndex) override { return nullptr; }
 
-  void setInData(std::shared_ptr<QtNodes::NodeData>, QtNodes::PortIndex) override
-  {
-  }
+    void setInData(std::shared_ptr<QtNodes::NodeData>, QtNodes::PortIndex) override {}
 
-  void
-  name(QString name)
-  {
-    _name = std::move(name);
-  }
+    void name(QString name) { _name = std::move(name); }
 
-  void
-  caption(QString caption)
-  {
-    _caption = std::move(caption);
-  }
+    void caption(QString caption) { _caption = std::move(caption); }
 
 private:
-  QString _name    = "name";
-  QString _caption = "caption";
+    QString _name = "name";
+    QString _caption = "caption";
 };

--- a/test/src/TestDataModelRegistry.cpp
+++ b/test/src/TestDataModelRegistry.cpp
@@ -11,62 +11,53 @@ using QtNodes::NodeDataType;
 using QtNodes::PortIndex;
 using QtNodes::PortType;
 
-namespace
-{
+namespace {
 class StubModelStaticName : public StubNodeDataModel
 {
 public:
-  static QString
-  Name()
-  {
-    return "Name";
-  }
+    static QString Name() { return "Name"; }
 };
-}
+} // namespace
 
 TEST_CASE("DataModelRegistry::registerModel", "[interface]")
 {
-  DataModelRegistry registry;
+    DataModelRegistry registry;
 
-  SECTION("stub model")
-  {
-    registry.registerModel<StubNodeDataModel>();
-    auto model = registry.create("name");
-
-    CHECK(model->name() == "name");
-  }
-  SECTION("stub model with static name")
-  {
-    registry.registerModel<StubModelStaticName>();
-    auto model = registry.create("Name");
-
-    CHECK(model->name() == "name");
-  }
-  SECTION("From model creator function")
-  {
-    SECTION("non-static name()")
+    SECTION("stub model")
     {
-      registry.registerModel([] {
-        return std::make_unique<StubNodeDataModel>();
-      });
+        registry.registerModel<StubNodeDataModel>();
+        auto model = registry.create("name");
 
-      auto model = registry.create("name");
-
-      REQUIRE(model != nullptr);
-      CHECK(model->name() == "name");
-      CHECK(dynamic_cast<StubNodeDataModel*>(model.get()));
+        CHECK(model->name() == "name");
     }
-    SECTION("static Name()")
+    SECTION("stub model with static name")
     {
-      registry.registerModel([] {
-        return std::make_unique<StubModelStaticName>();
-      });
+        registry.registerModel<StubModelStaticName>();
+        auto model = registry.create("Name");
 
-      auto model = registry.create("Name");
-
-      REQUIRE(model != nullptr);
-      CHECK(model->name() == "name");
-      CHECK(dynamic_cast<StubModelStaticName*>(model.get()));
+        CHECK(model->name() == "name");
     }
-  }
+    SECTION("From model creator function")
+    {
+        SECTION("non-static name()")
+        {
+            registry.registerModel([] { return std::make_unique<StubNodeDataModel>(); });
+
+            auto model = registry.create("name");
+
+            REQUIRE(model != nullptr);
+            CHECK(model->name() == "name");
+            CHECK(dynamic_cast<StubNodeDataModel *>(model.get()));
+        }
+        SECTION("static Name()")
+        {
+            registry.registerModel([] { return std::make_unique<StubModelStaticName>(); });
+
+            auto model = registry.create("Name");
+
+            REQUIRE(model != nullptr);
+            CHECK(model->name() == "name");
+            CHECK(dynamic_cast<StubModelStaticName *>(model.get()));
+        }
+    }
 }

--- a/test/src/TestDragging.cpp
+++ b/test/src/TestDragging.cpp
@@ -25,44 +25,44 @@ using QtNodes::PortType;
 
 TEST_CASE("Dragging node changes position", "[gui]")
 {
-  auto app = applicationSetup();
+    auto app = applicationSetup();
 
-  FlowScene scene;
-  FlowView  view(&scene);
+    FlowScene scene;
+    FlowView view(&scene);
 
-  view.show();
-  REQUIRE(QTest::qWaitForWindowExposed(&view));
+    view.show();
+    REQUIRE(QTest::qWaitForWindowExposed(&view));
 
-  SECTION("just one node")
-  {
-    auto& node = scene.createNode(std::make_unique<StubNodeDataModel>());
+    SECTION("just one node")
+    {
+        auto &node = scene.createNode(std::make_unique<StubNodeDataModel>());
 
-    auto& ngo = node.nodeGraphicsObject();
+        auto &ngo = node.nodeGraphicsObject();
 
-    QPointF scPosBefore = ngo.pos();
+        QPointF scPosBefore = ngo.pos();
 
-    QPointF scClickPos = ngo.boundingRect().center();
-    scClickPos         = QPointF(ngo.sceneTransform().map(scClickPos).toPoint());
+        QPointF scClickPos = ngo.boundingRect().center();
+        scClickPos = QPointF(ngo.sceneTransform().map(scClickPos).toPoint());
 
-    QPoint vwClickPos = view.mapFromScene(scClickPos);
-    QPoint vwDestPos  = vwClickPos + QPoint(10, 20);
+        QPoint vwClickPos = view.mapFromScene(scClickPos);
+        QPoint vwDestPos = vwClickPos + QPoint(10, 20);
 
-    QPointF scExpectedDelta = view.mapToScene(vwDestPos) - scClickPos;
+        QPointF scExpectedDelta = view.mapToScene(vwDestPos) - scClickPos;
 
-    CAPTURE(scClickPos);
-    CAPTURE(vwClickPos);
-    CAPTURE(vwDestPos);
-    CAPTURE(scExpectedDelta);
+        CAPTURE(scClickPos);
+        CAPTURE(vwClickPos);
+        CAPTURE(vwDestPos);
+        CAPTURE(scExpectedDelta);
 
-    QTest::mouseMove(view.windowHandle(), vwClickPos);
-    QTest::mousePress(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwClickPos);
-    QTest::mouseMove(view.windowHandle(), vwDestPos);
-    QTest::mouseRelease(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwDestPos);
+        QTest::mouseMove(view.windowHandle(), vwClickPos);
+        QTest::mousePress(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwClickPos);
+        QTest::mouseMove(view.windowHandle(), vwDestPos);
+        QTest::mouseRelease(view.windowHandle(), Qt::LeftButton, Qt::NoModifier, vwDestPos);
 
-    QPointF scDelta            = ngo.pos() - scPosBefore;
-    QPoint  roundDelta         = scDelta.toPoint();
-    QPoint  roundExpectedDelta = scExpectedDelta.toPoint();
+        QPointF scDelta = ngo.pos() - scPosBefore;
+        QPoint roundDelta = scDelta.toPoint();
+        QPoint roundExpectedDelta = scExpectedDelta.toPoint();
 
-    CHECK(roundDelta == roundExpectedDelta);
-  }
+        CHECK(roundDelta == roundExpectedDelta);
+    }
 }

--- a/test/src/TestFlowScene.cpp
+++ b/test/src/TestFlowScene.cpp
@@ -13,7 +13,6 @@
 #include <utility>
 #include <vector>
 
-
 using QtNodes::Connection;
 using QtNodes::DataModelRegistry;
 using QtNodes::FlowScene;
@@ -26,231 +25,204 @@ using QtNodes::PortType;
 
 TEST_CASE("FlowScene triggers connections created or deleted", "[gui]")
 {
-  struct MockDataModel : StubNodeDataModel
-  {
-    unsigned int nPorts(PortType) const override { return 1; }
-
-    void
-    inputConnectionCreated(Connection const&) override
+    struct MockDataModel : StubNodeDataModel
     {
-      inputCreatedCalledCount++;
-    }
+        unsigned int nPorts(PortType) const override { return 1; }
 
-    void
-    inputConnectionDeleted(Connection const&) override
+        void inputConnectionCreated(Connection const &) override { inputCreatedCalledCount++; }
+
+        void inputConnectionDeleted(Connection const &) override { inputDeletedCalledCount++; }
+
+        void outputConnectionCreated(Connection const &) override { outputCreatedCalledCount++; }
+
+        void outputConnectionDeleted(Connection const &) override { outputDeletedCalledCount++; }
+
+        int inputCreatedCalledCount = 0;
+        int inputDeletedCalledCount = 0;
+        int outputCreatedCalledCount = 0;
+        int outputDeletedCalledCount = 0;
+
+        void resetCallCounts()
+        {
+            inputCreatedCalledCount = 0;
+            inputDeletedCalledCount = 0;
+            outputCreatedCalledCount = 0;
+            outputDeletedCalledCount = 0;
+        }
+    };
+
+    auto setup = applicationSetup();
+
+    FlowScene scene;
+
+    Node &fromNode = scene.createNode(std::make_unique<MockDataModel>());
+    Node &toNode = scene.createNode(std::make_unique<MockDataModel>());
+    Node &unrelatedNode = scene.createNode(std::make_unique<MockDataModel>());
+
+    auto &fromNgo = fromNode.nodeGraphicsObject();
+    auto &toNgo = toNode.nodeGraphicsObject();
+    auto &unrelatedNgo = unrelatedNode.nodeGraphicsObject();
+
+    fromNgo.setPos(0, 0);
+    toNgo.setPos(200, 20);
+    unrelatedNgo.setPos(-100, -100);
+
+    auto &from = dynamic_cast<MockDataModel &>(*fromNode.nodeDataModel());
+    auto &to = dynamic_cast<MockDataModel &>(*toNode.nodeDataModel());
+    auto &unrelated = dynamic_cast<MockDataModel &>(*unrelatedNode.nodeDataModel());
+
+    SECTION("creating half a connection (not finishing the connection)")
     {
-      inputDeletedCalledCount++;
-    }
-
-    void
-    outputConnectionCreated(Connection const&) override
-    {
-      outputCreatedCalledCount++;
-    }
-
-    void
-    outputConnectionDeleted(Connection const&) override
-    {
-      outputDeletedCalledCount++;
-    }
-
-    int inputCreatedCalledCount  = 0;
-    int inputDeletedCalledCount  = 0;
-    int outputCreatedCalledCount = 0;
-    int outputDeletedCalledCount = 0;
-
-    void
-    resetCallCounts()
-    {
-      inputCreatedCalledCount  = 0;
-      inputDeletedCalledCount  = 0;
-      outputCreatedCalledCount = 0;
-      outputDeletedCalledCount = 0;
-    }
-  };
-
-  auto setup = applicationSetup();
-
-  FlowScene scene;
-
-  Node& fromNode      = scene.createNode(std::make_unique<MockDataModel>());
-  Node& toNode        = scene.createNode(std::make_unique<MockDataModel>());
-  Node& unrelatedNode = scene.createNode(std::make_unique<MockDataModel>());
-
-  auto& fromNgo      = fromNode.nodeGraphicsObject();
-  auto& toNgo        = toNode.nodeGraphicsObject();
-  auto& unrelatedNgo = unrelatedNode.nodeGraphicsObject();
-
-  fromNgo.setPos(0, 0);
-  toNgo.setPos(200, 20);
-  unrelatedNgo.setPos(-100, -100);
-
-  auto& from      = dynamic_cast<MockDataModel&>(*fromNode.nodeDataModel());
-  auto& to        = dynamic_cast<MockDataModel&>(*toNode.nodeDataModel());
-  auto& unrelated = dynamic_cast<MockDataModel&>(*unrelatedNode.nodeDataModel());
-
-
-  SECTION("creating half a connection (not finishing the connection)")
-  {
-    auto connection = scene.createConnection(PortType::Out, fromNode, 0);
-
-    CHECK(from.inputCreatedCalledCount == 0);
-    CHECK(from.outputCreatedCalledCount == 0);
-
-    CHECK(to.inputCreatedCalledCount == 0);
-    CHECK(to.outputCreatedCalledCount == 0);
-
-    CHECK(unrelated.inputCreatedCalledCount == 0);
-    CHECK(unrelated.outputCreatedCalledCount == 0);
-
-    scene.deleteConnection(*connection);
-  }
-
-  struct Creation
-  {
-    std::string                                  name;
-    std::function<std::shared_ptr<Connection>()> createConnection;
-  };
-
-  Creation sceneCreation{"scene.createConnection",
-                         [&] { return scene.createConnection(toNode, 0, fromNode, 0); }};
-
-  Creation partialCreation{"scene.createConnection-by partial", [&] {
-                             auto connection = scene.createConnection(PortType::Out, fromNode, 0);
-                             connection->setNodeToPort(toNode, PortType::In, 0);
-
-                             return connection;
-                           }};
-
-  struct Deletion
-  {
-    std::string                                      name;
-    std::function<void(Connection & connection)> deleteConnection;
-  };
-
-  Deletion sceneDeletion{"scene.deleteConnection",
-                         [&](Connection & c) { scene.deleteConnection(c); }};
-
-  Deletion partialDragDeletion{"scene-deleteConnectionByDraggingOff",
-                               [&](Connection & c)
-                               {
-                                 PortIndex portIndex = c.getPortIndex(PortType::In);
-                                 Node * node = c.getNode(PortType::In);
-                                 node->nodeState().getEntries(PortType::In)[portIndex].clear();
-                                 c.clearNode(PortType::In);
-                               }};
-
-  SECTION("creating a connection")
-  {
-    std::vector<Creation> cases({sceneCreation, partialCreation});
-
-    for (Creation const& create : cases)
-    {
-      SECTION(create.name)
-      {
-        auto connection = create.createConnection();
+        auto connection = scene.createConnection(PortType::Out, fromNode, 0);
 
         CHECK(from.inputCreatedCalledCount == 0);
-        CHECK(from.outputCreatedCalledCount == 1);
+        CHECK(from.outputCreatedCalledCount == 0);
 
-        CHECK(to.inputCreatedCalledCount == 1);
+        CHECK(to.inputCreatedCalledCount == 0);
         CHECK(to.outputCreatedCalledCount == 0);
 
         CHECK(unrelated.inputCreatedCalledCount == 0);
         CHECK(unrelated.outputCreatedCalledCount == 0);
 
         scene.deleteConnection(*connection);
-      }
     }
-  }
 
-  SECTION("deleting a connection")
-  {
-    std::vector<Deletion> cases({sceneDeletion, partialDragDeletion});
-
-    for (auto const& deletion : cases)
+    struct Creation
     {
-      SECTION("deletion: " + deletion.name)
-      {
-        Connection & connection = *sceneCreation.createConnection();
+        std::string name;
+        std::function<std::shared_ptr<Connection>()> createConnection;
+    };
 
-        from.resetCallCounts();
-        to.resetCallCounts();
+    Creation sceneCreation{"scene.createConnection",
+                           [&] { return scene.createConnection(toNode, 0, fromNode, 0); }};
 
-        deletion.deleteConnection(connection);
+    Creation partialCreation{"scene.createConnection-by partial", [&] {
+                                 auto connection = scene.createConnection(PortType::Out,
+                                                                          fromNode,
+                                                                          0);
+                                 connection->setNodeToPort(toNode, PortType::In, 0);
 
-        // Here the Connection reference becomes dangling
+                                 return connection;
+                             }};
 
-        CHECK(from.inputDeletedCalledCount == 0);
-        CHECK(from.outputDeletedCalledCount == 1);
+    struct Deletion
+    {
+        std::string name;
+        std::function<void(Connection &connection)> deleteConnection;
+    };
 
-        CHECK(to.inputDeletedCalledCount == 1);
-        CHECK(to.outputDeletedCalledCount == 0);
+    Deletion sceneDeletion{"scene.deleteConnection",
+                           [&](Connection &c) { scene.deleteConnection(c); }};
 
-        CHECK(unrelated.inputDeletedCalledCount == 0);
-        CHECK(unrelated.outputDeletedCalledCount == 0);
-      }
+    Deletion partialDragDeletion{"scene-deleteConnectionByDraggingOff", [&](Connection &c) {
+                                     PortIndex portIndex = c.getPortIndex(PortType::In);
+                                     Node *node = c.getNode(PortType::In);
+                                     node->nodeState().getEntries(PortType::In)[portIndex].clear();
+                                     c.clearNode(PortType::In);
+                                 }};
+
+    SECTION("creating a connection")
+    {
+        std::vector<Creation> cases({sceneCreation, partialCreation});
+
+        for (Creation const &create : cases) {
+            SECTION(create.name)
+            {
+                auto connection = create.createConnection();
+
+                CHECK(from.inputCreatedCalledCount == 0);
+                CHECK(from.outputCreatedCalledCount == 1);
+
+                CHECK(to.inputCreatedCalledCount == 1);
+                CHECK(to.outputCreatedCalledCount == 0);
+
+                CHECK(unrelated.inputCreatedCalledCount == 0);
+                CHECK(unrelated.outputCreatedCalledCount == 0);
+
+                scene.deleteConnection(*connection);
+            }
+        }
     }
-  }
-}
 
+    SECTION("deleting a connection")
+    {
+        std::vector<Deletion> cases({sceneDeletion, partialDragDeletion});
+
+        for (auto const &deletion : cases) {
+            SECTION("deletion: " + deletion.name)
+            {
+                Connection &connection = *sceneCreation.createConnection();
+
+                from.resetCallCounts();
+                to.resetCallCounts();
+
+                deletion.deleteConnection(connection);
+
+                // Here the Connection reference becomes dangling
+
+                CHECK(from.inputDeletedCalledCount == 0);
+                CHECK(from.outputDeletedCalledCount == 1);
+
+                CHECK(to.inputDeletedCalledCount == 1);
+                CHECK(to.outputDeletedCalledCount == 0);
+
+                CHECK(unrelated.inputDeletedCalledCount == 0);
+                CHECK(unrelated.outputDeletedCalledCount == 0);
+            }
+        }
+    }
+}
 
 TEST_CASE("FlowScene's DataModelRegistry outlives nodes and connections", "[asan][gui]")
 {
-  class MockDataModel : public StubNodeDataModel
-  {
-  public:
-    MockDataModel(int* const& incrementOnDestruction)
-      : incrementOnDestruction(incrementOnDestruction)
+    class MockDataModel : public StubNodeDataModel
     {
+    public:
+        MockDataModel(int *const &incrementOnDestruction)
+            : incrementOnDestruction(incrementOnDestruction)
+        {}
+
+        ~MockDataModel() { (*incrementOnDestruction)++; }
+
+        // The reference ensures that we point into the memory that would be free'd
+        // if the DataModelRegistry doesn't outlive this node
+        int *const &incrementOnDestruction;
+    };
+
+    struct MockDataModelCreator
+    {
+        MockDataModelCreator(int *shouldBeAliveWhenAssignedTo)
+            : shouldBeAliveWhenAssignedTo(shouldBeAliveWhenAssignedTo)
+        {}
+
+        auto operator()() const
+        {
+            return std::make_unique<MockDataModel>(shouldBeAliveWhenAssignedTo);
+        }
+
+        int *shouldBeAliveWhenAssignedTo;
+    };
+
+    int modelsDestroyed = 0;
+
+    // Introduce a new scope, so that modelsDestroyed will be alive even after the
+    // FlowScene is destroyed.
+    {
+        auto setup = applicationSetup();
+
+        auto registry = std::make_shared<DataModelRegistry>();
+        registry->registerModel(MockDataModelCreator(&modelsDestroyed));
+
+        modelsDestroyed = 0;
+
+        FlowScene scene(std::move(registry));
+
+        auto &node = scene.createNode(scene.registry().create("name"));
+
+        // On destruction, if this `node` outlives its MockDataModelCreator,
+        // (if it outlives the DataModelRegistry), then we trigger undefined
+        // behavior through use-after-free. ASAN will catch that.
     }
 
-    ~MockDataModel()
-    {
-      (*incrementOnDestruction)++;
-    }
-
-    // The reference ensures that we point into the memory that would be free'd
-    // if the DataModelRegistry doesn't outlive this node
-    int* const& incrementOnDestruction;
-  };
-
-  struct MockDataModelCreator
-  {
-    MockDataModelCreator(int* shouldBeAliveWhenAssignedTo)
-      : shouldBeAliveWhenAssignedTo(shouldBeAliveWhenAssignedTo)
-    {
-    }
-
-    auto
-    operator()() const
-    {
-      return std::make_unique<MockDataModel>(shouldBeAliveWhenAssignedTo);
-    }
-
-    int* shouldBeAliveWhenAssignedTo;
-  };
-
-  int modelsDestroyed = 0;
-
-  // Introduce a new scope, so that modelsDestroyed will be alive even after the
-  // FlowScene is destroyed.
-  {
-    auto setup = applicationSetup();
-
-    auto registry = std::make_shared<DataModelRegistry>();
-    registry->registerModel(MockDataModelCreator(&modelsDestroyed));
-
-    modelsDestroyed = 0;
-
-    FlowScene scene(std::move(registry));
-
-    auto& node = scene.createNode(scene.registry().create("name"));
-
-    // On destruction, if this `node` outlives its MockDataModelCreator,
-    // (if it outlives the DataModelRegistry), then we trigger undefined
-    // behavior through use-after-free. ASAN will catch that.
-  }
-
-  CHECK(modelsDestroyed == 1);
+    CHECK(modelsDestroyed == 1);
 }


### PR DESCRIPTION
.clang-format has been added. 
The reference for the configuration is the default used by Qt here: https://raw.githubusercontent.com/qt-creator/qt-creator/master/.clang-format

The whole codebase has been formatted following these rules. In linux it's very straightforward, just launch

`find . \( \( -name \*.cpp -o -name \*.hpp \) -print0 | xargs -0 -n 1 clang-format-13 -i`

from the repository root directory.

With Qt creator it's possible to auto-indent the file on save with the beautifier plugin. In `Preferences -> Beaufitifer -> General` check the "enable auto format on file save. Then in the tab `clang-format` select `use predefined style: File`. If the local machine does not have clang-format installed, it can be found in the Qt installation in the folder `Tools/QtCreator/libexec/qtcreator/clang/bin/clang-format`. This might be different depending on the Qt Creator version installed. This guide is valid for Linux, I cannot check in other OS, but it should be quite similar.

The CI can be configured to check the proper code format and reject the MR or even auto-correct the code. I don't know how to do that with the github action since I'm using Gitlab. and I think it should be a different task.

Please @paceholder check if you're ok with the current code format.

Closes #146 


