### PR TITLE
UndoCommands new feature and fix

### DIFF
--- a/src/DataFlowGraphModel.cpp
+++ b/src/DataFlowGraphModel.cpp
@@ -3,6 +3,8 @@
 
 #include <QJsonArray>
 
+#include <stdexcept>
+
 namespace QtNodes
 {
 
@@ -563,6 +565,11 @@ loadNode(QJsonObject const & nodeJson)
                 pos);
 
     _models[restoredNodeId]->load(internalDataJson);
+  }
+  else
+  {
+    throw std::logic_error(std::string("No registered model with name ") +
+                           delegateModelName.toLocal8Bit().data());
   }
 }
 

--- a/src/DataFlowGraphicsScene.cpp
+++ b/src/DataFlowGraphicsScene.cpp
@@ -4,6 +4,7 @@
 #include "GraphicsView.hpp"
 #include "NodeDelegateModelRegistry.hpp"
 #include "NodeGraphicsObject.hpp"
+#include "UndoCommands.hpp"
 
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QGraphicsSceneMoveEvent>
@@ -130,14 +131,7 @@ createSceneMenu(QPointF const scenePos)
               return;
             }
 
-            NodeId nodeId = this->_graphModel.addNode(item->text(0));
-
-            if (nodeId != InvalidNodeId)
-            {
-              _graphModel.setNodeData(nodeId,
-                                      NodeRole::Position,
-                                      scenePos);
-            }
+            this->undoStack().push(new CreateCommand(this, item->text(0), scenePos));
 
             modelMenu->close();
           });

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -337,7 +337,6 @@ mouseMoveEvent(QGraphicsSceneMouseEvent* event)
     auto diff = event->pos() - event->lastPos();
 
     nodeScene()->undoStack().push(new MoveNodeCommand(nodeScene(),
-                                                      _nodeId,
                                                       diff));
 
     event->accept();

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -445,10 +445,8 @@ redo()
 
 MoveNodeCommand::
 MoveNodeCommand(BasicGraphicsScene* scene,
-                NodeId const nodeId,
                 QPointF const &diff)
   : _scene(scene)
-  , _nodeId(nodeId)
   , _diff(diff)
 {
 }
@@ -457,13 +455,19 @@ void
 MoveNodeCommand::
 undo()
 {
-  auto oldPos = 
-    _scene->graphModel().nodeData(_nodeId,
-                                  NodeRole::Position).value<QPointF>();
+  for (QGraphicsItem * item : _scene->selectedItems())
+  {
+    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
+    {
+      auto oldPos = 
+        _scene->graphModel().nodeData(n->nodeId(),
+                                      NodeRole::Position).value<QPointF>();
 
-  oldPos -= _diff;
+      oldPos -= _diff;
 
-  _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, oldPos);
+      _scene->graphModel().setNodeData(n->nodeId(), NodeRole::Position, oldPos);
+    }
+  }
 }
 
 
@@ -471,13 +475,19 @@ void
 MoveNodeCommand::
 redo()
 {
-  auto oldPos = 
-    _scene->graphModel().nodeData(_nodeId,
-                                  NodeRole::Position).value<QPointF>();
+  for (QGraphicsItem * item : _scene->selectedItems())
+  {
+    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
+    {
+      auto oldPos = 
+        _scene->graphModel().nodeData(n->nodeId(),
+                                      NodeRole::Position).value<QPointF>();
 
-  oldPos += _diff;
+      oldPos += _diff;
 
-  _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, oldPos);
+      _scene->graphModel().setNodeData(n->nodeId(), NodeRole::Position, oldPos);
+    }
+  }
 }
 
 
@@ -500,5 +510,4 @@ mergeWith(QUndoCommand const *c)
   return true;
 }
 
-//
-}
+} // namespace QtNodes

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -541,9 +541,12 @@ mergeWith(QUndoCommand const *c)
 {
   auto mc = static_cast<MoveNodeCommand const*>(c);
 
-  _diff += mc->_diff;
-
-  return true;
+  if (_selectedNodes == mc->_selectedNodes)
+  {
+    _diff += mc->_diff;
+    return true;
+  }
+  return false;
 }
 
 } // namespace QtNodes

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -367,6 +367,26 @@ redo()
   }
   catch(...)
   {
+    auto & graphModel = _scene->graphModel();
+
+    QJsonArray connJsonArray;
+    for (QGraphicsItem * item : _scene->selectedItems())
+    {
+      if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
+      {
+        graphModel.deleteConnection(c->connectionId());
+      }
+    }
+
+    QJsonArray nodesJsonArray;
+    for (QGraphicsItem * item : _scene->selectedItems())
+    {
+      if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
+      {
+        graphModel.deleteNode(n->nodeId());
+      }
+    }
+
     setObsolete(true);
   }
 }

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -157,11 +157,16 @@ CreateCommand(BasicGraphicsScene* scene,
               QString const name,
               QPointF const & mouseScenePos)
   : _scene(scene)
+  , _sceneJson(QJsonObject())
 {
   _nodeId = _scene->graphModel().addNode(name);
   if (_nodeId != InvalidNodeId)
   {
     _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, mouseScenePos);
+  }
+  else
+  {
+    setObsolete(true);
   }
 }
 
@@ -179,6 +184,8 @@ void
 CreateCommand::
 redo()
 {
+  if(_sceneJson.isEmpty())
+    return;
   _scene->graphModel().loadNode(_sceneJson);
 }
 
@@ -222,6 +229,10 @@ DeleteCommand(BasicGraphicsScene* scene)
       nodesJsonArray.append(graphModel.saveNode(n->nodeId()));
     }
   }
+
+  // If nothing is deleted, cancel this operation
+  if(connJsonArray.isEmpty() && nodesJsonArray.isEmpty())
+    setObsolete(true);
 
   _sceneJson["nodes"] = nodesJsonArray;
   _sceneJson["connections"] = connJsonArray;

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -149,6 +149,42 @@ computeAverageNodePosition(QJsonObject const & sceneJson)
 }
 
 
+//-------------------------------------
+
+
+CreateCommand::
+CreateCommand(BasicGraphicsScene* scene,
+              QString const name,
+              QPointF const & mouseScenePos)
+  : _scene(scene)
+{
+  _nodeId = _scene->graphModel().addNode(name);
+  if (_nodeId != InvalidNodeId)
+  {
+    _scene->graphModel().setNodeData(_nodeId, NodeRole::Position, mouseScenePos);
+  }
+}
+
+
+void
+CreateCommand::
+undo()
+{
+  _sceneJson = _scene->graphModel().saveNode(_nodeId);
+  _scene->graphModel().deleteNode(_nodeId);
+}
+
+
+void
+CreateCommand::
+redo()
+{
+  _scene->graphModel().loadNode(_sceneJson);
+}
+
+
+//-------------------------------------
+
 
 DeleteCommand::
 DeleteCommand(BasicGraphicsScene* scene)

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -497,6 +497,13 @@ MoveNodeCommand(BasicGraphicsScene* scene,
   , _diff(diff)
 {
   _selectedNodes.clear();
+  for (QGraphicsItem * item : _scene->selectedItems())
+  {
+    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
+    {
+      _selectedNodes.insert(n->nodeId());
+    }
+  }
 }
 
 void
@@ -520,20 +527,15 @@ void
 MoveNodeCommand::
 redo()
 {
-  for (QGraphicsItem * item : _scene->selectedItems())
+  for (auto nodeId : _selectedNodes)
   {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
-    {
-      _selectedNodes.insert(n->nodeId());
+    auto oldPos = 
+      _scene->graphModel().nodeData(nodeId,
+                                    NodeRole::Position).value<QPointF>();
 
-      auto oldPos = 
-        _scene->graphModel().nodeData(n->nodeId(),
-                                      NodeRole::Position).value<QPointF>();
+    oldPos += _diff;
 
-      oldPos += _diff;
-
-      _scene->graphModel().setNodeData(n->nodeId(), NodeRole::Position, oldPos);
-    }
+    _scene->graphModel().setNodeData(nodeId, NodeRole::Position, oldPos);
   }
 }
 

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -95,6 +95,8 @@ insertSerializedItems(QJsonObject const & json,
 
     // Restore the connection
     graphModel.addConnection(connId);
+
+    scene->connectionGraphicsObject(connId)->setSelected(true);
   }
 }
 
@@ -360,23 +362,16 @@ redo()
 {
   _scene->clearSelection();
 
-  // Ignore if pasted in content that does not generate nodes.
+  // Ignore if pasted in content does not generate nodes.
   try
   {
     insertSerializedItems(_newSceneJson, _scene);
   }
   catch(...)
   {
+    // If the paste does not work, delete all selected nodes and connections
+    // `deleteNode(...)` implicitly removed connections
     auto & graphModel = _scene->graphModel();
-
-    QJsonArray connJsonArray;
-    for (QGraphicsItem * item : _scene->selectedItems())
-    {
-      if (auto c = qgraphicsitem_cast<ConnectionGraphicsObject*>(item))
-      {
-        graphModel.deleteConnection(c->connectionId());
-      }
-    }
 
     QJsonArray nodesJsonArray;
     for (QGraphicsItem * item : _scene->selectedItems())

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -449,24 +449,22 @@ MoveNodeCommand(BasicGraphicsScene* scene,
   : _scene(scene)
   , _diff(diff)
 {
+  _selectedNodes.clear();
 }
 
 void
 MoveNodeCommand::
 undo()
 {
-  for (QGraphicsItem * item : _scene->selectedItems())
+  for (auto nodeId : _selectedNodes)
   {
-    if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
-    {
-      auto oldPos = 
-        _scene->graphModel().nodeData(n->nodeId(),
-                                      NodeRole::Position).value<QPointF>();
+    auto oldPos = 
+      _scene->graphModel().nodeData(nodeId,
+                                    NodeRole::Position).value<QPointF>();
 
-      oldPos -= _diff;
+    oldPos -= _diff;
 
-      _scene->graphModel().setNodeData(n->nodeId(), NodeRole::Position, oldPos);
-    }
+    _scene->graphModel().setNodeData(nodeId, NodeRole::Position, oldPos);
   }
 }
 
@@ -479,6 +477,8 @@ redo()
   {
     if (auto n = qgraphicsitem_cast<NodeGraphicsObject*>(item))
     {
+      _selectedNodes.insert(n->nodeId());
+
       auto oldPos = 
         _scene->graphModel().nodeData(n->nodeId(),
                                       NodeRole::Position).value<QPointF>();

--- a/src/UndoCommands.hpp
+++ b/src/UndoCommands.hpp
@@ -6,6 +6,8 @@
 #include <QtCore/QPointF>
 #include <QtCore/QJsonObject>
 
+#include <unordered_set>
+
 namespace QtNodes
 {
 
@@ -110,6 +112,7 @@ public:
 
 private:
   BasicGraphicsScene* _scene;
+  std::unordered_set<NodeId> _selectedNodes;
   QPointF _diff;
 };
 

--- a/src/UndoCommands.hpp
+++ b/src/UndoCommands.hpp
@@ -92,7 +92,6 @@ class MoveNodeCommand : public QUndoCommand
 {
 public:
   MoveNodeCommand(BasicGraphicsScene* scene,
-                  NodeId const nodeId,
                   QPointF const &diff);
 
   void undo() override;
@@ -111,9 +110,8 @@ public:
 
 private:
   BasicGraphicsScene* _scene;
-  NodeId _nodeId;
   QPointF _diff;
 };
 
 
-}
+} // namespace QtNodes

--- a/src/UndoCommands.hpp
+++ b/src/UndoCommands.hpp
@@ -14,6 +14,23 @@ namespace QtNodes
 class BasicGraphicsScene;
 
 
+class CreateCommand : public QUndoCommand
+{
+public:
+  CreateCommand(BasicGraphicsScene* scene,
+                QString const name,
+                QPointF const & mouseScenePos);
+
+  void undo() override;
+  void redo() override;
+
+private:
+  BasicGraphicsScene* _scene;
+  NodeId _nodeId;
+  QJsonObject _sceneJson;
+};
+
+
 /**
  * Selected scene objects are serialized and then removed from the scene.
  * The deleted elements could be restored in `undo`.


### PR DESCRIPTION
* drag all the selected models (Fix #357), and distinguishes between different drags (with different nodes selected).
* add CreateCommand to create node.
* fix DeleteCommand, If nothing is selected for deletion, mark this DeleteCommand as obsolete.
* fix CopyCommand, Just a copy of connections will crash
* fix PasteCommand, If `"model-name"` does not exist in the pasted content or if the value is not in the registry, it will crash