### PR TITLE
Fixed broken context search and hide empty categories from filter.

### DIFF
--- a/src/DataFlowGraphicsScene.cpp
+++ b/src/DataFlowGraphicsScene.cpp
@@ -140,13 +140,24 @@ createSceneMenu(QPointF const scenePos)
   connect(txtBox, &QLineEdit::textChanged,
           [treeView](const QString& text)
           {
+            QTreeWidgetItemIterator categoryIt(treeView, QTreeWidgetItemIterator::HasChildren);
+            while (*categoryIt)
+              (*categoryIt++)->setHidden(true);
             QTreeWidgetItemIterator it(treeView, QTreeWidgetItemIterator::NoChildren);
             while (*it)
             {
-              auto modelName = (*it)->data(0, Qt::UserRole).toString();
+              auto modelName = (*it)->text(0);
               const bool match = (modelName.contains(text, Qt::CaseInsensitive));
               (*it)->setHidden(!match);
-
+              if (match)
+              {
+                QTreeWidgetItem *parent = (*it)->parent();
+                while (parent)
+                {
+                  parent->setHidden(false);
+                  parent = parent->parent();
+                }
+              }
               ++it;
             }
           });


### PR DESCRIPTION
Searching through the context menu was broken after 883e8a0 due to a mis-comparison on node data that is never inserted, returning no results. This has been fixed by correctly comparing against `QTreeWidgetItem::text`.

Furthermore, the filtering system has been changed to hide empty categories, showing only those that are relevant (contain matching nodes).

![New filter demonstration](https://i.imgur.com/6V3jLhQ.gif)

Tested on Gentoo Linux, kernel 6.1.0, Qt 5.15.7