### PR TITLE
Re-implement node connection creation/deletion slots and node movement signal.

### DIFF
--- a/include/QtNodes/internal/BasicGraphicsScene.hpp
+++ b/include/QtNodes/internal/BasicGraphicsScene.hpp
@@ -147,6 +147,8 @@ public Q_SLOTS:
 
     void onNodeUpdated(NodeId const nodeId);
 
+    void onNodeClicked(NodeId const nodeId);
+
     void onModelReset();
 
 private:
@@ -165,6 +167,8 @@ private:
     std::unique_ptr<AbstractNodeGeometry> _nodeGeometry;
 
     std::unique_ptr<AbstractNodePainter> _nodePainter;
+
+    bool _nodeDrag;
 
     QUndoStack *_undoStack;
 

--- a/include/QtNodes/internal/DataFlowGraphModel.hpp
+++ b/include/QtNodes/internal/DataFlowGraphModel.hpp
@@ -100,6 +100,10 @@ Q_SIGNALS:
 private:
     NodeId newNodeId() override { return _nextNodeId++; }
 
+	void sendConnectionCreation(ConnectionId const connectionId);
+
+	void sendConnectionDeletion(ConnectionId const connectionId);
+
 private Q_SLOTS:
     /**
    * Fuction is called in three cases:

--- a/include/QtNodes/internal/NodeDelegateModel.hpp
+++ b/include/QtNodes/internal/NodeDelegateModel.hpp
@@ -17,7 +17,7 @@ class StyleCollection;
 /**
  * The class wraps Node-specific data operations and propagates it to
  * the nesting DataFlowGraphModel which is a subclass of
- * AbstractGrapModel.
+ * AbstractGraphModel.
  * This class is the same what has been called NodeDataModel before v3.
  */
 class NODE_EDITOR_PUBLIC NodeDelegateModel : public QObject, public Serializable

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -36,6 +36,7 @@ BasicGraphicsScene::BasicGraphicsScene(AbstractGraphModel &graphModel, QObject *
     , _graphModel(graphModel)
     , _nodeGeometry(std::make_unique<DefaultHorizontalNodeGeometry>(_graphModel))
     , _nodePainter(std::make_unique<DefaultNodePainter>())
+    , _nodeDrag(false)
     , _undoStack(new QUndoStack(this))
     , _orientation(Qt::Horizontal)
 {
@@ -70,6 +71,11 @@ BasicGraphicsScene::BasicGraphicsScene(AbstractGraphModel &graphModel, QObject *
             &AbstractGraphModel::nodeUpdated,
             this,
             &BasicGraphicsScene::onNodeUpdated);
+
+    connect(this,
+            &BasicGraphicsScene::nodeClicked,
+            this,
+            &BasicGraphicsScene::onNodeClicked);
 
     connect(&_graphModel, &AbstractGraphModel::modelReset, this, &BasicGraphicsScene::onModelReset);
 
@@ -257,6 +263,7 @@ void BasicGraphicsScene::onNodePositionUpdated(NodeId const nodeId)
     if (node) {
         node->setPos(_graphModel.nodeData(nodeId, NodeRole::Position).value<QPointF>());
         node->update();
+        _nodeDrag = true;
     }
 }
 
@@ -272,6 +279,13 @@ void BasicGraphicsScene::onNodeUpdated(NodeId const nodeId)
         node->update();
         node->moveConnections();
     }
+}
+
+void BasicGraphicsScene::onNodeClicked(NodeId const nodeId)
+{
+    if (_nodeDrag)
+        Q_EMIT nodeMoved(nodeId, _graphModel.nodeData(nodeId, NodeRole::Position).value<QPointF>());
+    _nodeDrag = false;
 }
 
 void BasicGraphicsScene::onModelReset()

--- a/src/DataFlowGraphModel.cpp
+++ b/src/DataFlowGraphModel.cpp
@@ -134,7 +134,7 @@ void DataFlowGraphModel::addConnection(ConnectionId const connectionId)
 {
     _connectivity.insert(connectionId);
 
-    Q_EMIT connectionCreated(connectionId);
+	sendConnectionCreation(connectionId);
 
     QVariant const portDataToPropagate = portData(connectionId.outNodeId,
                                                   PortType::Out,
@@ -146,6 +146,36 @@ void DataFlowGraphModel::addConnection(ConnectionId const connectionId)
                 connectionId.inPortIndex,
                 portDataToPropagate,
                 PortRole::Data);
+}
+
+void DataFlowGraphModel::sendConnectionCreation(ConnectionId const connectionId)
+{
+    Q_EMIT connectionCreated(connectionId);
+
+	auto iti = _models.find(connectionId.inNodeId);
+	auto ito = _models.find(connectionId.outNodeId);
+    if (iti != _models.end() && ito != _models.end())
+	{
+		auto &modeli = iti->second;
+		auto &modelo = ito->second;
+		modeli->inputConnectionCreated(connectionId);
+		modelo->outputConnectionCreated(connectionId);
+	}
+}
+
+void DataFlowGraphModel::sendConnectionDeletion(ConnectionId const connectionId)
+{
+    Q_EMIT connectionDeleted(connectionId);
+
+	auto iti = _models.find(connectionId.inNodeId);
+	auto ito = _models.find(connectionId.outNodeId);
+    if (iti != _models.end() && ito != _models.end())
+	{
+		auto &modeli = iti->second;
+		auto &modelo = ito->second;
+		modeli->inputConnectionDeleted(connectionId);
+		modelo->outputConnectionDeleted(connectionId);
+	}
 }
 
 bool DataFlowGraphModel::nodeExists(NodeId const nodeId) const
@@ -357,7 +387,7 @@ bool DataFlowGraphModel::deleteConnection(ConnectionId const connectionId)
     }
 
     if (disconnected) {
-        Q_EMIT connectionDeleted(connectionId);
+		sendConnectionDeletion(connectionId);
 
         propagateEmptyDataTo(getNodeId(PortType::In, connectionId),
                              getPortIndex(PortType::In, connectionId));


### PR DESCRIPTION
The following slots have been fixed as they were never being called:
- `NodeDelegateModel::inputConnectionCreated`
- `NodeDelegateModel::inputConnectionDeleted`
- `NodeDelegateModel::outputConnectionCreated`
- `NodeDelegateModel::outputConnectionDeleted`

The following slot has been implemented:
- `BasicGraphicsScene::onNodeClicked`

The following signal has been fixed as it was never being emitted:
- `BasicGraphicsScene::nodeMoved`

A nuance concerning `nodeMoved`, unlike `AbstractGraphModel::nodePositionUpdated` which is called every frame of movement and captured by `BasicGraphicsScene::onNodePositionUpdated`, `nodeMoved` will only be called when the mouse is released, locking the node into its new position. Similarly, `onNodeClicked` is only called when the mouse is released. See [Issue 364](https://github.com/paceholder/nodeeditor/issues/364) for more information.

Note also that [TestFlowScene.cpp](https://github.com/paceholder/nodeeditor/blob/master/test/src/TestFlowScene.cpp#L32) is old and no longer works in v3, but does contain some example uses of the fixed slots.