### PR TITLE
Added propagation control functions.

### DIFF
--- a/include/QtNodes/internal/DataFlowGraphModel.hpp
+++ b/include/QtNodes/internal/DataFlowGraphModel.hpp
@@ -94,6 +94,15 @@ public:
         return model;
     }
 
+public Q_SLOTS:
+    virtual void propagate(NodeId const nodeId);
+
+protected:
+    virtual bool canPropagate(ConnectionId const connectionId)
+    {
+        return true;
+    }
+
 Q_SIGNALS:
     void inPortDataWasSet(NodeId const, PortType const, PortIndex const);
 


### PR DESCRIPTION
Added the ability to explicitly control propagation of data in `DataFlowGraphModel` through the use of a new virtual function `canPropagate(ConnectionId)`, and another function `propagate(NodeId)` to request a propagation without having to update input/output data.

These functions are both virtual so that derivative dataflow models can specify their own control model. As an example:

My project has nodes of text data ranging in the gigabytes. I use a global execution state to control when data is propagated along with a forking mechanism to copy the text data each time a node has multiple outputs, rather than copying the data on _every_ node. All of this can be achieved with custom `canPropagate` and `propagate` functions:

![Controlled data propagation](https://i.imgur.com/tYR1nAK.gif)

```c++
PipedGraphModel::
PipedGraphModel(std::shared_ptr<NodeDelegateModelRegistry> registry) :
    DataFlowGraphModel(registry)
{
    executing = false;
}

PipedGraphModel::~PipedGraphModel(void)
{}

bool
PipedGraphModel::canPropagate(const ConnectionId conn)
{
    if (executing)
        return true;
    // data should only be passed on if the graph is being executed
    // or if the node is capable of performing the calculation in
    // such a negligible amount of time that it may as well calculate
    // immediately (think math or array nodes)
    Node *delegate = this->delegateModel<Node>(conn.inNodeId);
    return delegate->canInstantCompute();
}

void
PipedGraphModel::stopExecute(void)
{
    executing = false;
}

void
PipedGraphModel::execute(void)
{
    executing = true;
    for (NodeId id : this->allNodeIds())
    {
        // check each node for any inputs, and if it contains none, then
        // it must be an input node, from which we can propagate the rest of the
        // graph
        Node *delegate = this->delegateModel<Node>(id);
        if (delegate->numInputs() == 0 && delegate->numOutputs() > 0)
            this->propagate(id);
    }
    executing = false;
}

void
PipedGraphModel::propagate(const NodeId nodeId)
{
    unsigned int nPorts = nodeData(nodeId, NodeRole::OutPortCount).toUInt();
    for (PortIndex idx = 0; idx < nPorts; ++idx) {
        //onOutPortDataUpdated(nodeId, idx);
        std::unordered_set<ConnectionId> const &connected = connections(nodeId,
                                                                        PortType::Out,
                                                                        portIndex);

        QVariant const portDataToPropagate = portData(nodeId, PortType::Out, portIndex, PortRole::Data);

        unsigned int connum = 0;
        for (auto const &cn : connected) {
            if (canPropagate(cn)) {
                if (connum > 0)
                    portDataToPropagate = qvariant_cast<BaseNodeData>(portDataToPropagate).clone(); // fork additional connections
                setPortData(cn.inNodeId, PortType::In, cn.inPortIndex, portDataToPropagate, PortRole::Data);
                connum++;
            }
        }
    }
}

```