### PR TITLE
Add a signal `modified` for the scene.

### DIFF
--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -77,8 +77,12 @@ int main(int argc, char *argv[])
 
     auto menuBar = new QMenuBar();
     QMenu *menu = menuBar->addMenu("File");
+
     auto saveAction = menu->addAction("Save Scene");
+    saveAction->setShortcut(QKeySequence::Save);
+
     auto loadAction = menu->addAction("Load Scene");
+    loadAction->setShortcut(QKeySequence::Open);
 
     QVBoxLayout *l = new QVBoxLayout(&mainWidget);
 
@@ -92,13 +96,20 @@ int main(int argc, char *argv[])
     l->setContentsMargins(0, 0, 0, 0);
     l->setSpacing(0);
 
-    QObject::connect(saveAction, &QAction::triggered, scene, &DataFlowGraphicsScene::save);
+    QObject::connect(saveAction, &QAction::triggered, scene, [scene, &mainWidget]() {
+        if (scene->save())
+            mainWidget.setWindowModified(false);
+    });
 
     QObject::connect(loadAction, &QAction::triggered, scene, &DataFlowGraphicsScene::load);
 
     QObject::connect(scene, &DataFlowGraphicsScene::sceneLoaded, view, &GraphicsView::centerScene);
 
-    mainWidget.setWindowTitle("Data Flow: simplest calculator");
+    QObject::connect(scene, &DataFlowGraphicsScene::modified, &mainWidget, [&mainWidget]() {
+        mainWidget.setWindowModified(true);
+    });
+
+    mainWidget.setWindowTitle("[*]Data Flow: simplest calculator");
     mainWidget.resize(800, 600);
     // Center window.
     mainWidget.move(QApplication::primaryScreen()->availableGeometry().center()

--- a/include/QtNodes/internal/BasicGraphicsScene.hpp
+++ b/include/QtNodes/internal/BasicGraphicsScene.hpp
@@ -101,6 +101,8 @@ public:
     virtual QMenu *createSceneMenu(QPointF const scenePos);
 
 Q_SIGNALS:
+    void modified(BasicGraphicsScene *);
+
     void nodeMoved(NodeId const nodeId, QPointF const &newLocation);
 
     void nodeClicked(NodeId const nodeId);

--- a/include/QtNodes/internal/DataFlowGraphicsScene.hpp
+++ b/include/QtNodes/internal/DataFlowGraphicsScene.hpp
@@ -26,9 +26,9 @@ public:
     QMenu *createSceneMenu(QPointF const scenePos) override;
 
 public Q_SLOTS:
-    void save() const;
+    bool save() const;
 
-    void load();
+    bool load();
 
 Q_SIGNALS:
     void sceneLoaded();

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -230,6 +230,8 @@ void BasicGraphicsScene::onConnectionDeleted(ConnectionId const connectionId)
 
     updateAttachedNodes(connectionId, PortType::Out);
     updateAttachedNodes(connectionId, PortType::In);
+
+    Q_EMIT modified(this);
 }
 
 void BasicGraphicsScene::onConnectionCreated(ConnectionId const connectionId)
@@ -239,6 +241,8 @@ void BasicGraphicsScene::onConnectionCreated(ConnectionId const connectionId)
 
     updateAttachedNodes(connectionId, PortType::Out);
     updateAttachedNodes(connectionId, PortType::In);
+
+    Q_EMIT modified(this);
 }
 
 void BasicGraphicsScene::onNodeDeleted(NodeId const nodeId)
@@ -246,12 +250,16 @@ void BasicGraphicsScene::onNodeDeleted(NodeId const nodeId)
     auto it = _nodeGraphicsObjects.find(nodeId);
     if (it != _nodeGraphicsObjects.end()) {
         _nodeGraphicsObjects.erase(it);
+
+        Q_EMIT modified(this);
     }
 }
 
 void BasicGraphicsScene::onNodeCreated(NodeId const nodeId)
 {
     _nodeGraphicsObjects[nodeId] = std::make_unique<NodeGraphicsObject>(*this, nodeId);
+
+    Q_EMIT modified(this);
 }
 
 void BasicGraphicsScene::onNodePositionUpdated(NodeId const nodeId)
@@ -280,8 +288,10 @@ void BasicGraphicsScene::onNodeUpdated(NodeId const nodeId)
 
 void BasicGraphicsScene::onNodeClicked(NodeId const nodeId)
 {
-    if (_nodeDrag)
+    if (_nodeDrag) {
         Q_EMIT nodeMoved(nodeId, _graphModel.nodeData(nodeId, NodeRole::Position).value<QPointF>());
+        Q_EMIT modified(this);
+    }
     _nodeDrag = false;
 }
 

--- a/src/DataFlowGraphicsScene.cpp
+++ b/src/DataFlowGraphicsScene.cpp
@@ -144,7 +144,7 @@ QMenu *DataFlowGraphicsScene::createSceneMenu(QPointF const scenePos)
     return modelMenu;
 }
 
-void DataFlowGraphicsScene::save() const
+bool DataFlowGraphicsScene::save() const
 {
     QString fileName = QFileDialog::getSaveFileName(nullptr,
                                                     tr("Open Flow Scene"),
@@ -158,11 +158,13 @@ void DataFlowGraphicsScene::save() const
         QFile file(fileName);
         if (file.open(QIODevice::WriteOnly)) {
             file.write(QJsonDocument(_graphModel.save()).toJson());
+            return true;
         }
     }
+    return false;
 }
 
-void DataFlowGraphicsScene::load()
+bool DataFlowGraphicsScene::load()
 {
     QString fileName = QFileDialog::getOpenFileName(nullptr,
                                                     tr("Open Flow Scene"),
@@ -170,12 +172,12 @@ void DataFlowGraphicsScene::load()
                                                     tr("Flow Scene Files (*.flow)"));
 
     if (!QFileInfo::exists(fileName))
-        return;
+        return false;
 
     QFile file(fileName);
 
     if (!file.open(QIODevice::ReadOnly))
-        return;
+        return false;
 
     clearScene();
 
@@ -184,6 +186,8 @@ void DataFlowGraphicsScene::load()
     _graphModel.load(QJsonDocument::fromJson(wholeFile).object());
 
     Q_EMIT sceneLoaded();
+
+    return true;
 }
 
 } // namespace QtNodes


### PR DESCRIPTION
This signal is sent when nodes or connections change.

Many editors will have a file modified flag after modifying the file. We can connect this signal to determine which scene has been modified.
![image](https://user-images.githubusercontent.com/55644167/218409685-c581e332-23d7-4a05-bbcf-7ebae030487b.png)
![image](https://user-images.githubusercontent.com/55644167/218409763-0f8bc740-262e-42b7-bd6e-2bd99784ea6e.png)
