### PR TITLE
Add option to make the drop shadow effect optional (fix performance)

### DIFF
--- a/include/QtNodes/internal/AbstractNodeGeometry.hpp
+++ b/include/QtNodes/internal/AbstractNodeGeometry.hpp
@@ -14,7 +14,7 @@ class AbstractGraphModel;
 class NODE_EDITOR_PUBLIC AbstractNodeGeometry
 {
 public:
-    AbstractNodeGeometry(AbstractGraphModel &);
+    AbstractNodeGeometry(AbstractGraphModel &, double marginsRatio = 0.2);
     virtual ~AbstractNodeGeometry() {}
 
     /**
@@ -26,6 +26,8 @@ public:
    * at each side of the rectangle.
    */
     virtual QRectF boundingRect(NodeId const nodeId) const;
+
+    virtual void setMarginsRatio(double marginsRatio);
 
     /// A direct rectangle defining the borders of the node's rectangle.
     virtual QSize size(NodeId const nodeId) const = 0;
@@ -74,6 +76,7 @@ public:
 
 protected:
     AbstractGraphModel &_graphModel;
+    double _marginsRatio{0.0};
 };
 
 } // namespace QtNodes

--- a/include/QtNodes/internal/BasicGraphicsScene.hpp
+++ b/include/QtNodes/internal/BasicGraphicsScene.hpp
@@ -53,6 +53,10 @@ public:
 
     QUndoStack &undoStack();
 
+    void setDropShadowEffect(bool enable);
+
+    bool isDropShadowEffectEnabled() const;
+
 public:
     /// Creates a "draft" instance of ConnectionGraphicsObject.
     /**
@@ -173,6 +177,8 @@ private:
     QUndoStack *_undoStack;
 
     Qt::Orientation _orientation;
+
+    bool _dropShadowEffect{false};
 };
 
 } // namespace QtNodes

--- a/src/AbstractNodeGeometry.cpp
+++ b/src/AbstractNodeGeometry.cpp
@@ -9,8 +9,9 @@
 
 namespace QtNodes {
 
-AbstractNodeGeometry::AbstractNodeGeometry(AbstractGraphModel &graphModel)
+AbstractNodeGeometry::AbstractNodeGeometry(AbstractGraphModel &graphModel, double marginsRatio)
     : _graphModel(graphModel)
+    , _marginsRatio(marginsRatio)
 {
     //
 }
@@ -19,16 +20,19 @@ QRectF AbstractNodeGeometry::boundingRect(NodeId const nodeId) const
 {
     QSize s = size(nodeId);
 
-    double ratio = 0.20;
-
-    int widthMargin = s.width() * ratio;
-    int heightMargin = s.height() * ratio;
+    int widthMargin = s.width() * _marginsRatio;
+    int heightMargin = s.height() * _marginsRatio;
 
     QMargins margins(widthMargin, heightMargin, widthMargin, heightMargin);
 
     QRectF r(QPointF(0, 0), s);
 
     return r.marginsAdded(margins);
+}
+
+void AbstractNodeGeometry::setMarginsRatio(double marginsRatio)
+{
+    _marginsRatio = marginsRatio;
 }
 
 QPointF AbstractNodeGeometry::portScenePosition(NodeId const nodeId,

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -111,6 +111,16 @@ QUndoStack &BasicGraphicsScene::undoStack()
     return *_undoStack;
 }
 
+void BasicGraphicsScene::setDropShadowEffect(bool enable)
+{
+    _dropShadowEffect = enable;
+}
+
+bool BasicGraphicsScene::isDropShadowEffectEnabled() const
+{
+    return _dropShadowEffect;
+}
+
 std::unique_ptr<ConnectionGraphicsObject> const &BasicGraphicsScene::makeDraftConnection(
     ConnectionId const incompleteConnectionId)
 {

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -37,6 +37,7 @@ NodeGraphicsObject::NodeGraphicsObject(BasicGraphicsScene &scene, NodeId nodeId)
 
     NodeStyle nodeStyle(nodeStyleJson);
 
+    if (scene.isDropShadowEffectEnabled())
     {
         auto effect = new QGraphicsDropShadowEffect;
         effect->setOffset(4, 4);


### PR DESCRIPTION
This change add an option to the GraphicsScene class to enable or disable the drop shadow effect for all the items.
This fixes performance issue when zooming, at least on Ubuntu 22.10.

Changes:

- getter/setter to enable globally the drop shadow effect on the GraphicsScene class
- Added margins ratio member and setter to nicely fit the bounding rect to the widget node boundaries (kept the default to 0.2 for compatibility)