### PR TITLE
Change some `unsigned int` variables to `NodeId`.

### DIFF
--- a/examples/dynamic_ports/DynamicPortsModel.cpp
+++ b/examples/dynamic_ports/DynamicPortsModel.cpp
@@ -325,7 +325,7 @@ QJsonObject DynamicPortsModel::save() const
 
 void DynamicPortsModel::loadNode(QJsonObject const &nodeJson)
 {
-    NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInt());
+    NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInteger());
 
     _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
 

--- a/examples/dynamic_ports/DynamicPortsModel.hpp
+++ b/examples/dynamic_ports/DynamicPortsModel.hpp
@@ -122,5 +122,5 @@ private:
     mutable std::unordered_map<NodeId, PortAddRemoveWidget *> _nodeWidgets;
 
     /// A convenience variable needed for generating unique node ids.
-    unsigned int _nextNodeId;
+    NodeId _nextNodeId;
 };

--- a/examples/simple_graph_model/SimpleGraphModel.cpp
+++ b/examples/simple_graph_model/SimpleGraphModel.cpp
@@ -275,7 +275,7 @@ QJsonObject SimpleGraphModel::saveNode(NodeId const nodeId) const
 
 void SimpleGraphModel::loadNode(QJsonObject const &nodeJson)
 {
-    NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInt());
+    NodeId restoredNodeId = static_cast<NodeId>(nodeJson["id"].toInteger());
 
     // Next NodeId must be larger that any id existing in the graph
     _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);

--- a/examples/simple_graph_model/SimpleGraphModel.hpp
+++ b/examples/simple_graph_model/SimpleGraphModel.hpp
@@ -105,5 +105,5 @@ private:
     mutable std::unordered_map<NodeId, NodeGeometryData> _nodeGeometryData;
 
     /// A convenience variable needed for generating unique node ids.
-    unsigned int _nextNodeId;
+    NodeId _nextNodeId;
 };

--- a/examples/vertical_layout/SimpleGraphModel.cpp
+++ b/examples/vertical_layout/SimpleGraphModel.cpp
@@ -274,7 +274,7 @@ QJsonObject SimpleGraphModel::saveNode(NodeId const nodeId) const
 
 void SimpleGraphModel::loadNode(QJsonObject const &nodeJson)
 {
-    NodeId restoredNodeId = nodeJson["id"].toInt();
+    NodeId restoredNodeId = nodeJson["id"].toInteger();
 
     // Next NodeId must be larger that any id existing in the graph
     _nextNodeId = std::max(restoredNodeId + 1, _nextNodeId);

--- a/examples/vertical_layout/SimpleGraphModel.hpp
+++ b/examples/vertical_layout/SimpleGraphModel.hpp
@@ -106,5 +106,5 @@ private:
     mutable std::unordered_map<NodeId, NodeGeometryData> _nodeGeometryData;
 
     /// A convenience variable needed for generating unique node ids.
-    unsigned int _nextNodeId;
+    NodeId _nextNodeId;
 };

--- a/include/QtNodes/internal/ConnectionIdUtils.hpp
+++ b/include/QtNodes/internal/ConnectionIdUtils.hpp
@@ -9,7 +9,7 @@
 
 namespace QtNodes {
 
-inline PortIndex getNodeId(PortType portType, ConnectionId connectionId)
+inline NodeId getNodeId(PortType portType, ConnectionId connectionId)
 {
     NodeId id = InvalidNodeId;
 
@@ -140,9 +140,9 @@ inline QJsonObject toJson(ConnectionId const &connId)
 
 inline ConnectionId fromJson(QJsonObject const &connJson)
 {
-    ConnectionId connId{static_cast<NodeId>(connJson["outNodeId"].toInt(InvalidNodeId)),
+    ConnectionId connId{static_cast<NodeId>(connJson["outNodeId"].toInteger(InvalidNodeId)),
                         static_cast<PortIndex>(connJson["outPortIndex"].toInt(InvalidPortIndex)),
-                        static_cast<NodeId>(connJson["intNodeId"].toInt(InvalidNodeId)),
+                        static_cast<NodeId>(connJson["intNodeId"].toInteger(InvalidNodeId)),
                         static_cast<PortIndex>(connJson["inPortIndex"].toInt(InvalidPortIndex))};
 
     return connId;

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -193,7 +193,7 @@ void BasicGraphicsScene::traverseGraphAndPopulateGraphicsObjects()
 
     // Then for each node check output connections and insert them.
     for (NodeId const nodeId : allNodeIds) {
-        unsigned int nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
+        auto nOutPorts = _graphModel.nodeData<PortCount>(nodeId, NodeRole::OutPortCount);
 
         for (PortIndex index = 0; index < nOutPorts; ++index) {
             auto const &outConnectionIds = _graphModel.connections(nodeId, PortType::Out, index);

--- a/src/DataFlowGraphModel.cpp
+++ b/src/DataFlowGraphModel.cpp
@@ -456,7 +456,7 @@ void DataFlowGraphModel::loadNode(QJsonObject const &nodeJson)
     // loading.
     // 2. When undoing the deletion command.  Conflict is not possible
     // because all the new ids were created past the removed nodes.
-    NodeId restoredNodeId = nodeJson["id"].toInt();
+    NodeId restoredNodeId = nodeJson["id"].toInteger();
 
     _nextNodeId = std::max(_nextNodeId, restoredNodeId + 1);
 

--- a/src/UndoCommands.cpp
+++ b/src/UndoCommands.cpp
@@ -64,7 +64,7 @@ static void insertSerializedItems(QJsonObject const &json, BasicGraphicsScene *s
 
         graphModel.loadNode(obj);
 
-        auto id = obj["id"].toInt();
+        auto id = obj["id"].toInteger();
         scene->nodeGraphicsObject(id)->setZValue(1.0);
         scene->nodeGraphicsObject(id)->setSelected(true);
     }
@@ -99,7 +99,7 @@ static void deleteSerializedItems(QJsonObject &sceneJson, AbstractGraphModel &gr
 
     for (QJsonValueRef node : nodesJsonArray) {
         QJsonObject nodeJson = node.toObject();
-        graphModel.deleteNode(nodeJson["id"].toInt());
+        graphModel.deleteNode(nodeJson["id"].toInteger());
     }
 }
 
@@ -333,7 +333,7 @@ QJsonObject PasteCommand::makeNewNodeIdsInScene(QJsonObject const &sceneJson)
     for (QJsonValueRef node : nodesJsonArray) {
         QJsonObject nodeJson = node.toObject();
 
-        NodeId oldNodeId = nodeJson["id"].toInt();
+        NodeId oldNodeId = nodeJson["id"].toInteger();
 
         NodeId newNodeId = graphModel.newNodeId();
 


### PR DESCRIPTION
Fix the `getNodeId()` function return value to `NodeId`

`toInteger()` is used because you want to be compatible with `uint64_t`