### PR TITLE
fix: name of paste selection GraphicsView action

### DIFF
--- a/src/GraphicsView.cpp
+++ b/src/GraphicsView.cpp
@@ -129,7 +129,7 @@ void GraphicsView::setScene(BasicGraphicsScene *scene)
 
     {
         delete _pasteAction;
-        _pasteAction = new QAction(QStringLiteral("Copy Selection"), this);
+        _pasteAction = new QAction(QStringLiteral("Paste Selection"), this);
         _pasteAction->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
         _pasteAction->setShortcut(QKeySequence(QKeySequence::Paste));
         connect(_pasteAction, &QAction::triggered, this, &GraphicsView::onPasteObjects);


### PR DESCRIPTION
The paste selection action was incorrectly named "Copy Selection"

This fixes #372 