### PR TITLE
Use nodeId style instead the generic StyleCollection style

### DIFF
--- a/src/DataFlowGraphModel.cpp
+++ b/src/DataFlowGraphModel.cpp
@@ -211,7 +211,7 @@ QVariant DataFlowGraphModel::nodeData(NodeId nodeId, NodeRole role) const
         break;
 
     case NodeRole::Style: {
-        auto style = StyleCollection::nodeStyle();
+        auto style = _models.at(nodeId)->nodeStyle();
         result = style.toJson().toVariantMap();
     } break;
 


### PR DESCRIPTION
If we want to customize a nodeId style then we should return the data of the nodeId instead of the generic StyleCollection style. By default the nodeId style use the generic StyleCollection so there is no change for user that don't tweak the style.