### PR TITLE
Fixed building with Qt5 and Qt6 versions installed in the same time

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -32,24 +32,28 @@ jobs:
             compiler: gcc
             qt_version: "5.15.2"
             modules: ""
+            use_qt6: "OFF"
 
           - toolchain: macos-clang
             os: macos-latest
             compiler: clang
             qt_version: "5.15.2"
             modules: ""
+            use_qt6: "OFF"
 
           - toolchain: windows-msvc
             os: windows-latest
             compiler: msvc
             qt_version: "5.15.2"
             modules: ""
+            use_qt6: "OFF"
 
           - toolchain: windows-msvc
             os: windows-latest
             compiler: msvc
             qt_version: "6.3.0"
             modules: "qt5compat"
+            use_qt6: "ON"
 
     steps:
     - name: Checkout Code
@@ -74,7 +78,7 @@ jobs:
         arch: x64
 
     - name: Configure (${{ matrix.configuration }})
-      run: cmake -S . -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DBUILD_DOCS=OFF
+      run: cmake -S . -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DBUILD_DOCS=OFF -DUSE_QT6=${{ matrix.use_qt6 }}
 
     - name: Build with ${{ matrix.compiler }}
       run: cmake --build build --config ${{ matrix.configuration }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(BUILD_DOCS "Build Documentation" "${QT_NODES_DEVELOPER_DEFAULTS}")
 option(BUILD_SHARED_LIBS "Build as shared library" ON)
 option(BUILD_DEBUG_POSTFIX_D "Append d suffix to debug libraries" OFF)
 option(QT_NODES_FORCE_TEST_COLOR "Force colorized unit test output" OFF)
+option(USE_QT6 "Build with Qt6 (Enabled by default)" ON)
 
 enable_testing()
 
@@ -46,7 +47,12 @@ endif()
 
 add_subdirectory(external)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+if(USE_QT6)
+  find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets)
+else()
+  find_package(QT NAMES Qt5 REQUIRED COMPONENTS Widgets)
+endif()
+
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Gui OpenGL)
 message(STATUS "QT_VERSION: ${QT_VERSION}, QT_DIR: ${QT_DIR}")
 

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,16 @@ Current State (v3)
 Building
 ========
 
+Set this option to false if you want to build with Qt5 version instead of Qt6:
+
+::
+
+   USE_QT6
+
+   mkdir build && cd build && cmake .. -DUSE_QT6=on
+   or
+   mkdir build && cd build && cmake .. -DUSE_QT6=off
+
 Linux
 -----
 


### PR DESCRIPTION
https://github.com/paceholder/nodeeditor/issues/397

This seems to be intuitive option, plus adds some control for library users to use the versions they want

Added flag for switching Qt versions + readme update on this info