### PR TITLE
[Bug Fix] Update embedded QWidget position after node update

### DIFF
--- a/include/QtNodes/internal/NodeGraphicsObject.hpp
+++ b/include/QtNodes/internal/NodeGraphicsObject.hpp
@@ -50,6 +50,8 @@ public:
     /// Repaints the node once with reacting ports.
     void reactToConnection(ConnectionGraphicsObject const *cgo);
 
+    void updateQWidgetEmbedPos();
+
 protected:
     void paint(QPainter *painter,
                QStyleOptionGraphicsItem const *option,

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -281,6 +281,7 @@ void BasicGraphicsScene::onNodeUpdated(NodeId const nodeId)
 
         _nodeGeometry->recomputeSize(nodeId);
 
+        node->updateQWidgetEmbedPos();
         node->update();
         node->moveConnections();
     }

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -76,6 +76,11 @@ BasicGraphicsScene *NodeGraphicsObject::nodeScene() const
     return dynamic_cast<BasicGraphicsScene *>(scene());
 }
 
+void NodeGraphicsObject::updateQWidgetEmbedPos()
+{
+    _proxyWidget->setPos(nodeScene()->nodeGeometry().widgetPosition(_nodeId));
+}
+
 void NodeGraphicsObject::embedQWidget()
 {
     AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
@@ -99,7 +104,7 @@ void NodeGraphicsObject::embedQWidget()
             _proxyWidget->setMinimumHeight(widgetHeight);
         }
 
-        _proxyWidget->setPos(geometry.widgetPosition(_nodeId));
+        updateQWidgetEmbedPos();
 
         //update();
 


### PR DESCRIPTION
Currently, if a node's inputs or outputs are updated, the embedded QWidget's position will remain unchanged - possibly occluding the new ports' captions.

This code fixes that issue, and moves the embedded QWidget with the new geometry after a node has changed.

## Before
![image](https://github.com/paceholder/nodeeditor/assets/160380770/4e972334-a595-4ad5-a25e-266be7a20f76)

## After
![image](https://github.com/paceholder/nodeeditor/assets/160380770/a7e3f984-a8f7-416f-a7f5-725f16b1417f)
