### PR TITLE
Optimizing performance | Add shadow enabler

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -196,6 +196,7 @@ the moment of writing this documentation.
       "GradientColor2": [64, 64, 64],
       "GradientColor3": [58, 58, 58],
       "ShadowColor": [20, 20, 20],
+      "ShadowEnabled": false,
       "FontColor" : "white",
       "FontColorFaded" : "gray",
       "ConnectionPointColor": [169, 169, 169],

--- a/examples/styles/main.cpp
+++ b/examples/styles/main.cpp
@@ -52,6 +52,7 @@ static void setStyle()
       "GradientColor2": "mintcream",
       "GradientColor3": "mintcream",
       "ShadowColor": [200, 200, 200],
+      "ShadowEnabled": true,
       "FontColor": [10, 10, 10],
       "FontColorFaded": [100, 100, 100],
       "ConnectionPointColor": "white",

--- a/include/QtNodes/internal/NodeStyle.hpp
+++ b/include/QtNodes/internal/NodeStyle.hpp
@@ -34,6 +34,7 @@ public:
     QColor GradientColor2;
     QColor GradientColor3;
     QColor ShadowColor;
+    bool ShadowEnabled;
     QColor FontColor;
     QColor FontColorFaded;
 

--- a/resources/DefaultStyle.json
+++ b/resources/DefaultStyle.json
@@ -12,6 +12,7 @@
     "GradientColor2": [64, 64, 64],
     "GradientColor3": [58, 58, 58],
     "ShadowColor": [20, 20, 20],
+    "ShadowEnabled": false,
     "FontColor" : "white",
     "FontColorFaded" : "gray",
     "ConnectionPointColor": [169, 169, 169],

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -37,6 +37,7 @@ NodeGraphicsObject::NodeGraphicsObject(BasicGraphicsScene &scene, NodeId nodeId)
 
     NodeStyle nodeStyle(nodeStyleJson);
 
+    if(nodeStyle.ShadowEnabled)
     {
         auto effect = new QGraphicsDropShadowEffect;
         effect->setOffset(4, 4);

--- a/src/NodeStyle.cpp
+++ b/src/NodeStyle.cpp
@@ -88,6 +88,18 @@ void NodeStyle::setNodeStyle(QString jsonText)
         values[#variable] = variable; \
     }
 
+#define NODE_STYLE_READ_BOOL(values, variable) \
+    { \
+            auto valueRef = values[#variable]; \
+            NODE_STYLE_CHECK_UNDEFINED_VALUE(valueRef, variable) \
+            variable = valueRef.toBool(); \
+    }
+
+#define NODE_STYLE_WRITE_BOOL(values, variable) \
+    { \
+            values[#variable] = variable; \
+    }
+
 void NodeStyle::loadJson(QJsonObject const &json)
 {
     QJsonValue nodeStyleValues = json["NodeStyle"];
@@ -101,6 +113,7 @@ void NodeStyle::loadJson(QJsonObject const &json)
     NODE_STYLE_READ_COLOR(obj, GradientColor2);
     NODE_STYLE_READ_COLOR(obj, GradientColor3);
     NODE_STYLE_READ_COLOR(obj, ShadowColor);
+    NODE_STYLE_READ_BOOL(obj, ShadowEnabled);
     NODE_STYLE_READ_COLOR(obj, FontColor);
     NODE_STYLE_READ_COLOR(obj, FontColorFaded);
     NODE_STYLE_READ_COLOR(obj, ConnectionPointColor);
@@ -126,6 +139,7 @@ QJsonObject NodeStyle::toJson() const
     NODE_STYLE_WRITE_COLOR(obj, GradientColor2);
     NODE_STYLE_WRITE_COLOR(obj, GradientColor3);
     NODE_STYLE_WRITE_COLOR(obj, ShadowColor);
+    NODE_STYLE_WRITE_BOOL(obj, ShadowEnabled);
     NODE_STYLE_WRITE_COLOR(obj, FontColor);
     NODE_STYLE_WRITE_COLOR(obj, FontColorFaded);
     NODE_STYLE_WRITE_COLOR(obj, ConnectionPointColor);


### PR DESCRIPTION
In my app if count nodes more 30+, so then starting freezing and downing performance. The culprit of all this's shadows. I added enabler shadow. And now in my project disabled shadows and i can spawn very more nodes

There was a problem:
![image](https://github.com/paceholder/nodeeditor/assets/48309973/b83624d5-e7cb-463d-96f6-b8fe094fddf2)
