### PR TITLE
Fixed NULL pointer exception on connecting nodes (https://github.com/…

### DIFF
--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -85,7 +85,9 @@ void NodeGraphicsObject::embedQWidget()
 {
     AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
     geometry.recomputeSize(_nodeId);
-    _proxyWidget = new QGraphicsProxyWidget(this);
+    if (! _proxyWidget) {
+        _proxyWidget = new QGraphicsProxyWidget(this);
+    }
     if (auto w = _graphModel.nodeData(_nodeId, NodeRole::Widget).value<QWidget *>()) {
 
 

--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -85,9 +85,9 @@ void NodeGraphicsObject::embedQWidget()
 {
     AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
     geometry.recomputeSize(_nodeId);
-
+    _proxyWidget = new QGraphicsProxyWidget(this);
     if (auto w = _graphModel.nodeData(_nodeId, NodeRole::Widget).value<QWidget *>()) {
-        _proxyWidget = new QGraphicsProxyWidget(this);
+
 
         _proxyWidget->setWidget(w);
 


### PR DESCRIPTION
…paceholder/nodeeditor/issues/441)

Moved the creation of the ProxyWidget in NodeGraphicsObject::embedQWidget() (line 84 ff.) out of the if { } block to ensure that it wouldn't be NULL when someone tried to dereference it. See issue #441. May be relevant also for #417 and #442.