### PR TITLE
Provide a const BasicGraphicsScene::nodeGeometry method

### DIFF
--- a/include/QtNodes/internal/BasicGraphicsScene.hpp
+++ b/include/QtNodes/internal/BasicGraphicsScene.hpp
@@ -46,6 +46,8 @@ public:
 
     AbstractGraphModel &graphModel();
 
+    AbstractNodeGeometry const &nodeGeometry() const;
+
     AbstractNodeGeometry &nodeGeometry();
 
     AbstractNodePainter &nodePainter();

--- a/src/BasicGraphicsScene.cpp
+++ b/src/BasicGraphicsScene.cpp
@@ -93,6 +93,11 @@ AbstractGraphModel &BasicGraphicsScene::graphModel()
     return _graphModel;
 }
 
+AbstractNodeGeometry const &BasicGraphicsScene::nodeGeometry() const
+{
+    return *_nodeGeometry;
+}
+
 AbstractNodeGeometry &BasicGraphicsScene::nodeGeometry()
 {
     return *_nodeGeometry;


### PR DESCRIPTION
The context is some drag and drop code which needs to know when a drag operation from the widget inside a node has left the node. My calculations need access to the node geometry.

(Additional context: I'm transitioning some working code from nodeeditor v2 to v3.)