### PR TITLE
Ensure vertically expanding widgets don't overwrite the caption

### DIFF
--- a/src/DefaultHorizontalNodeGeometry.cpp
+++ b/src/DefaultHorizontalNodeGeometry.cpp
@@ -155,7 +155,7 @@ QPointF DefaultHorizontalNodeGeometry::widgetPosition(NodeId const nodeId) const
         // place it immediately after the caption.
         if (w->sizePolicy().verticalPolicy() & QSizePolicy::ExpandFlag) {
             return QPointF(2.0 * _portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
-                           captionHeight);
+                           _portSpasing + captionHeight);
         } else {
             return QPointF(2.0 * _portSpasing + maxPortsTextAdvance(nodeId, PortType::In),
                            (captionHeight + size.height() - w->height()) / 2.0);


### PR DESCRIPTION
The calculation needs to account for the extra port spacing in addition to the caption size.

Without fix:
![Screenshot from 2025-05-24 07-54-30](https://github.com/user-attachments/assets/fc197416-e42b-48be-965e-ebf93fdd8a61)

With fix:
![Screenshot from 2025-05-24 07-57-47](https://github.com/user-attachments/assets/bbc1df37-3e6c-4717-837a-d4899fd47de2)
