### PR TITLE
Use a fixed margin for bounding rectangle rather than a ratio of node size

### DIFF
--- a/include/QtNodes/internal/AbstractNodeGeometry.hpp
+++ b/include/QtNodes/internal/AbstractNodeGeometry.hpp
@@ -21,11 +21,8 @@ public:
    * The node's size plus some additional margin around it to account for drawing
    * effects (for example shadows) or node's parts outside the size rectangle
    * (for example port points).
-   *
-   * The default implementation returns QSize + 20 percent of width and heights
-   * at each side of the rectangle.
    */
-    virtual QRectF boundingRect(NodeId const nodeId) const;
+    virtual QRectF boundingRect(NodeId const nodeId) const = 0;
 
     /// A direct rectangle defining the borders of the node's rectangle.
     virtual QSize size(NodeId const nodeId) const = 0;

--- a/include/QtNodes/internal/DefaultHorizontalNodeGeometry.hpp
+++ b/include/QtNodes/internal/DefaultHorizontalNodeGeometry.hpp
@@ -15,7 +15,7 @@ public:
     DefaultHorizontalNodeGeometry(AbstractGraphModel &graphModel);
 
 public:
-    QRectF boundingRect(NodeId const nodeId) const;
+    QRectF boundingRect(NodeId const nodeId) const override;
 
     QSize size(NodeId const nodeId) const override;
 

--- a/include/QtNodes/internal/DefaultHorizontalNodeGeometry.hpp
+++ b/include/QtNodes/internal/DefaultHorizontalNodeGeometry.hpp
@@ -15,6 +15,8 @@ public:
     DefaultHorizontalNodeGeometry(AbstractGraphModel &graphModel);
 
 public:
+    QRectF boundingRect(NodeId const nodeId) const;
+
     QSize size(NodeId const nodeId) const override;
 
     void recomputeSize(NodeId const nodeId) const override;

--- a/include/QtNodes/internal/DefaultVerticalNodeGeometry.hpp
+++ b/include/QtNodes/internal/DefaultVerticalNodeGeometry.hpp
@@ -15,6 +15,8 @@ public:
     DefaultVerticalNodeGeometry(AbstractGraphModel &graphModel);
 
 public:
+    QRectF boundingRect(NodeId const nodeId) const override;
+
     QSize size(NodeId const nodeId) const override;
 
     void recomputeSize(NodeId const nodeId) const override;

--- a/src/AbstractNodeGeometry.cpp
+++ b/src/AbstractNodeGeometry.cpp
@@ -15,22 +15,6 @@ AbstractNodeGeometry::AbstractNodeGeometry(AbstractGraphModel &graphModel)
     //
 }
 
-QRectF AbstractNodeGeometry::boundingRect(NodeId const nodeId) const
-{
-    QSize s = size(nodeId);
-
-    double ratio = 0.20;
-
-    int widthMargin = s.width() * ratio;
-    int heightMargin = s.height() * ratio;
-
-    QMargins margins(widthMargin, heightMargin, widthMargin, heightMargin);
-
-    QRectF r(QPointF(0, 0), s);
-
-    return r.marginsAdded(margins);
-}
-
 QPointF AbstractNodeGeometry::portScenePosition(NodeId const nodeId,
                                                 PortType const portType,
                                                 PortIndex const index,

--- a/src/DefaultHorizontalNodeGeometry.cpp
+++ b/src/DefaultHorizontalNodeGeometry.cpp
@@ -23,6 +23,18 @@ DefaultHorizontalNodeGeometry::DefaultHorizontalNodeGeometry(AbstractGraphModel 
     _portSize = _fontMetrics.height();
 }
 
+QRectF DefaultHorizontalNodeGeometry::boundingRect(NodeId const nodeId) const
+{
+    QSize s = size(nodeId);
+
+    qreal marginSize = 2.0 * _portSpasing;
+    QMargins margins(marginSize, marginSize, marginSize, marginSize);
+
+    QRectF r(QPointF(0, 0), s);
+
+    return r.marginsAdded(margins);
+}
+
 QSize DefaultHorizontalNodeGeometry::size(NodeId const nodeId) const
 {
     return _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);

--- a/src/DefaultVerticalNodeGeometry.cpp
+++ b/src/DefaultVerticalNodeGeometry.cpp
@@ -23,6 +23,18 @@ DefaultVerticalNodeGeometry::DefaultVerticalNodeGeometry(AbstractGraphModel &gra
     _portSize = _fontMetrics.height();
 }
 
+QRectF DefaultVerticalNodeGeometry::boundingRect(NodeId const nodeId) const
+{
+    QSize s = size(nodeId);
+
+    qreal marginSize = 2.0 * _portSpasing;
+    QMargins margins(marginSize, marginSize, marginSize, marginSize);
+
+    QRectF r(QPointF(0, 0), s);
+
+    return r.marginsAdded(margins);
+}
+
 QSize DefaultVerticalNodeGeometry::size(NodeId const nodeId) const
 {
     return _graphModel.nodeData<QSize>(nodeId, NodeRole::Size);


### PR DESCRIPTION
The current ratio-based calculation for bounding rectangle leads to a weird situation where the mouse does not necessarily select the nearest node. In the screenshot, the mouse is selecting the top node rather than the nearer node on the left:
![Screenshot from 2025-05-24 08-07-46](https://github.com/user-attachments/assets/cbe3a796-90b2-45bc-b586-f39a2b244695)

This PR fixes the problem using a fixed value (twice the port spacing) as the extra margin. Since the required information is not available in the AbstractNodeGeometry, the boundingRect method has been made pure virtual and implementations are provided in DefaultHorizontalNodeGeometry and DefaultVerticalNodeGeometry.