### PR TITLE
fix: includes are not compatible with Qt5

### DIFF
--- a/examples/lock_nodes_and_connections/main.cpp
+++ b/examples/lock_nodes_and_connections/main.cpp
@@ -2,7 +2,7 @@
 #include <QtNodes/GraphicsView>
 #include <QtNodes/NodeDelegateModelRegistry>
 
-#include <QtGui/QAction>
+#include <QAction>
 #include <QtGui/QScreen>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QCheckBox>

--- a/include/QtNodes/internal/UndoCommands.hpp
+++ b/include/QtNodes/internal/UndoCommands.hpp
@@ -5,7 +5,7 @@
 
 #include <QtCore/QJsonObject>
 #include <QtCore/QPointF>
-#include <QtGui/QUndoCommand>
+#include <QUndoCommand>
 
 #include <unordered_set>
 


### PR DESCRIPTION
Build failures were occurring because the headers referenced in the changeset are at different locations in Qt5 and Qt6.