### PR TITLE
Adds find_package(Catch2) to test_nodes CMakeLists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Dependencies
 
 * Qt >5.15
 * CMake 3.8
-* Catch2
+* Catch2 (add `Catch2_DIR` to the system variable, pointing to the folder containing `Catch2Config.cmake`)
 
 
 Current State (v3)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,8 @@ else()
   find_package(Qt5 COMPONENTS Test)
 endif()
 
+find_package(Catch2)
+
 add_executable(test_nodes
   test_main.cpp
   src/TestAbstractGraphModel.cpp


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [x] Documentation/refactoring

## Description
In case you have Catch2 installed and the correct system variable for `Catch2_DIR`, the `test_nodes` lib won't find the Catch2 package without the explicit directive to see it. 
This PR includes `find_package(Catch2)` to test_nodes CMakeLists.txt to fix that.
And it also adds instructions in README.txt, to create the Catch2_DIR system variable.

## Testing
- Qt version tested: 
- [x] Existing tests still pass

## Breaking changes?
No

## Related issue
None.
