### PR TITLE
fix: crash in QGraphicsObject::mousePressEvent if node is locked

### DIFF
--- a/src/NodeGraphicsObject.cpp
+++ b/src/NodeGraphicsObject.cpp
@@ -177,8 +177,9 @@ QVariant NodeGraphicsObject::itemChange(GraphicsItemChange change, const QVarian
 
 void NodeGraphicsObject::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    //if (_nodeState.locked())
-    //return;
+    if (graphModel().nodeFlags(_nodeId) & NodeFlag::Locked) {
+        return;
+    }
 
     AbstractNodeGeometry &geometry = nodeScene()->nodeGeometry();
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation/refactoring

## Description
<!--
Brief description of the change;
If this is a breaking change, please describe what breaks and how to migrate
-->
- early return in `NodeGraphicsObject::mousePressEvent` because otherwise `QGraphicsObject::mousePressEvent` would crash

## Testing
- Qt version tested: 6.5.3
- [x] Existing tests still pass
- [ ] Added tests for new functionality (if applicable)

## Breaking changes?
<!-- If yes, describe what breaks and how to migrate -->
N/A

## Related issue
<!-- Link with "Fixes #123" or "Closes #123" if applicable -->
Fixes #487  

---
*Please fill out the sections above to help reviewers understand your changes.*