### PR TITLE
fix: calculator headers not shown in QtCreator

### DIFF
--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CALC_HEADER_FILES
 
 add_executable(calculator
   ${CALC_SOURCE_FILES}
-  ${CALC_HEAEDR_FILES}
+  ${CALC_HEADER_FILES}
 )
 
 target_link_libraries(calculator QtNodes)
@@ -33,7 +33,7 @@ set(HEADLESS_CALC_SOURCE_FILES
 
 add_executable(headless_calculator 
   ${HEADLESS_CALC_SOURCE_FILES}
-  ${CALC_HEAEDR_FILES}
+  ${CALC_HEADER_FILES}
 )
 
 target_link_libraries(headless_calculator QtNodes)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation/refactoring

## Description
<!--
Brief description of the change;
If this is a breaking change, please describe what breaks and how to migrate
-->
- Fixes typo in CMakeLists.txt that causes headers to not display in QtCreator for the calculator example

## Testing
- Qt version tested: 5/6
- [x] Existing tests still pass
- [ ] Added tests for new functionality (if applicable)

## Breaking changes?
<!-- If yes, describe what breaks and how to migrate -->
No

## Related issue
<!-- Link with "Fixes #123" or "Closes #123" if applicable -->
- Fixes #491 
---
*Please fill out the sections above to help reviewers understand your changes.*