### PR TITLE
Fix wrong QGraphicsView cast

### DIFF
--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -210,7 +210,10 @@ void ConnectionGraphicsObject::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
     prepareGeometryChange();
 
-    auto view = static_cast<QGraphicsView *>(event->widget());
+    auto views = scene()->views();
+    Q_ASSERT(!views.isEmpty());
+    auto view = views.first();
+    Q_ASSERT(view);
     auto ngo = locateNodeAt(event->scenePos(), *nodeScene(), view->transform());
     if (ngo) {
         ngo->reactToConnection(this);
@@ -242,7 +245,9 @@ void ConnectionGraphicsObject::mouseReleaseEvent(QGraphicsSceneMouseEvent *event
     ungrabMouse();
     event->accept();
 
-    auto view = static_cast<QGraphicsView *>(event->widget());
+    auto views = scene()->views();
+    Q_ASSERT(!views.isEmpty());
+    auto view = views.first();
 
     Q_ASSERT(view);
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation/refactoring

## Description
I built nodeeditor with address sanitizer. App crashes when I try to create a link connection with my mouse.

I need an opengl context. So I inherited `GraphicsView` and I `setViewport` with a `QOpenGLWidget`.

With this patch, I can create a link connection.

## Testing
- Qt version tested: 6.6
- [ ] Existing tests still pass : not tested but it shouldn't.
- [ ] Added tests for new functionality (if applicable)

## Breaking changes?
No

## Related issue
No
