### PR TITLE
Adds support for macOS Delete key

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -51,7 +51,7 @@ jobs:
           - toolchain: windows-msvc
             os: windows-latest
             compiler: msvc
-            qt_version: "6.3.0"
+            qt_version: "6.9.2"
             modules: "qt5compat"
             use_qt6: "ON"
 
@@ -62,7 +62,7 @@ jobs:
         submodules: true
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: ${{ matrix.qt_version }}
         modules: ${{ matrix.modules }}
@@ -83,7 +83,7 @@ jobs:
       run: cmake -S . -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DBUILD_DOCS=OFF -DUSE_QT6=${{ matrix.use_qt6 }}
 
     - name: Build with ${{ matrix.compiler }}
-      run: cmake --build build --config ${{ matrix.configuration }} --verbose
+      run: cmake --build build --config ${{ matrix.configuration }}
 
     - name: Run Tests (Linux)
       if: startsWith (matrix.os, 'ubuntu')

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -83,7 +83,7 @@ jobs:
       run: cmake -S . -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DBUILD_DOCS=OFF -DUSE_QT6=${{ matrix.use_qt6 }}
 
     - name: Build with ${{ matrix.compiler }}
-      run: cmake --build build --config ${{ matrix.configuration }}
+      run: cmake --build build --config ${{ matrix.configuration }} --verbose
 
     - name: Run Tests (Linux)
       if: startsWith (matrix.os, 'ubuntu')

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -37,7 +37,7 @@ jobs:
           - toolchain: macos-clang
             os: macos-latest
             compiler: clang
-            qt_version: "6.7.1"
+            qt_version: "6.9.2"
             modules: ""
             use_qt6: "ON"
 

--- a/src/GraphicsView.cpp
+++ b/src/GraphicsView.cpp
@@ -371,6 +371,13 @@ void GraphicsView::onPasteObjects()
 void GraphicsView::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {
+#ifdef Q_OS_MACOS
+    case Qt::Key_Backspace: {
+        onDeleteSelectedObjects();
+        event->accept();
+        return;
+    }
+#endif
     case Qt::Key_F2: {
         BasicGraphicsScene *sc = nodeScene();
 

--- a/src/GraphicsView.cpp
+++ b/src/GraphicsView.cpp
@@ -372,12 +372,13 @@ void GraphicsView::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {
 #ifdef Q_OS_MACOS
-    case Qt::Key_Backspace: {
+    case Qt::Key_Backspace:
+#endif
+    case Qt::Key_Delete: {
         onDeleteSelectedObjects();
         event->accept();
         return;
     }
-#endif
     case Qt::Key_F2: {
         BasicGraphicsScene *sc = nodeScene();
 

--- a/test/src/TestUIInteraction.cpp
+++ b/test/src/TestUIInteraction.cpp
@@ -409,16 +409,17 @@ TEST_CASE("UI Interaction - Keyboard Shortcuts", "[ui][visual]")
             QSignalSpy deletionSpy(model.get(), &TestGraphModel::nodeDeleted);
 
             // Simulate delete key press
-            QKeyEvent deleteEvent(QEvent::KeyPress, Qt::Key_Delete, Qt::NoModifier);
-            QApplication::sendEvent(&view, &deleteEvent);
+            // The physical Delete key on macOS is reported as Backspace
+#ifdef Q_OS_MACOS
+            QTest::keyClick(&view, Qt::Key_Backspace);
+#else
+            QTest::keyClick(&view, Qt::Key_Delete);
+#endif
             UITestHelper::waitForUI();
 
-            // Check if deletion signal was emitted or node was removed
-            INFO("Node deletion signals emitted: " << deletionSpy.count());
+            // Check if node was removed
             CHECK(deletionSpy.count() >= 0); // Accept any count, implementation may vary
-            
-            // (Implementation may vary depending on how delete is handled)
-            CHECK(true); // Test passed if no crash occurred
+            CHECK_FALSE(model->nodeExists(nodeId));
         }
     }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix

## Description
The macOS delete key (`Key_Backspace`) was unable to delete items. This PR adds support for deletion on macOS using this shortcut.

## Testing
- Qt version tested: 6.11.1
- [X] Existing tests still pass
- [X] Added tests for new functionality
---